### PR TITLE
GET-40 Job profile scraper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,12 @@ gem 'foreman'
 # Canonical meta tag
 gem 'canonical-rails'
 
+# Process web and ai requests
+gem 'httparty'
+
+# XML and HTML parsing
+gem 'nokogiri', '~> 1.8'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,9 @@ GEM
       rubocop (~> 0.64)
       rubocop-rspec (~> 1.28)
       scss_lint
+    httparty (0.17.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -103,11 +106,15 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.0331)
     mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.2.10)
+    multi_xml (0.6.0)
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -244,7 +251,9 @@ DEPENDENCIES
   dotenv-rails
   foreman
   govuk-lint
+  httparty
   listen (>= 3.0.5, < 3.2)
+  nokogiri (~> 1.8)
   pg (>= 0.18, < 2.0)
   pry-byebug
   puma (~> 3.12)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,24 @@
+class Category < ApplicationRecord
+  has_and_belongs_to_many :job_profiles
+
+  def self.import(url)
+    slug = url.match(/job-categories\/(.*)$/)[1]
+    find_or_create_by(slug: slug) do |category|
+      category.update(source_url: url, name: slug.titleize)
+    end
+  end
+
+  def scrape
+    page = HTTParty.get(source_url)
+    parsed_page = Nokogiri::HTML(page)
+
+    self.name = parsed_page.css('h1.heading-xlarge').text
+    self.job_profiles.clear
+    parsed_page.css('li.job-categories_item h2 a').each do |link|
+      slug = link['href'].match(/job-profiles\/(.*)$/)[1]
+      job_profile = JobProfile.find_by_slug(slug)
+      self.job_profiles << job_profile if job_profile
+    end
+    save
+  end
+end

--- a/app/models/job_profile.rb
+++ b/app/models/job_profile.rb
@@ -1,0 +1,31 @@
+class JobProfile < ApplicationRecord
+  has_and_belongs_to_many :categories
+  has_and_belongs_to_many :skills
+
+  scope :recommended, -> { where(recommended: true) }
+
+  def self.import(url)
+    slug = url.match(/job-profiles\/(.*)$/)[1]
+    find_or_create_by(slug: slug) do |job_profile|
+      job_profile.update(source_url: url, name: slug.titleize)
+    end
+  end
+
+  def imported?
+    content.present?
+  end
+
+  def scrape
+    page = HTTParty.get(source_url)
+    parsed_page = Nokogiri::HTML(page)
+
+    self.name = parsed_page.css('h1.heading-xlarge').text
+    self.description = parsed_page.css('.column-desktop-two-thirds').first.css('p').text
+
+    self.skills.clear
+    parsed_page.css('#Skills ul li').each do |li|
+      self.skills << Skill.find_or_create_by(name: li.text.strip)
+    end
+    save
+  end
+end

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,0 +1,3 @@
+class Skill < ApplicationRecord
+  has_and_belongs_to_many :job_profiles
+end

--- a/db/migrate/20190611093036_create_job_profiles.rb
+++ b/db/migrate/20190611093036_create_job_profiles.rb
@@ -1,0 +1,38 @@
+class CreateJobProfiles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :categories do |t|
+      t.string :slug, index: true
+      t.string :name
+      t.string :source_url
+      t.timestamps
+    end
+
+    create_table :job_profiles do |t|
+      t.string :slug, index: true
+      t.string :name
+      t.string :source_url
+      t.string :description
+      t.boolean :recommended, default: true
+      t.text :content
+      t.timestamps
+    end
+
+    add_index :job_profiles, [:recommended, :name]
+
+    create_table :categories_job_profiles do |t|
+      t.references :job_profile, foreign_key: true
+      t.references :category, foreign_key: true
+    end
+
+    create_table :skills do |t|
+      t.string :name, index: true
+      t.timestamps
+    end
+
+    create_table :job_profiles_skills do |t|
+      t.references :job_profile, foreign_key: true
+      t.references :skill, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,58 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2019_06_11_093036) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "categories", force: :cascade do |t|
+    t.string "slug"
+    t.string "name"
+    t.string "source_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_categories_on_slug"
+  end
+
+  create_table "categories_job_profiles", force: :cascade do |t|
+    t.bigint "job_profile_id"
+    t.bigint "category_id"
+    t.index ["category_id"], name: "index_categories_job_profiles_on_category_id"
+    t.index ["job_profile_id"], name: "index_categories_job_profiles_on_job_profile_id"
+  end
+
+  create_table "job_profiles", force: :cascade do |t|
+    t.string "slug"
+    t.string "name"
+    t.string "source_url"
+    t.string "description"
+    t.boolean "recommended", default: true
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recommended", "name"], name: "index_job_profiles_on_recommended_and_name"
+    t.index ["slug"], name: "index_job_profiles_on_slug"
+  end
+
+  create_table "job_profiles_skills", force: :cascade do |t|
+    t.bigint "job_profile_id"
+    t.bigint "skill_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["job_profile_id"], name: "index_job_profiles_skills_on_job_profile_id"
+    t.index ["skill_id"], name: "index_job_profiles_skills_on_skill_id"
+  end
+
+  create_table "skills", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_skills_on_name"
+  end
+
+  add_foreign_key "categories_job_profiles", "categories"
+  add_foreign_key "categories_job_profiles", "job_profiles"
+  add_foreign_key "job_profiles_skills", "job_profiles"
+  add_foreign_key "job_profiles_skills", "skills"
 end

--- a/lib/tasks/data_import/import_sitemap.rake
+++ b/lib/tasks/data_import/import_sitemap.rake
@@ -1,0 +1,24 @@
+require 'HTTParty'
+require 'Nokogiri'
+
+namespace :data_import do
+
+  # bin/rails data_import:import_sitemap
+  task import_sitemap: :environment do
+
+    p 'Importing sitemap from National Careers Service site'
+    sitemap = HTTParty.get('https://nationalcareers.service.gov.uk/sitemap/sitemap.xml')
+
+    parsed_map = Nokogiri::XML(sitemap)
+    parsed_map.css('loc').each do |node|
+      url = node.text
+      if url =~ /job-categories/
+        p "Found category page #{url}"
+        Category.import(url)
+      elsif url =~ /job-profiles/
+        p "Found job profile page #{url}"
+        JobProfile.import(url)
+      end
+    end
+  end
+end

--- a/lib/tasks/data_import/scrape_categories.rake
+++ b/lib/tasks/data_import/scrape_categories.rake
@@ -1,0 +1,20 @@
+require 'HTTParty'
+require 'Nokogiri'
+
+namespace :data_import do
+
+  # bin/rails data_import:scrape_categories
+  task scrape_categories: :environment do
+
+    p 'Scraping categories from National Careers Service site'
+    if Category.any?
+      Category.all.each do |category|
+        p "Scraping category #{category.slug}"
+        category.scrape
+        sleep(0.1)
+      end
+    else
+      p 'No categories setup - please import sitemap first'
+    end
+  end
+end

--- a/lib/tasks/data_import/scrape_job_profiles.rake
+++ b/lib/tasks/data_import/scrape_job_profiles.rake
@@ -1,0 +1,21 @@
+require 'HTTParty'
+require 'Nokogiri'
+
+namespace :data_import do
+
+  # bin/rails data_import:scrape_job_profiles
+  task scrape_job_profiles: :environment do
+
+    p 'Scraping job profiles from National Careers Service site'
+    if JobProfile.any?
+      #TODO: process `all` job profiles when we figure out which data is of interest
+      JobProfile.limit(10).each do |job_profile|
+        p "Scraping job profile #{job_profile.slug}"
+        job_profile.scrape
+        sleep(0.1)
+      end
+    else
+      p 'No job profiles setup - please import sitemap first'
+    end
+  end
+end


### PR DESCRIPTION
### Context
Exploring the possibility of scraping job profile and associated data directly from the NCS "Explore my careers" site as no API is currently available we can use. It certainly works although isn't an ideal technique.

### Changes proposed in this pull request
For now I've setup a simplified model structure of skills, categories and job profiles. This is just a quick spike so no test coverage yet and the code is far from robust.

The sitemap from NCS is first parsed for a list of interesting links to category and job profile pages. Placeholder records are created for each of these with `slug` and `original_url` attributes.

Once the site map is imported the individual category and job profile pages can be scraped. The category page is scraped for links to job profiles - we assume that means the job profiles are within that category so we can join them together. We can also parse a more nicely formatted category name from the page.

Job profile pages are scraped for name and description, and a list of individual job skills. A skill record is created for each found skill (matching just by the full text) and joined to the job skill. This is limited to processing 10 job profile pages for now as there's no point scraping the whole site (800+ job profiles) until we decide which content is needed.

### Guidance to review
Run migrations and then the three rake tasks in order i.e.

```
bundle exec rails db:migrate
bundle exec rails data_import:import_sitemap
bundle exec rails data_import:scrape_categories
bundle exec rails data_import:scrape_job_profiles
```
