### PR TITLE
Initial simple data model to support persisting job profiles and related info

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+  has_many :job_profiles, through: :job_profile_categories
+end

--- a/app/models/job_profile.rb
+++ b/app/models/job_profile.rb
@@ -1,0 +1,4 @@
+class JobProfile < ApplicationRecord
+  has_many :categories, through: :job_profile_categories
+  has_many :skills, through: :job_profile_skills
+end

--- a/app/models/job_profile_category.rb
+++ b/app/models/job_profile_category.rb
@@ -1,0 +1,4 @@
+class JobProfileCategory < ApplicationRecord
+  belongs_to :job_profile
+  belongs_to :category
+end

--- a/app/models/job_profile_skill.rb
+++ b/app/models/job_profile_skill.rb
@@ -1,0 +1,4 @@
+class JobProfileSkill < ApplicationRecord
+  belongs_to :job_profile
+  belongs_to :skill
+end

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,0 +1,3 @@
+class Skill < ApplicationRecord
+  has_many :job_profiles, through: :job_profile_skills
+end

--- a/db/migrate/20190614101226_create_job_profiles.rb
+++ b/db/migrate/20190614101226_create_job_profiles.rb
@@ -1,0 +1,39 @@
+class CreateJobProfiles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :categories do |t|
+      t.string :slug, index: { unique: true }
+      t.string :name
+      t.string :source_url
+      t.timestamps
+    end
+
+    create_table :job_profiles do |t|
+      t.string :slug, index: { unique: true }
+      t.string :name
+      t.string :source_url
+      t.string :description
+      t.string :salary_range
+      t.boolean :recommended, default: false
+      t.text :content
+      t.timestamps
+    end
+
+    create_table :skills do |t|
+      t.string :name, index: true
+      t.timestamps
+    end
+
+    create_table :job_profile_categories do |t|
+      t.belongs_to :job_profile, index: true
+      t.belongs_to :category, index: true
+      t.timestamps
+    end
+
+    create_table :job_profile_skills do |t|
+      t.belongs_to :job_profile, index: true
+      t.belongs_to :skill, index: true
+      t.boolean :required, default: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,57 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2019_06_14_101226) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "slug"
+    t.string "name"
+    t.string "source_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_categories_on_slug", unique: true
+  end
+
+  create_table "job_profile_categories", force: :cascade do |t|
+    t.bigint "job_profile_id"
+    t.bigint "category_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_job_profile_categories_on_category_id"
+    t.index ["job_profile_id"], name: "index_job_profile_categories_on_job_profile_id"
+  end
+
+  create_table "job_profile_skills", force: :cascade do |t|
+    t.bigint "job_profile_id"
+    t.bigint "skill_id"
+    t.boolean "required", default: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["job_profile_id"], name: "index_job_profile_skills_on_job_profile_id"
+    t.index ["skill_id"], name: "index_job_profile_skills_on_skill_id"
+  end
+
+  create_table "job_profiles", force: :cascade do |t|
+    t.string "slug"
+    t.string "name"
+    t.string "source_url"
+    t.string "description"
+    t.string "salary_range"
+    t.boolean "recommended", default: false
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_job_profiles_on_slug", unique: true
+  end
+
+  create_table "skills", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_skills_on_name"
+  end
 
 end


### PR DESCRIPTION
### Context
As per description

### Changes proposed in this pull request
Added a few specific attributes to job profile to support things we might want to display in a search results page - most other things will be scraped and rendered as a `content` block of html. Also added `recommended` attribute to support future opinionated search results.

Skills have only a unique `name` attribute. Job profile and categories have a unique `slug` attribute representing part of the original url they were scraped from.

### Guidance to review

