### PR TITLE
GET-49 Set up CI with Azure Pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,18 +11,11 @@ RUN apk add --update $BUILD_PACKAGES && \
 # Generate Assets
 WORKDIR /app
 COPY Gemfile Gemfile.lock .ruby-version ./
-RUN bundle install --clean --without "test development"
+RUN bundle install --clean --without "development"
 COPY package.json yarn.lock ./
 RUN yarn install
 COPY . ./
 RUN bundle exec rails webpacker:compile SECRET_KEY_BASE=stubbed
-
-# Install dependencies
-FROM ruby:2.6-alpine as bundler
-WORKDIR /app
-COPY Gemfile Gemfile.lock .ruby-version ./
-COPY --from=assets /usr/local/bundle /usr/local/bundle
-RUN bundle install --clean --without "test development"
 
 FROM ruby:2.6-alpine
 
@@ -38,6 +31,5 @@ RUN apk add --update $BUILD_PACKAGES && \
 
 WORKDIR /app
 COPY . ./
+COPY --from=assets /usr/local/bundle /usr/local/bundle
 COPY --from=assets /app/public/packs /app/public/packs
-COPY --from=bundler /usr/local/bundle /usr/local/bundle
-CMD bundle exec puma -C config/puma.rb

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Greenkeeper badge](https://badges.greenkeeper.io/DFE-Digital/govuk-rails-boilerplate.svg)](https://greenkeeper.io/)
+[![Build Status](https://dev.azure.com/abeersalameh/get-help-to-retrain/_apis/build/status/DFE-Digital.get-help-to-retrain?branchName=master)](https://dev.azure.com/abeersalameh/get-help-to-retrain/_build/latest?definitionId=5&branchName=master)
 
 # Get Help to Retrain
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,74 @@
+jobs:
+- job: TestsAndBuild
+  displayName: Run Tests And Build Image
+
+  pool:
+    vmImage: 'ubuntu-16.04'
+
+  variables:
+  - group: get-help-to-retrain
+  - name: postgresImage
+    value: postgres:11-alpine
+  - name: postgresPassword
+    value: test
+  - name: postgresDatabaseUrl
+    value: postgres://postgres:test@postgres/get-help-to-retrain
+  - name: dockerRun
+    value: docker run --rm --link $(postgresImage) -e DATABASE_URL=$(postgresDatabaseUrl) -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag)
+
+  steps:
+    - script: |
+        git_sha=$(echo $(Build.SourceVersion) | cut -c 1-7)
+        echo "##vso[task.setvariable variable=ImageTag;]$(Build.BuildNumber)-$git_sha"
+      displayName: 'Set Image Tags'
+
+    - script: docker login -u $(dockerRegistry) -u $(dockerId) -p $pswd
+      env:
+        pswd: $(dockerPassword)
+      displayName: Docker Login
+
+    - script: |
+        docker run --name=postgres -e POSTGRESS_PASSWORD=$(postgresPassword) -d $(postgresImage)
+      displayName: Launch Postgres
+
+    - script: |
+        docker pull $(dockerRegistry)/$(imageName):latest || true
+      displayName: Retrieve latest Docker build to use as cache
+      condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+
+    - script: |
+        docker build -f Dockerfile --cache-from=$(dockerRegistry)/$(imageName):latest -t $(dockerRegistry)/$(imageName):$(imageTag) .
+      displayName: Build Docker Image using Cache
+      condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+
+    - script: |
+        docker build -f Dockerfile -t $(dockerRegistry)/$(imageName):$(imageTag) -t $(dockerRegistry)/$(imageName):latest .
+      displayName: Build Docker Image without Cache
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+
+    - script: |
+        $DOCKER_RUN bundle exec rake db:create db:test:prepare
+      displayName: Database Setup
+      env:
+        DOCKER_RUN: $(dockerRun)
+
+    - script: |
+        $DOCKER_RUN bundle exec govuk-lint-ruby app lib spec
+      displayName: GovUK linter
+      env:
+        DOCKER_RUN: $(dockerRun)
+
+    - script: |
+        $DOCKER_RUN bundle exec rspec
+      displayName: Rspec
+      env:
+        DOCKER_RUN: $(dockerRun)
+
+    - script: |
+        docker push $(dockerRegistry)/$(imageName):$(imageTag)
+      displayName: 'Push Docker Image'
+
+    - script: |
+        docker push $(dockerRegistry)/$(imageName):latest
+      displayName: Push Latest Docker Image
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-49 

* Docker image now builds test dependencies (needs rethink)
* Add azure pipeline to run tests and build images per commit and tag with build number and Git SHA
* If this is master is will build without cache and with the tag: latest
* If build is successful it will push images to DockerHub
* Things to look out for:
  - link is deprecated, could we use docker-compose instead?
  - could not make use of service containers as network would not allow connections properly
  - using separate jobs for testing and deploy (deploy job) did not allow us to share the image build 
    meaning we had to rebuild it, so for now everything is in a single job



