### PR TITLE
Introduce Version model

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,5 @@
 class Category < ApplicationRecord
-  has_many :job_profile_categories
+  belongs_to :version
+  has_many :job_profile_categories, dependent: :delete_all
   has_many :job_profiles, through: :job_profile_categories, inverse_of: :categories
 end

--- a/app/models/job_profile.rb
+++ b/app/models/job_profile.rb
@@ -1,4 +1,5 @@
 class JobProfile < ApplicationRecord
+  belongs_to :version
   has_many :job_profile_categories
   has_many :job_profile_skills
   has_many :categories, through: :job_profile_categories, inverse_of: :job_profiles

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,4 +1,5 @@
 class Skill < ApplicationRecord
-  has_many :job_profile_skills
+  belongs_to :version
+  has_many :job_profile_skills, dependent: :delete_all
   has_many :job_profiles, through: :job_profile_skills, inverse_of: :skills
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,0 +1,25 @@
+class Version < ApplicationRecord
+  enum version: [:draft, :current, :previous]
+
+  has_many :skills, dependent: :delete_all
+  has_many :categories, dependent: :delete_all
+  has_many :job_profiles, dependent: :delete_all
+
+  def self.draft
+    @_draft ||= find_by(version: :draft)
+  end
+
+  def self.current
+    @_current ||= find_by(version: :current)
+  end
+
+  def self.previous
+    @_previous ||= find_by(version: :previous)
+  end
+
+  def self.promote
+    previous&.delete
+    current&.update(version: :previous)
+    draft&.update(version: :current)
+  end
+end

--- a/db/migrate/20190619090119_create_versions.rb
+++ b/db/migrate/20190619090119_create_versions.rb
@@ -1,0 +1,12 @@
+class CreateVersions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :versions do |t|
+      t.integer :version, null: false
+      t.timestamps
+    end
+
+    add_reference :categories, :version, index: true
+    add_reference :job_profiles, :version, index: true
+    add_reference :skills, :version, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_14_101226) do
+ActiveRecord::Schema.define(version: 2019_06_19_090119) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,9 @@ ActiveRecord::Schema.define(version: 2019_06_14_101226) do
     t.string "source_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "version_id"
     t.index ["slug"], name: "index_categories_on_slug", unique: true
+    t.index ["version_id"], name: "index_categories_on_version_id"
   end
 
   create_table "job_profile_categories", force: :cascade do |t|
@@ -53,14 +55,24 @@ ActiveRecord::Schema.define(version: 2019_06_14_101226) do
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "version_id"
     t.index ["slug"], name: "index_job_profiles_on_slug", unique: true
+    t.index ["version_id"], name: "index_job_profiles_on_version_id"
   end
 
   create_table "skills", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "version_id"
     t.index ["name"], name: "index_skills_on_name"
+    t.index ["version_id"], name: "index_skills_on_version_id"
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.integer "version", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end


### PR DESCRIPTION
### Context
The intent here is to allow a future/draft version of the job profile and associated models to be created without breaking the existing job profile data in the meantime.

### Changes proposed in this pull request
Once the screen scraping completes successfully the draft version becomes the current version. I've also added support for keeping a previous version - not sure if that will be useful but no harm in adding it for now and removing if it proves unnecessary.

This means that when working with the core `JobProfile`, `Category` and `Skill` models we will instead need to refer to `Version.current.job_profiles`, `Version.current.categories` and `Version.current.skills` respectively.

### Guidance to review
This is still WIP and just a proposed approach for now - if we like this then I'll flesh it out more.