### PR TITLE
Make sure assets are compiled under production environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:2.6-alpine as assets
 
 ENV RAILS_ENV production
+ENV NODE_ENV production
 ENV BUILD_PACKAGES build-base nodejs yarn tzdata postgresql-dev
 
 # Update and install all of the required packages.
@@ -33,5 +34,6 @@ WORKDIR /app
 COPY . ./
 COPY --from=assets /usr/local/bundle /usr/local/bundle
 COPY --from=assets /app/public/packs /app/public/packs
-
 CMD bundle exec rails server -b 0.0.0.0
+
+


### PR DESCRIPTION
To include all our assets correctly, set NODE_ENV to production so when assets are compiled for deploy they are under the right environment