### PR TITLE
Include assets folder as well as packs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ WORKDIR /app
 COPY . ./
 COPY --from=assets /usr/local/bundle /usr/local/bundle
 COPY --from=assets /app/public/packs /app/public/packs
+COPY --from=assets /app/public/assets /app/public/assets
 CMD bundle exec rails server -b 0.0.0.0
 
 


### PR DESCRIPTION
Images from node modules are included under different directory
include that when porting assets to final container

### Context

### Changes proposed in this pull request

### Guidance to review

