### PR TITLE
Use last commit sha

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
 
   steps:
     - script: |
-        git_sha=$(echo $(Build.SourceVersion) | cut -c 1-7)
+        git_sha=$(git rev-parse --short HEAD)
         echo "##vso[build.updatebuildnumber]$git_sha"
         echo "##vso[task.setvariable variable=ImageTag;]$git_sha"
       displayName: 'Set Image Tags'


### PR DESCRIPTION
### Context
We want to use the last commit (short) sha to identify our builds. 

### Changes proposed in this pull request

Use the short sha of the last commit (head)

### Guidance to review

