### PR TITLE
Skip builds for PRs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,11 @@
+trigger:
+  batch: true
+  branches:
+    include:
+      - "*"
+
+pr: none
+
 jobs:
 - job: TestsAndBuild
   displayName: Run Tests And Build Image


### PR DESCRIPTION
### Context
We are having duplicate builds because we build on every branch. On PRs we get a build for the branch and also for the PR event.

### Changes proposed in this pull request
Don't trigger builds on PRs

### Guidance to review

