### PR TITLE
GET-156 Add Azure Application Insights to the application

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -192,6 +192,26 @@
       ]
     },
     {
+      "apiVersion": "2017-05-10",
+      "name": "app-insights",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'application-insights.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appInsightsName": {
+            "value": "[variables('appServiceName')]"
+          },
+          "attachedService": {
+            "value": "[variables('appServiceName')]"
+          }
+        }
+      }
+    },
+    {
       "name": "app-service-plan",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2017-05-10",
@@ -239,6 +259,10 @@
           },
           "appServiceAppSettings": {
             "value": [
+              {
+                "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+                "value": "[reference('app-insights').outputs.instrumentationKey.value]"
+              },
               {
                 "name": "DB_DATABASE",
                 "value": "[parameters('databaseName')]"


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-156

### Changes proposed in this pull request
This PR creates the Azure Application Insights resource that the application will send data to.
It also exposes the `Instrumentation Key` dynamically to the running container via the `APPINSIGHTS_INSTRUMENTATIONKEY` environment variable. 

### Guidance to review

This can be approved and merged before the application is ready to send metrics, as it just creates the monitoring namespace and an authentication token to it.
