### PR TITLE
GET-141 scrape salary range

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby File.read('.ruby-version').chomp
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
+gem 'rails-i18n', '~> 5.1'
 
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.3)
       actionpack (= 5.2.3)
       activesupport (= 5.2.3)
@@ -335,6 +338,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 3.12)
   rails (~> 5.2.3)
+  rails-i18n (~> 5.1)
   rspec-rails (~> 3.8)
   rubocop (~> 0.68)
   rubocop-rspec (~> 1.32)

--- a/app/decorators/job_profile_decorator.rb
+++ b/app/decorators/job_profile_decorator.rb
@@ -3,10 +3,9 @@
 # which should remove the need to disable rubocop rules here.
 class JobProfileDecorator < SimpleDelegator
   include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::NumberHelper
 
   # rubocop:disable Metrics/LineLength
-  SALARY_MIN_XPATH = "//div[@id='Salary']//p[@class='dfc-code-jpsstarter']".freeze
-  SALARY_MAX_XPATH = "//div[@id='Salary']//p[@class='dfc-code-jpsexperienced']".freeze
   WORKING_HOURS_XPATH = "//div[@id='WorkingHours']//p[@class='dfc-code-jphours']".freeze
   WORKING_HOURS_PATTERNS_XPATH = "//div[@id='WorkingHoursPatterns']//p[@class='dfc-code-jpwpattern']".freeze
   HERO_COPY_XPATH = "//header[@class='job-profile-hero']//h1[@class='heading-xlarge']".freeze
@@ -25,13 +24,9 @@ class JobProfileDecorator < SimpleDelegator
   # rubocop:enable Metrics/LineLength
 
   def salary_range
-    min_salary = html_body.xpath(SALARY_MIN_XPATH).children[0]
+    return 'Variable' unless salary_min && salary_max
 
-    return 'Variable' unless min_salary
-
-    max_salary = html_body.xpath(SALARY_MAX_XPATH).children[0]
-
-    "#{min_salary.text.strip} - #{max_salary.text.strip}"
+    "#{number_to_currency(salary_min, precision: 0)} - #{number_to_currency(salary_max, precision: 0)}"
   end
 
   def working_hours
@@ -81,7 +76,7 @@ class JobProfileDecorator < SimpleDelegator
   private
 
   def html_body
-    @html_body ||= Nokogiri::HTML(__getobj__ .content)
+    @html_body ||= Nokogiri::HTML(content)
   end
 
   def mutate_html_body

--- a/app/models/job_profile.rb
+++ b/app/models/job_profile.rb
@@ -18,37 +18,8 @@ class JobProfile < ApplicationRecord
     scraper = JobProfileScraper.new
     scraped = scraper.scrape(source_url)
 
-    update(name: scraped['title'], description: scraped['description'], content: scraped['body'])
-    self.skills = Skill.import(scraped['skills'])
-  end
-
-  def salary
-    {
-      min: html_body.xpath(SALARY_MIN_XPATH).children[0].text.strip,
-      max: html_body.xpath(SALARY_MAX_XPATH).children[0].text.strip
-    }
-  end
-
-  def working_hours
-    html_body.xpath(WORKING_HOURS_XPATH)
-             .children[0]
-             .text
-             .strip
-             .gsub('to', '-')
-             .delete(' ')
-  end
-
-  def working_hours_patterns
-    html_body.xpath(WORKING_HOURS_PATTERNS_XPATH)
-             .children[0]
-             .text
-             .strip
-             .capitalize
-  end
-
-  private
-
-  def html_body
-    @html_body ||= Nokogiri::HTML(content)
+    self.name = scraped.delete('title')
+    self.skills = Skill.import scraped.delete('skills')
+    update!(scraped)
   end
 end

--- a/app/scrapers/job_profile_scraper.rb
+++ b/app/scrapers/job_profile_scraper.rb
@@ -3,6 +3,15 @@ class JobProfileScraper
 
   title css: 'h1.heading-xlarge'
   description css: '.column-desktop-two-thirds p'
-  body 'css=body', :html
+
+  salary_min css: '#Salary p.dfc-code-jpsstarter/text()' do |min|
+    min.gsub(/\D/, '').to_i if min =~ /\d/
+  end
+
+  salary_max css: '#Salary p.dfc-code-jpsexperienced/text()' do |max|
+    max.gsub(/\D/, '').to_i if max =~ /\d/
+  end
+
+  content 'css=body', :html
   skills 'css=#Skills ul li', :list
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,5 +28,7 @@ module GetHelpToRetrain
     # the framework and any gems in your application.
 
     config.exceptions_app = routes
+
+    config.i18n.default_locale = :'en-GB'
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,4 @@
-en:
+en-GB:
   breadcrumb:
     home: Home
     task_list: Get help to retrain

--- a/db/migrate/20190626115718_add_salary_range_to_job_profiles.rb
+++ b/db/migrate/20190626115718_add_salary_range_to_job_profiles.rb
@@ -1,0 +1,7 @@
+class AddSalaryRangeToJobProfiles < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :job_profiles, :salary_range
+    add_column :job_profiles, :salary_min, :integer
+    add_column :job_profiles, :salary_max, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_14_101226) do
+ActiveRecord::Schema.define(version: 2019_06_26_115718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,11 +48,12 @@ ActiveRecord::Schema.define(version: 2019_06_14_101226) do
     t.string "name"
     t.string "source_url"
     t.string "description"
-    t.string "salary_range"
     t.boolean "recommended", default: false
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "salary_min"
+    t.integer "salary_max"
     t.index ["slug"], name: "index_job_profiles_on_slug", unique: true
   end
 

--- a/spec/decorators/job_profile_decorator_spec.rb
+++ b/spec/decorators/job_profile_decorator_spec.rb
@@ -1,27 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe JobProfileDecorator do
-  subject(:job_profile) {
-    described_class.new(build_stubbed(:job_profile, content: html_body))
-  }
+  subject(:job_profile) { described_class.new(model) }
+
+  let(:model) { build_stubbed :job_profile, content: html_body }
 
   describe '#salary_range' do
-    let(:html_body) do
-      '<div id="Salary" class="column-40 job-profile-heroblock">
-        <h2>
-          Average salary
-          <span>(a year)</span>
-        </h2>
-        <div class="job-profile-salary job-profile-heroblock-content">
-          <p class="dfc-code-jpsstarter">£18,000 <span>Starter</span></p>
-          <i class="sr-hidden">to</i>
-          <p class="dfc-code-jpsexperienced">£30,000 <span>Experienced</span></p>
-        </div>
-      </div>'
+    context 'with defined minimum and maximum' do
+      let(:model) { build_stubbed :job_profile, salary_min: 18_000, salary_max: 30_000 }
+
+      it 'formats the salary range' do
+        expect(job_profile.salary_range).to eq '£18,000 - £30,000'
+      end
     end
 
-    it 'extracts the correct date range values' do
-      expect(job_profile.salary_range).to eq '£18,000 - £30,000'
+    context 'with missing minimum or maximum' do
+      let(:model) { build_stubbed :job_profile }
+
+      it 'returns Variable' do
+        expect(job_profile.salary_range).to eq 'Variable'
+      end
     end
   end
 

--- a/spec/models/job_profile_spec.rb
+++ b/spec/models/job_profile_spec.rb
@@ -130,6 +130,14 @@ RSpec.describe JobProfile do
       expect(job_profile.description).to match 'organising meetings'
     end
 
+    it 'updates salary minimum with scraped salary' do
+      expect(job_profile.salary_min).to eq 14_000
+    end
+
+    it 'updates salary maximum with scraped salary' do
+      expect(job_profile.salary_max).to eq 30_000
+    end
+
     it 'updates content with scraped body' do
       expect(job_profile.content).to match 'National Careers Service'
     end

--- a/spec/scrapers/job_profile_scraper_spec.rb
+++ b/spec/scrapers/job_profile_scraper_spec.rb
@@ -21,8 +21,16 @@ RSpec.describe JobProfileScraper, vcr: { cassette_name: 'explore_my_careers_job_
       expect(scraped['description']).to match 'organising meetings'
     end
 
+    it 'parses job profile minimum salary' do
+      expect(scraped['salary_min']).to eq 14_000
+    end
+
+    it 'parses job profile maximum salary' do
+      expect(scraped['salary_max']).to eq 30_000
+    end
+
     it 'parses job profile full page' do
-      expect(scraped['body']).to match 'National Careers Service'
+      expect(scraped['content']).to match 'National Careers Service'
     end
 
     it 'parses skills' do

--- a/spec/scrapers/job_profile_scraper_spec.rb
+++ b/spec/scrapers/job_profile_scraper_spec.rb
@@ -1,40 +1,87 @@
 require 'rails_helper'
 
 RSpec.describe JobProfileScraper, vcr: { cassette_name: 'explore_my_careers_job_profile' } do
+  subject(:scraped) { scraper.scrape(job_profile_url) }
+
   let(:scraper) { described_class.new }
   let(:job_profile_url) { 'https://nationalcareers.service.gov.uk/job-profiles/admin-assistant' }
-  let(:skills) do
-    [
-      'administration skills',
-      'customer service skills'
-    ]
-  end
 
-  describe '#scrape' do
-    subject(:scraped) { scraper.scrape(job_profile_url) }
-
+  describe 'title' do
     it 'parses job profile name' do
       expect(scraped['title']).to eq 'Admin assistant'
     end
+  end
 
+  describe 'description' do
     it 'parses job profile description' do
       expect(scraped['description']).to match 'organising meetings'
     end
+  end
 
-    it 'parses job profile minimum salary' do
-      expect(scraped['salary_min']).to eq 14_000
-    end
-
-    it 'parses job profile maximum salary' do
-      expect(scraped['salary_max']).to eq 30_000
-    end
-
+  describe 'content' do
     it 'parses job profile full page' do
       expect(scraped['content']).to match 'National Careers Service'
     end
+  end
 
+  describe 'skills' do
     it 'parses skills' do
-      expect(scraped['skills']).to include(*skills)
+      expect(scraped['skills']).to include('administration skills', 'customer service skills')
+    end
+  end
+
+  describe 'salary_max' do
+    it 'parses job profile maximum salary' do
+      expect(scraped['salary_max']).to eq 30_000
+    end
+  end
+
+  describe 'salary_min' do
+    let(:fake_page) { Mechanize::Page.new nil, nil, body, 200, scraper.mechanize }
+
+    around do |example|
+      scraper.metadata.page fake_page
+      example.run
+      scraper.metadata.page nil
+    end
+
+    context 'with valid salary' do
+      let(:body) do
+        '<div id="Salary" class="column-40 job-profile-heroblock">
+          <div class="job-profile-salary job-profile-heroblock-content">
+            <p class="dfc-code-jpsstarter">£18,000 <span>Starter</span></p>
+          </div>
+        </div>'
+      end
+
+      it 'parses job profile minimum salary' do
+        expect(scraped['salary_min']).to eq 18_000
+      end
+    end
+
+    context 'with missing salary' do
+      let(:body) do
+        '<div id="Salary" class="column-40 job-profile-heroblock">
+        </div>'
+      end
+
+      it 'returns nil' do
+        expect(scraped['salary_min']).to be_nil
+      end
+    end
+
+    context 'with invalid salary' do
+      let(:body) do
+        '<div id="Salary" class="column-40 job-profile-heroblock">
+          <div class="job-profile-salary job-profile-heroblock-content">
+            <p class="dfc-code-jpsstarter">£LOADSAMONEY <span>Starter</span></p>
+          </div>
+        </div>'
+      end
+
+      it 'returns nil' do
+        expect(scraped['salary_min']).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
Salary range was previously rendered on the fly using Nokogiri to parse the job profile body content. This was too slow when viewing a large number of job profiles on the search results page.

### Changes proposed in this pull request
Added new attributes to job profile for salary min and max values. These are populated when scraping the job profile, and then used within the decorator. Also cleaned up a little related/dead code.

As the salary values are held as integers, they need to be reformatted back to currency values. I've changed the default locale to `en-GB` to accomodate this, otherwise we would need to specify currency symbol every time. Open to other approaches though.

Search results page (for all 857 jobs) is now nice and quick:

```
  Rendering explore_occupations/results.html.erb within layouts/application
  Rendered shared/search/_results_form.html.erb (0.8ms)
  Rendered shared/_contact_us.html.erb (0.5ms)
  Rendered explore_occupations/results.html.erb within layouts/application (408.6ms)
  Rendered shared/navigation/_main_header.html.erb (0.7ms)
Completed 200 OK in 755ms (Views: 429.6ms | ActiveRecord: 124.8ms)
```

### Guidance to review
Job profiles need to be re-scraped by running `bundle exec rails data_import:scrape_job_profiles` - otherwise all job profiles will display `Varied` for salary range. It's not necessary to run the other scraper steps just for this.