### PR TITLE
GET-138 Allow job profile to show paths from results or categories

### DIFF
--- a/app/helpers/job_profiles_helper.rb
+++ b/app/helpers/job_profiles_helper.rb
@@ -1,0 +1,5 @@
+module JobProfilesHelper
+  def job_profile_breadcrumbs_for(url)
+    URI(url).path =~ /categories/ ? t('breadcrumb.job_category') : t('breadcrumb.search_results')
+  end
+end

--- a/app/views/job_profiles/show.html.erb
+++ b/app/views/job_profiles/show.html.erb
@@ -5,7 +5,7 @@
         [t('breadcrumb.home'), root_path],
         [t('breadcrumb.task_list'), task_list_path],
         [t('breadcrumb.explore_occupations'), explore_occupations_path],
-        [t('breadcrumb.search_results'), results_explore_occupations_path]
+        [job_profile_breadcrumbs_for(request.referer), request.referer]
       ]
     )
   end

--- a/app/views/skills/index.html.erb
+++ b/app/views/skills/index.html.erb
@@ -5,7 +5,7 @@
         [t('breadcrumb.home'), root_path],
         [t('breadcrumb.task_list'), task_list_path],
         [t('breadcrumb.check_your_skills'), check_your_skills_path],
-        [t('breadcrumb.search_results'), results_check_your_skills_path]
+        [t('breadcrumb.search_results'), request.referer]
       ]
     )
   end

--- a/spec/helpers/job_profiles_helper_spec.rb
+++ b/spec/helpers/job_profiles_helper_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe JobProfilesHelper do
+  describe '.job_profile_breadcrumbs_for' do
+    it 'returns title for categories if referer path is a category' do
+      expect(helper.job_profile_breadcrumbs_for('categories')).to eq(t('breadcrumb.job_category'))
+    end
+
+    it 'defaults to results page title' do
+      expect(helper.job_profile_breadcrumbs_for('results')).to eq(t('breadcrumb.search_results'))
+    end
+  end
+end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-138

* Pages which come back from a search will now allow a user to
  maintain their search results
* Job profile page will now allow you to either go back to a
  profile or a search results page.