### PR TITLE
GET-156 Business metrics (KPIs)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.6-alpine as assets
 
 ENV RAILS_ENV production
 ENV NODE_ENV production
-ENV BUILD_PACKAGES build-base nodejs yarn tzdata postgresql-dev
+ENV BUILD_PACKAGES build-base nodejs yarn tzdata postgresql-dev git
 
 # Update and install all of the required packages.
 # At the end, remove the apk cache

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem 'foreman'
 # Canonical meta tag
 gem 'canonical-rails'
 
+gem 'application_insights'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ end
 ruby File.read('.ruby-version').chomp
 
 # To use Azure application insights
-gem 'application_insights', '~> 0.5.6'
+gem 'application_insights', github: 'microsoft/ApplicationInsights-Ruby', ref: 'a7429200'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ end
 
 ruby File.read('.ruby-version').chomp
 
+# To use Azure application insights
+gem 'application_insights', '~> 0.5.6'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
 gem 'rails-i18n', '~> 5.1'
@@ -32,8 +35,6 @@ gem 'foreman'
 
 # Canonical meta tag
 gem 'canonical-rails'
-
-gem 'application_insights'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/microsoft/ApplicationInsights-Ruby.git
+  revision: a74292001cf12f6de957dfdcefaf8dbe415d7181
+  ref: a7429200
+  specs:
+    application_insights (0.5.7)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -44,7 +51,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    application_insights (0.5.6)
     arel (9.0.0)
     ast (2.4.0)
     backports (3.15.0)
@@ -322,7 +328,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  application_insights
+  application_insights!
   bootsnap (>= 1.1.0)
   brakeman (~> 4.5)
   byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    application_insights (0.5.6)
     arel (9.0.0)
     ast (2.4.0)
     backports (3.15.0)
@@ -321,6 +322,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  application_insights
   bootsnap (>= 1.1.0)
   brakeman (~> 4.5)
   byebug

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,6 +1,6 @@
 class CategoriesController < ApplicationController
   def show
-    @category = Category.find(params[:id])
+    @category = Category.find_by_slug(params[:id])
     @other_categories = Category.with_job_profiles_without(@category)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  def page_title(key)
+    content_for(:page_title, I18n.t(key, scope: 'page_titles'))
+  end
+
   def generate_breadcrumbs(current_page, previous_pages)
     safe_join(
       [

--- a/app/helpers/explore_occupations_helper.rb
+++ b/app/helpers/explore_occupations_helper.rb
@@ -1,7 +1,7 @@
 module ExploreOccupationsHelper
   def job_profile_category_list(job_profile)
     job_profile.categories.map { |category|
-      link_to(category.name, category_path(category), class: 'govuk-link')
+      link_to(category.name, category_path(category.slug), class: 'govuk-link')
     }.join(', ').html_safe
   end
 end

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -21,7 +21,7 @@
       <ul class="govuk-list">
         <% @other_categories.each do |category| %>
           <li>
-            <%= link_to category.name, category_path(category), class: 'govuk-link govuk-body-s' %>
+            <%= link_to category.name, category_path(category.slug), class: 'govuk-link govuk-body-s' %>
           </li>
         <% end %>
       </ul>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,4 +1,4 @@
-<% page_title :job_category %>
+<% page_title :categories_show %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.job_category'),

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,3 +1,4 @@
+<% page_title :job_category %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.job_category'),

--- a/app/views/check_your_skills/index.html.erb
+++ b/app/views/check_your_skills/index.html.erb
@@ -1,3 +1,4 @@
+<% page_title :check_your_skills %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.check_your_skills'),

--- a/app/views/check_your_skills/index.html.erb
+++ b/app/views/check_your_skills/index.html.erb
@@ -1,4 +1,4 @@
-<% page_title :check_your_skills %>
+<% page_title :check_your_skills_index %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.check_your_skills'),

--- a/app/views/check_your_skills/results.html.erb
+++ b/app/views/check_your_skills/results.html.erb
@@ -1,4 +1,4 @@
-<% page_title :check_skills_results %>
+<% page_title :check_your_skills_results %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.search_results'),

--- a/app/views/check_your_skills/results.html.erb
+++ b/app/views/check_your_skills/results.html.erb
@@ -1,3 +1,4 @@
+<% page_title :check_skills_results %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.search_results'),

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,3 +1,5 @@
+<% page_title :errors_internal_server_error %>
+
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,3 +1,5 @@
+<% page_title :errors_not_found %>
+
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,3 +1,5 @@
+<% page_title :errors_unprocessable_entity %>
+
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/explore_occupations/index.html.erb
+++ b/app/views/explore_occupations/index.html.erb
@@ -1,4 +1,4 @@
-<% page_title :explore_occupations %>
+<% page_title :explore_occupations_index %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.explore_occupations'),

--- a/app/views/explore_occupations/index.html.erb
+++ b/app/views/explore_occupations/index.html.erb
@@ -16,7 +16,7 @@
       <% @categories.each do |category| %>
         <li class="govuk-!-padding-top-1 column-list-item">
           <h4 class="govuk-!-margin-0">
-            <%= link_to category.name, category_path(category), class: 'govuk-link' %>
+            <%= link_to category.name, category_path(category.slug), class: 'govuk-link' %>
           </h4>
         </li>
       <% end %>

--- a/app/views/explore_occupations/index.html.erb
+++ b/app/views/explore_occupations/index.html.erb
@@ -1,3 +1,4 @@
+<% page_title :explore_occupations %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.explore_occupations'),

--- a/app/views/explore_occupations/results.html.erb
+++ b/app/views/explore_occupations/results.html.erb
@@ -1,4 +1,4 @@
-<% page_title :job_profile_results %>
+<% page_title :explore_occupations_results %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.search_results'),

--- a/app/views/explore_occupations/results.html.erb
+++ b/app/views/explore_occupations/results.html.erb
@@ -1,3 +1,4 @@
+<% page_title :job_profile_results %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.search_results'),

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,4 @@
-<% page_title :home %>
+<% page_title :home_index %>
 
 <div class="govuk-grid-row govuk-!-padding-top-4">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,5 @@
+<% page_title :home %>
+
 <div class="govuk-grid-row govuk-!-padding-top-4">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>

--- a/app/views/job_profiles/show.html.erb
+++ b/app/views/job_profiles/show.html.erb
@@ -1,4 +1,4 @@
-<% page_title :job_profile %>
+<% page_title :job_profiles_show %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.job_profile'),

--- a/app/views/job_profiles/show.html.erb
+++ b/app/views/job_profiles/show.html.erb
@@ -1,3 +1,4 @@
+<% page_title :job_profile %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.job_profile'),

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
-    <title>Get Help to Retrain</title>
+    <title><%= content_for?(:page_title) ? yield(:page_title) : t('page_titles.default') %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>

--- a/app/views/pages/find_training_courses.html.erb
+++ b/app/views/pages/find_training_courses.html.erb
@@ -1,3 +1,4 @@
+<% page_title :find_training_courses %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.find_training_courses'),

--- a/app/views/pages/find_training_courses.html.erb
+++ b/app/views/pages/find_training_courses.html.erb
@@ -1,4 +1,4 @@
-<% page_title :find_training_courses %>
+<% page_title :pages_find_training_courses %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.find_training_courses'),

--- a/app/views/pages/next_steps.html.erb
+++ b/app/views/pages/next_steps.html.erb
@@ -1,4 +1,4 @@
-<% page_title :next_steps %>
+<% page_title :pages_next_steps %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.next_steps'),

--- a/app/views/pages/next_steps.html.erb
+++ b/app/views/pages/next_steps.html.erb
@@ -1,3 +1,4 @@
+<% page_title :next_steps %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.next_steps'),

--- a/app/views/pages/task_list.html.erb
+++ b/app/views/pages/task_list.html.erb
@@ -1,4 +1,4 @@
-<% page_title :task_list %>
+<% page_title :pages_task_list %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.task_list'),

--- a/app/views/pages/task_list.html.erb
+++ b/app/views/pages/task_list.html.erb
@@ -1,3 +1,4 @@
+<% page_title :task_list %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.task_list'),

--- a/app/views/skills/index.html.erb
+++ b/app/views/skills/index.html.erb
@@ -1,4 +1,4 @@
-<% page_title :your_skills %>
+<% page_title :skills_index %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.your_skills'),

--- a/app/views/skills/index.html.erb
+++ b/app/views/skills/index.html.erb
@@ -1,3 +1,4 @@
+<% page_title :your_skills %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
       t('breadcrumb.your_skills'),

--- a/azure/template.json
+++ b/azure/template.json
@@ -62,6 +62,17 @@
         "description": "The container image to pull from the server. Should be in image:tag format."
       }
     },
+    "appInsightsJavaScriptEnabled": {
+      "type": "bool",
+      "defaultValue": false,
+      "allowedValues": [
+        true,
+        false
+      ],
+      "metadata": {
+        "description": "whether to enable JS page tracking for Application Insights"
+      }
+    },
     "secretKeyBase": {
       "type": "string",
       "metadata": {
@@ -262,6 +273,10 @@
               {
                 "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
                 "value": "[reference('app-insights').outputs.instrumentationKey.value]"
+              },
+              {
+                "name": "APPINSIGHTS_JAVASCRIPT_ENABLED",
+                "value": "[parameters('appInsightsJavaScriptEnabled')]"
               },
               {
                 "name": "DB_DATABASE",

--- a/config/initializers/application_insights.rb
+++ b/config/initializers/application_insights.rb
@@ -1,4 +1,4 @@
-unless Rails.env.test?
+if Rails.env.production?
   Rails.application.configure do
     if (app_insights_key = ENV['APPINSIGHTS_INSTRUMENTATIONKEY']) && app_insights_key.present?
       # the optional extra params are buffer_size (= 500) and send_interval (= 60),

--- a/config/initializers/application_insights.rb
+++ b/config/initializers/application_insights.rb
@@ -1,11 +1,11 @@
 unless Rails.env.test?
   Rails.application.configure do
-    if (app_insights_key = ENV["APPINSIGHTS_INSTRUMENTATIONKEY"]) && app_insights_key.present?
+    if (app_insights_key = ENV['APPINSIGHTS_INSTRUMENTATIONKEY']) && app_insights_key.present?
       # the optional extra params are buffer_size (= 500) and send_interval (= 60),
       # leaving for now as they appear sensible
       config.middleware.use(ApplicationInsights::Rack::TrackRequest, app_insights_key)
-      if 'true' ==  ENV["APPINSIGHTS_JAVASCRIPT_ENABLED"]
-          config.middleware.use(ApplicationInsights::Rack::InjectJavaScriptTracking, app_insights_key)
+      if ENV['APPINSIGHTS_JAVASCRIPT_ENABLED'] == 'true'
+        config.middleware.use(ApplicationInsights::Rack::InjectJavaScriptTracking, app_insights_key)
       end
     end
 
@@ -19,7 +19,7 @@ unless Rails.env.test?
     sender = ApplicationInsights::Channel::AsynchronousSender.new
     queue = ApplicationInsights::Channel::AsynchronousQueue.new(sender)
     channel = ApplicationInsights::Channel::TelemetryChannel.new(nil, queue)
-    #
+
     TELEMETRY_CLIENT = ApplicationInsights::TelemetryClient.new(app_insights_key, channel).tap do |tc|
       # flush telemetry if we have 10 or more telemetry items in our queue
       tc.channel.queue.max_queue_length = 10

--- a/config/initializers/application_insights.rb
+++ b/config/initializers/application_insights.rb
@@ -31,5 +31,8 @@ unless Rails.env.test?
       # the background worker thread will poll the queue every 0.5 seconds for new items
       tc.channel.sender.send_interval = 0.5
     end
+
+    # setup unhandled exception handler
+    ApplicationInsights::UnhandledException.collect(app_insights_key)
   end
 end

--- a/config/initializers/application_insights.rb
+++ b/config/initializers/application_insights.rb
@@ -16,21 +16,21 @@ if Rails.env.production?
     # # https://github.com/microsoft/ApplicationInsights-Ruby
     # # https://github.com/microsoft/ApplicationInsights-Home/wiki#getting-an-application-insights-instrumentation-key
     #
-    sender = ApplicationInsights::Channel::AsynchronousSender.new
-    queue = ApplicationInsights::Channel::AsynchronousQueue.new(sender)
-    channel = ApplicationInsights::Channel::TelemetryChannel.new(nil, queue)
-
-    TELEMETRY_CLIENT = ApplicationInsights::TelemetryClient.new(app_insights_key, channel).tap do |tc|
-      # flush telemetry if we have 10 or more telemetry items in our queue
-      tc.channel.queue.max_queue_length = 10
-      # send telemetry to the service in batches of 5
-      tc.channel.sender.send_buffer_size = 5
-      # the background worker thread will be active for 5 seconds before it shuts down. if
-      # during this time items are picked up from the queue, the timer is reset.
-      tc.channel.sender.send_time = 5
-      # the background worker thread will poll the queue every 0.5 seconds for new items
-      tc.channel.sender.send_interval = 0.5
-    end
+    # sender = ApplicationInsights::Channel::AsynchronousSender.new
+    # queue = ApplicationInsights::Channel::AsynchronousQueue.new(sender)
+    # channel = ApplicationInsights::Channel::TelemetryChannel.new(nil, queue)
+    #
+    # TELEMETRY_CLIENT = ApplicationInsights::TelemetryClient.new(app_insights_key, channel).tap do |tc|
+    #   # flush telemetry if we have 10 or more telemetry items in our queue
+    #   tc.channel.queue.max_queue_length = 10
+    #   # send telemetry to the service in batches of 5
+    #   tc.channel.sender.send_buffer_size = 5
+    #   # the background worker thread will be active for 5 seconds before it shuts down. if
+    #   # during this time items are picked up from the queue, the timer is reset.
+    #   tc.channel.sender.send_time = 5
+    #   # the background worker thread will poll the queue every 0.5 seconds for new items
+    #   tc.channel.sender.send_interval = 0.5
+    # end
 
     # setup unhandled exception handler
     ApplicationInsights::UnhandledException.collect(app_insights_key)

--- a/config/initializers/application_insights.rb
+++ b/config/initializers/application_insights.rb
@@ -1,0 +1,35 @@
+unless Rails.env.test?
+  Rails.application.configure do
+    if (app_insights_key = ENV["APPINSIGHTS_INSTRUMENTATIONKEY"]) && app_insights_key.present?
+      # the optional extra params are buffer_size (= 500) and send_interval (= 60),
+      # leaving for now as they appear sensible
+      config.middleware.use(ApplicationInsights::Rack::TrackRequest, app_insights_key)
+      if 'true' ==  ENV["APPINSIGHTS_JAVASCRIPT_ENABLED"]
+          config.middleware.use(ApplicationInsights::Rack::InjectJavaScriptTracking, app_insights_key)
+      end
+    end
+
+    # # This isn't needed _until_ we want to track events and metrics in addition
+    # # to the Rails app middleware (ApplicationInsights::Rack::TrackRequest). More
+    # # info here:
+    #
+    # # https://github.com/microsoft/ApplicationInsights-Ruby
+    # # https://github.com/microsoft/ApplicationInsights-Home/wiki#getting-an-application-insights-instrumentation-key
+    #
+    sender = ApplicationInsights::Channel::AsynchronousSender.new
+    queue = ApplicationInsights::Channel::AsynchronousQueue.new(sender)
+    channel = ApplicationInsights::Channel::TelemetryChannel.new(nil, queue)
+    #
+    TELEMETRY_CLIENT = ApplicationInsights::TelemetryClient.new(app_insights_key, channel).tap do |tc|
+      # flush telemetry if we have 10 or more telemetry items in our queue
+      tc.channel.queue.max_queue_length = 10
+      # send telemetry to the service in batches of 5
+      tc.channel.sender.send_buffer_size = 5
+      # the background worker thread will be active for 5 seconds before it shuts down. if
+      # during this time items are picked up from the queue, the timer is reset.
+      tc.channel.sender.send_time = 5
+      # the background worker thread will poll the queue every 0.5 seconds for new items
+      tc.channel.sender.send_interval = 0.5
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,17 +14,20 @@ en-GB:
 
   page_titles:
     default: Get help to retrain
-    home: Get help to retrain - Home
-    task_list: Get help to retrain - Tasks
-    check_your_skills: Get help to retrain - Check your skills
-    check_skills_results: Get help to retrain - Check skills results
-    your_skills: Get help to retrain - Your skills
-    explore_occupations: Get help to retrain - Explore occupations
-    job_category: Get help to retrain - Job category
-    job_profile_results: Get help to retrain - Search results
-    job_profile: Get help to retrain - Job profile
-    find_training_courses: Get help to retrain - Training courses
-    next_steps: Get help to retrain - Next steps
+    home_index: Get help to retrain - Home
+    pages_task_list: Get help to retrain - Tasks
+    check_your_skills_index: Get help to retrain - Check your skills
+    check_your_skills_results: Get help to retrain - Check your skills results
+    skills_index: Get help to retrain - Your skills
+    explore_occupations_index: Get help to retrain - Explore occupations
+    categories_show: Get help to retrain - Job category
+    explore_occupations_results: Get help to retrain - Explore occupations results
+    job_profiles_show: Get help to retrain - Job profile
+    pages_find_training_courses: Get help to retrain - Training courses
+    pages_next_steps: Get help to retrain - Next steps
+    errors_not_found: Get help to retrain - Not found
+    errors_unprocessable_entity: Get help to retrain - Unprocessable entity
+    errors_internal_server_error: Get help to retrain - Internal server error
 
   contact_us:
     title: Want to speak with an adviser?
@@ -59,6 +62,7 @@ en-GB:
   home:
     index:
       title: Get help to retrain
+
   pages:
     task_list:
       title: Get help to retrain

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,21 @@ en-GB:
     search_results: Search results
     job_profile: Job profile details
     your_skills: Your skills
+
+  page_titles:
+    default: Get help to retrain
+    home: Get help to retrain - Home
+    task_list: Get help to retrain - Tasks
+    check_your_skills: Get help to retrain - Check your skills
+    check_skills_results: Get help to retrain - Check skills results
+    your_skills: Get help to retrain - Your skills
+    explore_occupations: Get help to retrain - Explore occupations
+    job_category: Get help to retrain - Job category
+    job_profile_results: Get help to retrain - Search results
+    job_profile: Get help to retrain - Job profile
+    find_training_courses: Get help to retrain - Training courses
+    next_steps: Get help to retrain - Next steps
+
   contact_us:
     title: Want to speak with an adviser?
     body: Call

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationHelper do
+  describe '.page_title' do
+    it 'returns correct translated page title' do
+      helper.page_title(:home)
+      expect(helper.content_for(:page_title)).to eq 'Get help to retrain - Home'
+    end
+
+    it 'warns of missing translations' do
+      helper.page_title(:foo)
+      expect(helper.content_for(:page_title)).to eq 'translation missing: en-GB.page_titles.foo'
+    end
+  end
+
   describe '.generate_breadcrumbs' do
     it 'returns current page list item' do
       expect(helper.generate_breadcrumbs('Current Page', [])).to match(/Current Page/)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ApplicationHelper do
   describe '.page_title' do
     it 'returns correct translated page title' do
-      helper.page_title(:home)
+      helper.page_title(:home_index)
       expect(helper.content_for(:page_title)).to eq 'Get help to retrain - Home'
     end
 


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/GET-156

This adds a javascript snippet to every page in `production` which collects data on every page impression served. It also creates a permanent user cookie and temporary session cookie to track repeat visits.

### Changes proposed in this pull request
* Adding the gem and initialiser boilerplate for Azure application insights.
* Introduced page titles for each view to allow easier tracking of user journeys within app insights
* Use category slugs rather than id's for category paths so that these don't change after scraping new categories

### Guidance to review
This needs to be deployed to an Azure instance with a reasonable level of traffic to allow testing - there's also some lead time before data appears. I'd suggest we merge this and then evaluate how well it works with the updated page titles.