### PR TITLE
GET-136 rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+git_source(:github) do |repo|
+  "https://github.com/#{repo}.git"
+end
 
 ruby File.read('.ruby-version').chomp
 
@@ -84,7 +86,7 @@ group :test do
   # Easy installation and use of browser drivers to run system tests with different browsers
   gem 'webdrivers', '~> 4.0'
 
-    # Test coverage reporting
+  # Test coverage reporting
   gem 'simplecov', '~> 0.16', require: false
 
   # Web request caching for tests

--- a/app/decorators/job_profile_decorator.rb
+++ b/app/decorators/job_profile_decorator.rb
@@ -1,6 +1,10 @@
+# rubocop:disable Metrics/ClassLength
+# TODO: Most of the xpath expressions within this class will be migrated to JobProfileScraper over time
+# which should remove the need to disable rubocop rules here.
 class JobProfileDecorator < SimpleDelegator
   include ActionView::Helpers::TagHelper
 
+  # rubocop:disable Metrics/LineLength
   SALARY_MIN_XPATH = "//div[@id='Salary']//p[@class='dfc-code-jpsstarter']".freeze
   SALARY_MAX_XPATH = "//div[@id='Salary']//p[@class='dfc-code-jpsexperienced']".freeze
   WORKING_HOURS_XPATH = "//div[@id='WorkingHours']//p[@class='dfc-code-jphours']".freeze
@@ -18,6 +22,7 @@ class JobProfileDecorator < SimpleDelegator
   RESTRICTIONS_AND_REQUESTS_SECTION_XPATH = "//section[@id='Skills']//section[contains(@class, 'job-profile-subsection') and (contains(@id, 'restrictions'))]".freeze
   CAREER_TIPS_SECTION_XPATH = "//section[contains(@class, 'job-profile-subsection') and contains (@id, 'moreinfo')]//div[@class='job-profile-subsection-content']".freeze
   OTHER_ROUTES_SECTION_XPATH = "//section[contains(@class, 'job-profile-subsection') and contains (@id, 'otherroutes')]".freeze
+  # rubocop:enable Metrics/LineLength
 
   def salary_range
     min_salary = html_body.xpath(SALARY_MIN_XPATH).children[0]
@@ -70,7 +75,7 @@ class JobProfileDecorator < SimpleDelegator
 
     mutate_html_body
 
-    @doc.to_html.gsub(/<a.*?>(.+?)<\/a>/, '\1').concat(separator_line)
+    @doc.to_html.gsub(%r{<a.*?>(.+?)</a>}, '\1').concat(separator_line)
   end
 
   private
@@ -131,3 +136,4 @@ class JobProfileDecorator < SimpleDelegator
     content_tag :hr, nil, class: 'govuk-section-break govuk-section-break--m govuk-section-break--visible'
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,6 +68,12 @@ jobs:
         DOCKER_RUN: $(dockerRun)
 
     - script: |
+        $DOCKER_RUN bundle exec rubocop
+      displayName: Rubocop linter
+      env:
+        DOCKER_RUN: $(dockerRun)
+
+    - script: |
         $DOCKER_RUN bundle exec brakeman
       displayName: Brakeman check
       env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,12 +62,6 @@ jobs:
         DOCKER_RUN: $(dockerRun)
 
     - script: |
-        $DOCKER_RUN bundle exec govuk-lint-ruby app lib spec
-      displayName: GovUK linter
-      env:
-        DOCKER_RUN: $(dockerRun)
-
-    - script: |
         $DOCKER_RUN bundle exec rubocop
       displayName: Rubocop linter
       env:

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -3,4 +3,6 @@
   .rbenv-vars
   tmp/restart.txt
   tmp/caching-dev.txt
-].each { |path| Spring.watch(path) }
+].each do |path|
+  Spring.watch(path)
+end

--- a/features/step_definitions/test_steps.rb
+++ b/features/step_definitions/test_steps.rb
@@ -1,39 +1,39 @@
-When("I am on the {string} page") do |path|
+When('I am on the {string} page') do |path|
   visit("/#{path}")
 end
 
-Given("I am on the homepage") do
+Given('I am on the homepage') do
   visit(root_path)
 end
 
-Given("a job profile exists with the name {string}") do |name|
+Given('a job profile exists with the name {string}') do |name|
   create(:job_profile, name: name)
 end
 
-Then("the correct eligibility criteria is displayed") do
+Then('the correct eligibility criteria is displayed') do
   expect(page).to have_content('you\'re employed')
   expect(page).to have_content('you do not have a degree')
   expect(page).to have_content('you’re based in the Manchester area')
   expect(page).to have_content('aged 24 or over')
 end
 
-Then("the current page contains text {string}") do |content|
+Then('the current page contains text {string}') do |content|
   expect(page).to have_content(content)
 end
 
-Then("I click on the button {string}") do |string|
+Then('I click on the button {string}') do |string|
   click(string)
 end
 
-Then("I should see all stages of the journey") do
+Then('I should see all stages of the journey') do
   pending # Write code here that turns the phrase above into concrete actions
 end
 
-When("I click the text link {string}") do |string|
+When('I click the text link {string}') do |string|
   click_link(string)
 end
 
-When("there are placeholders for {string}") do |string|
+When('there are placeholders for {string}') do |string|
   case string
   when 'occupations'
     expect(page).to have_content('Explore the type of jobs you could retrain to do')
@@ -48,35 +48,35 @@ When("there are placeholders for {string}") do |string|
   end
 end
 
-When("the link {string} is inactive") do |string|
-  has_link? (string)
+When('the link {string} is inactive') do |string|
+  has_link? string
 end
 
-When("I enter {string} in {string} field") do |string, string2|
+When('I enter {string} in {string} field') do |string, string2|
   fill_in string2, with: string
 end
 
-When("I click the {string} button") do |string|
+When('I click the {string} button') do |string|
   find(string).click
 end
 
-Then("I should see the {string} page") do |title|
+Then('I should see the {string} page') do |title|
   has_title? title
 end
 
-Then("I see error message {string}") do |error|
+Then('I see error message {string}') do |error|
   expect(page).to have_content(error)
 end
 
-Then("Find a Course Service is unavailable") do |string|
+Then('Find a Course Service is unavailable') do |_string|
   pending # Write code here that turns the phrase above into concrete actions
 end
 
-Then("Find a Course Service is available again") do |string|
+Then('Find a Course Service is available again') do |_string|
   pending # Write code here that turns the phrase above into concrete actions
 end
 
-Then("I should see a list of occupations for {string}") do |string|
+Then('I should see a list of occupations for {string}') do |string|
   case string
   when 'Healthcare'
     expect(page).to have_content('Doctor')

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,10 +8,10 @@ DatabaseCleaner.allow_remote_database_url = true
 begin
   DatabaseCleaner.strategy = :truncation
 rescue NameError
-  raise "You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it."
+  raise 'You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it.'
 end
 
-Around do |scenario, block|
+Around do |_scenario, block|
   DatabaseCleaner.cleaning(&block)
 end
 
@@ -21,17 +21,15 @@ end
 
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu window-size=1280,2000 no-sandbox) }
+    chromeOptions: { args: %w[headless disable-gpu window-size=1280,2000 no-sandbox] }
   )
 
   Capybara::Selenium::Driver.new app,
-    browser: :chrome,
-    desired_capabilities: capabilities
+                                 browser: :chrome,
+                                 desired_capabilities: capabilities
 end
 
 Capybara.javascript_driver = :headless_chrome
 
 Cucumber::Rails::Database.javascript_strategy = :truncation
 World(FactoryBot::Syntax::Methods)
-
-


### PR DESCRIPTION
### Context
Fixes rubocop violations and adds a step to Azure pipeline so that we can use rubocop locally. The gov.uk linter seems to ignore a lot of violations so this is more thorough.

### Changes proposed in this pull request
Ignored class length and line length violations in JobProfileDecorator for now - that will be refactored over time to resolve those.

### Guidance to review
Check build passes - examine Azure devops output.

```
##[section]Starting: Rubocop linter
==============================================================================
Task         : Command line
Description  : Run a command line script using Bash on Linux and macOS and cmd.exe on Windows
Version      : 2.151.1
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/command-line
==============================================================================
Generating script.
Script contents:
$DOCKER_RUN bundle exec rubocop
========================== Starting Command Output ===========================
[command]/bin/bash --noprofile --norc /home/vsts/work/_temp/4a75aa44-fa52-443d-b6b4-a3bc27ad6927.sh
Inspecting 72 files
........................................................................

72 files inspected, no offenses detected
##[section]Finishing: Rubocop linter
```