### PR TITLE
Get 138 fix breadcrumbs

### DIFF
--- a/app/helpers/job_profiles_helper.rb
+++ b/app/helpers/job_profiles_helper.rb
@@ -1,5 +1,11 @@
 module JobProfilesHelper
-  def job_profile_breadcrumbs_for(url)
-    URI(url).path =~ /categories/ ? t('breadcrumb.job_category') : t('breadcrumb.search_results')
+  def job_profile_breadcrumbs_for(params)
+    if params[:category]
+      [t('breadcrumb.job_category'), category_path(params[:category])]
+    else
+      [t('breadcrumb.search_results'), results_explore_occupations_path(
+        name: params[:explore_occupations_result]
+      )]
+    end
   end
 end

--- a/app/views/categories/_results_list.html.erb
+++ b/app/views/categories/_results_list.html.erb
@@ -2,7 +2,7 @@
   <% job_profiles.each do |job_profile| %>
     <li class="govuk-!-padding-bottom-2 govuk-!-padding-top-4">
       <h3 class="govuk-!-margin-0">
-        <%= link_to job_profile.name, local_assigns[:show_skills_only] ? job_profile_skills_path(job_profile.slug, check_your_skills_result: params[:name]) : job_profile_path(job_profile.slug), class: 'govuk-link no-text-decoration' %>
+        <%= link_to job_profile.name, job_profile_path(job_profile.slug, category: params[:id]), class: 'govuk-link no-text-decoration' %>
       </h3>
       <p class="govuk-!-margin-0"><%= job_profile.description %></p>
     </li>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -2,8 +2,7 @@
     generate_breadcrumbs(
       t('breadcrumb.job_category'),
       [
-        [t('breadcrumb.home'), root_path],
-        [t('breadcrumb.task_list'), task_list_path],
+        [t('breadcrumb.task_list_home'), task_list_path],
         [t('breadcrumb.explore_occupations'), explore_occupations_path]
       ]
     )

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -12,7 +12,7 @@
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds" >
     <h3 class="govuk-heading-l"><%= @category.name %></h3>
-    <%= render "shared/search/results_list", job_profiles: @category.job_profiles %>
+    <%= render "results_list", job_profiles: @category.job_profiles %>
   </div>
   <%= render "shared/contact_us" %>
   <div class="govuk-grid-column-one-third">

--- a/app/views/check_your_skills/_results_list.html.erb
+++ b/app/views/check_your_skills/_results_list.html.erb
@@ -1,0 +1,10 @@
+<ul class="govuk-list">
+  <% job_profiles.each do |job_profile| %>
+    <li class="govuk-!-padding-bottom-2 govuk-!-padding-top-4">
+      <h3 class="govuk-!-margin-0">
+        <%= link_to job_profile.name, job_profile_skills_path(job_profile.slug, check_your_skills_result: params[:name]), class: 'govuk-link no-text-decoration' %>
+      </h3>
+      <p class="govuk-!-margin-0"><%= job_profile.description %></p>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/check_your_skills/index.html.erb
+++ b/app/views/check_your_skills/index.html.erb
@@ -2,8 +2,7 @@
     generate_breadcrumbs(
       t('breadcrumb.check_your_skills'),
       [
-        [t('breadcrumb.home'), root_path],
-        [t('breadcrumb.task_list'), task_list_path]
+        [t('breadcrumb.task_list_home'), task_list_path]
       ]
     )
   end

--- a/app/views/check_your_skills/results.html.erb
+++ b/app/views/check_your_skills/results.html.erb
@@ -18,7 +18,7 @@
     <% else %>
       <p class="govuk-body-m" ><%= t('.results', count: @job_profiles.count) %></p>
       <p class="govuk-body-l govuk-!-margin-bottom-1"><%= t('.body') %></p>
-      <%= render "shared/search/results_list", job_profiles: @job_profiles, show_skills_only: true %>
+      <%= render "results_list", job_profiles: @job_profiles %>
     <% end %>
   </div>
   <%= render "shared/contact_us" %>

--- a/app/views/check_your_skills/results.html.erb
+++ b/app/views/check_your_skills/results.html.erb
@@ -2,8 +2,7 @@
     generate_breadcrumbs(
       t('breadcrumb.search_results'),
       [
-        [t('breadcrumb.home'), root_path],
-        [t('breadcrumb.task_list'), task_list_path],
+        [t('breadcrumb.task_list_home'), task_list_path],
         [t('breadcrumb.check_your_skills'), check_your_skills_path]
       ]
     )

--- a/app/views/explore_occupations/index.html.erb
+++ b/app/views/explore_occupations/index.html.erb
@@ -2,8 +2,7 @@
     generate_breadcrumbs(
       t('breadcrumb.explore_occupations'),
       [
-        [t('breadcrumb.home'), root_path],
-        [t('breadcrumb.task_list'), task_list_path]
+        [t('breadcrumb.task_list_home'), task_list_path]
       ]
     )
   end

--- a/app/views/explore_occupations/results.html.erb
+++ b/app/views/explore_occupations/results.html.erb
@@ -22,7 +22,7 @@
         <% @job_profiles.each do |job_profile| %>
           <li class="govuk-!-padding-bottom-1">
             <h3 class="govuk-!-margin-0">
-               <%= link_to job_profile.name, job_profile_path(job_profile.slug), class: 'govuk-link no-text-decoration' %>
+               <%= link_to job_profile.name, job_profile_path(job_profile.slug, explore_occupations_result: params[:name]), class: 'govuk-link no-text-decoration' %>
             </h3>
             <p class="govuk-!-margin-0 govuk-!-margin-bottom-3"><%= job_profile.description %></p>
             <p class="govuk-body-s govuk-!-margin-bottom-1 strong"><%= job_profile.salary_range %></p>

--- a/app/views/explore_occupations/results.html.erb
+++ b/app/views/explore_occupations/results.html.erb
@@ -2,8 +2,7 @@
     generate_breadcrumbs(
       t('breadcrumb.search_results'),
       [
-        [t('breadcrumb.home'), root_path],
-        [t('breadcrumb.task_list'), task_list_path],
+        [t('breadcrumb.task_list_home'), task_list_path],
         [t('breadcrumb.explore_occupations'), explore_occupations_path]
       ]
     )

--- a/app/views/job_profiles/show.html.erb
+++ b/app/views/job_profiles/show.html.erb
@@ -4,7 +4,7 @@
       [
         [t('breadcrumb.task_list_home'), task_list_path],
         [t('breadcrumb.explore_occupations'), explore_occupations_path],
-        job_profile_breadcrumbs_for(request.referer)
+        [t('breadcrumb.search_results'), results_explore_occupations_path(name: params[:explore_occupations_result])]
       ]
     )
   end

--- a/app/views/job_profiles/show.html.erb
+++ b/app/views/job_profiles/show.html.erb
@@ -1,11 +1,10 @@
 <% content_for :breadcrumb do
     generate_breadcrumbs(
-      @job_profile.hero_copy,
+      t('breadcrumb.job_profile'),
       [
-        [t('breadcrumb.home'), root_path],
-        [t('breadcrumb.task_list'), task_list_path],
+        [t('breadcrumb.task_list_home'), task_list_path],
         [t('breadcrumb.explore_occupations'), explore_occupations_path],
-        [job_profile_breadcrumbs_for(request.referer), request.referer]
+        job_profile_breadcrumbs_for(request.referer)
       ]
     )
   end

--- a/app/views/job_profiles/show.html.erb
+++ b/app/views/job_profiles/show.html.erb
@@ -4,7 +4,7 @@
       [
         [t('breadcrumb.task_list_home'), task_list_path],
         [t('breadcrumb.explore_occupations'), explore_occupations_path],
-        [t('breadcrumb.search_results'), results_explore_occupations_path(name: params[:explore_occupations_result])]
+        job_profile_breadcrumbs_for(params)
       ]
     )
   end

--- a/app/views/pages/find_training_courses.html.erb
+++ b/app/views/pages/find_training_courses.html.erb
@@ -2,8 +2,7 @@
     generate_breadcrumbs(
       t('breadcrumb.find_training_courses'),
       [
-        [t('breadcrumb.home'), root_path],
-        [t('breadcrumb.task_list'), task_list_path]
+        [t('breadcrumb.task_list_home'), task_list_path]
       ]
     )
   end

--- a/app/views/pages/next_steps.html.erb
+++ b/app/views/pages/next_steps.html.erb
@@ -2,8 +2,7 @@
     generate_breadcrumbs(
       t('breadcrumb.next_steps'),
       [
-        [t('breadcrumb.home'), root_path],
-        [t('breadcrumb.task_list'), task_list_path]
+        [t('breadcrumb.task_list_home'), task_list_path]
       ]
     )
   end

--- a/app/views/pages/task_list.html.erb
+++ b/app/views/pages/task_list.html.erb
@@ -2,7 +2,7 @@
     generate_breadcrumbs(
       t('breadcrumb.task_list'),
       [
-        [t('breadcrumb.home'), root_path]
+        [t('breadcrumb.task_list_home'), root_path]
       ]
     )
   end

--- a/app/views/shared/search/_results_list.html.erb
+++ b/app/views/shared/search/_results_list.html.erb
@@ -2,7 +2,7 @@
   <% job_profiles.each do |job_profile| %>
     <li class="govuk-!-padding-bottom-2 govuk-!-padding-top-4">
       <h3 class="govuk-!-margin-0">
-        <%= link_to job_profile.name, local_assigns[:show_skills_only] ? job_profile_skills_path(job_profile.slug) : job_profile_path(job_profile.slug), class: 'govuk-link no-text-decoration' %>
+        <%= link_to job_profile.name, local_assigns[:show_skills_only] ? job_profile_skills_path(job_profile.slug, check_your_skills_result: params[:name]) : job_profile_path(job_profile.slug), class: 'govuk-link no-text-decoration' %>
       </h3>
       <p class="govuk-!-margin-0"><%= job_profile.description %></p>
     </li>

--- a/app/views/skills/index.html.erb
+++ b/app/views/skills/index.html.erb
@@ -2,8 +2,7 @@
     generate_breadcrumbs(
       t('breadcrumb.your_skills'),
       [
-        [t('breadcrumb.home'), root_path],
-        [t('breadcrumb.task_list'), task_list_path],
+        [t('breadcrumb.task_list_home'), task_list_path],
         [t('breadcrumb.check_your_skills'), check_your_skills_path],
         [t('breadcrumb.search_results'), request.referer]
       ]

--- a/app/views/skills/index.html.erb
+++ b/app/views/skills/index.html.erb
@@ -4,7 +4,7 @@
       [
         [t('breadcrumb.task_list_home'), task_list_path],
         [t('breadcrumb.check_your_skills'), check_your_skills_path],
-        [t('breadcrumb.search_results'), request.referer]
+        [t('breadcrumb.search_results'), results_check_your_skills_path(name: params[:check_your_skills_result])]
       ]
     )
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,12 +2,14 @@ en:
   breadcrumb:
     home: Home
     task_list: Get help to retrain
+    task_list_home: 'Home: Get help to retrain'
     check_your_skills: Check your existing skills
     explore_occupations: Explore occupations
     find_training_courses: Find and apply to training courses near you
     next_steps: Next steps
     job_category: Job category
     search_results: Search results
+    job_profile: Job profile details
     your_skills: Your skills
   contact_us:
     title: Want to speak with an adviser?

--- a/spec/helpers/job_profiles_helper_spec.rb
+++ b/spec/helpers/job_profiles_helper_spec.rb
@@ -2,12 +2,24 @@ require 'rails_helper'
 
 RSpec.describe JobProfilesHelper do
   describe '.job_profile_breadcrumbs_for' do
-    it 'returns title for categories if referer path is a category' do
-      expect(helper.job_profile_breadcrumbs_for('categories')).to eq(t('breadcrumb.job_category'))
+    it 'returns categories breadcrumbs if referer path is a category' do
+      params = { category: 1 }
+      expect(helper.job_profile_breadcrumbs_for(params)).to eq(
+        [t('breadcrumb.job_category'), category_path(1)]
+      )
     end
 
-    it 'defaults to results page title' do
-      expect(helper.job_profile_breadcrumbs_for('results')).to eq(t('breadcrumb.search_results'))
+    it 'returns explore occupations results breadcrumbs if referer path is a defined result' do
+      params = { explore_occupations_result: 'Developer' }
+      expect(helper.job_profile_breadcrumbs_for(params)).to eq(
+        [t('breadcrumb.search_results'), results_explore_occupations_path(name: 'Developer')]
+      )
+    end
+
+    it 'defaults to empty explore occupations results' do
+      expect(helper.job_profile_breadcrumbs_for({})).to eq(
+        [t('breadcrumb.search_results'), results_explore_occupations_path]
+      )
     end
   end
 end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-138

* users don't want to go back home but to tasklist from all pages
* keep home on task list breadcrumbs
* remove title of job and only have job details instead
* Move results list to specific directories to avoid confusion
  as now we are being explicit with passing params around
* Change breadcrumbs helper to rely on params rather than referrer
  request as that was flakey and not explicit causing unexpected
  behaviour from outside requests and if someone presses the back
  button on the browser

Breadcrumbs paths we support now (this is not the exact content but just to show the paths):
1) Homepage: none
2) Task list page: Home > Task list
3) Check your existing skills page: Home: Task list > Check your skills
4) Check your existing skills results page: Home: Task list > Check your skills > Search results
5) Skills page: Home: Task list > Check your skills > Search results > Skills (if you go back should now reserve your results)
6) Explore occupations page: Home: Task list > Explore Occupations
7) Categoires page: Home: Task list > Explore Occupations > Category
8) Job profile through category: Home: Task list > Explore Occupations > Category > Job profile
9) Explore occupations results page: Home: Task list > Explore Occupations > Search results
10) Job profile through results: Home: Task list > Explore Occupations >  Search results > Job profile (if you go back should now reserve your results)
11) apply for course: Home: Task list > Apply for course
12) Next steps: Home: Get help to retrain > Next steps