### PR TITLE
Add a new rake task to update job profile attributes with previous content

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,9 @@ Alternatively for development mode only, it's possible to create random data cre
 ```bash
   bundle exec rails db:seed
 ```
+
+If job profiles have been previously scraped and `content` is populated, it's possible to run the following rake task to refresh the persisted job profile attributes (e.g. name, description, skills, salary_min, salary_max etc.):
+
+```bash
+  bundle exec rails data_import:refresh_job_profiles
+```

--- a/app/models/job_profile.rb
+++ b/app/models/job_profile.rb
@@ -14,8 +14,7 @@ class JobProfile < ApplicationRecord
     end
   end
 
-  def scrape
-    scraper = JobProfileScraper.new
+  def scrape(scraper = JobProfileScraper.new)
     scraped = scraper.scrape(source_url)
 
     self.name = scraped.delete('title')

--- a/lib/tasks/data_import/refresh_job_profiles.rake
+++ b/lib/tasks/data_import/refresh_job_profiles.rake
@@ -1,0 +1,17 @@
+namespace :data_import do
+  # bin/rails data_import:scrape_job_profiles
+  task refresh_job_profiles: :environment do
+    print 'Refreshing job profile attributes with previously scraped content'
+    if JobProfile.any?
+      JobProfile.all.each do |job_profile|
+        scraper = JobProfileScraper.new
+        cached_page = Mechanize::Page.new(nil, nil, job_profile.content, 200, scraper.mechanize)
+        scraper.metadata.page cached_page
+        print "Refreshing job profile #{job_profile.slug}"
+        job_profile.scrape(scraper)
+      end
+    else
+      print 'No job profiles setup - please import sitemap first'
+    end
+  end
+end


### PR DESCRIPTION
### Context
This is much faster than re-scraping the entire set of job profiles from NCS again - taking around 10 seconds rather than 15 minutes. It's just a hacky thing so haven't added specs but tested locally and works well.

### Changes proposed in this pull request
Allowed `scraper` to be injected into job profile `scrape` method, which allows preloading the Wombat scraper with the stored `content`.

### Guidance to review
Run `bundle exec rails data_import:refresh_job_profiles` - this will populate `salary_min` and `salary_max` columns if the job profiles were scraped prior to GET-141 being merged.