### PR TITLE
Ensure accidental spaces are ignored at search

### DIFF
--- a/app/models/job_profile.rb
+++ b/app/models/job_profile.rb
@@ -5,7 +5,7 @@ class JobProfile < ApplicationRecord
   has_many :skills, through: :job_profile_skills, inverse_of: :job_profiles
 
   def self.search(name)
-    where('name ILIKE ?', "%#{name}%")
+    where('name ILIKE ?', "%#{name&.squish}%")
   end
 
   def self.import(slug, url)

--- a/spec/models/job_profile_spec.rb
+++ b/spec/models/job_profile_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe JobProfile do
   end
 
   describe '.search' do
+    it 'returns a job profile if a name has accidental spaces' do
+      job_profile = create(:job_profile, name: 'Music therapist')
+
+      expect(described_class.search('Music    therapist      ')).to contain_exactly(job_profile)
+    end
+
     it 'returns a job profile if a name matches exactly' do
       job_profile = create(:job_profile, name: 'Beverage Dissemination Officer')
 


### PR DESCRIPTION
### Context

Given I search for a keyword that already exists among Skills/Occupation, e.g `Music therapist`
When I add accidental spaces (no matter the position)
Then I get no results.

AC

Ensure our search keywords are stripped of any additional spaces.

When I search for `Music therapist` or ` Music therapist` or `Music   therapist` I should get the same results.

### JIRA Ticket

https://dfedigital.atlassian.net/browse/GET-168

