### PR TITLE
On task list keep home breadcrumb

### DIFF
--- a/app/views/pages/task_list.html.erb
+++ b/app/views/pages/task_list.html.erb
@@ -2,7 +2,7 @@
     generate_breadcrumbs(
       t('breadcrumb.task_list'),
       [
-        [t('breadcrumb.task_list_home'), root_path]
+        [t('breadcrumb.home'), root_path]
       ]
     )
   end


### PR DESCRIPTION
Accidentally added home: `Home: Get help to retrain` instead of `Home` on tasklist. This is the only page that should link back to home