### PR TITLE
GET-169 Add Alternative Titles

### DIFF
--- a/app/decorators/job_profile_decorator.rb
+++ b/app/decorators/job_profile_decorator.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 # TODO: Most of the xpath expressions within this class will be migrated to JobProfileScraper over time
 # which should remove the need to disable rubocop rules here.
 class JobProfileDecorator < SimpleDelegator
@@ -9,7 +8,6 @@ class JobProfileDecorator < SimpleDelegator
   WORKING_HOURS_XPATH = "//div[@id='WorkingHours']//p[@class='dfc-code-jphours']".freeze
   WORKING_HOURS_PATTERNS_XPATH = "//div[@id='WorkingHoursPatterns']//p[@class='dfc-code-jpwpattern']".freeze
   HERO_COPY_XPATH = "//header[@class='job-profile-hero']//h1[@class='heading-xlarge']".freeze
-  SUB_HERO_COPY_XPATH = "//header[@class='job-profile-hero']//h2[@class='heading-secondary']".freeze
   ADDITIONAL_COPY_XPATH = "//header[@class='job-profile-hero']//div[@class='column-desktop-two-thirds']/p".freeze
   APPRENTICESHIP_SECTION_XPATH = "//section[@id='Apprenticeship']".freeze
   DIRECT_APPLICATION_SECTION_XPATH = "//section[@id='directapplication']".freeze
@@ -47,14 +45,6 @@ class JobProfileDecorator < SimpleDelegator
 
   def hero_copy
     html_body.xpath(HERO_COPY_XPATH).text.strip
-  end
-
-  def sub_hero_copy
-    parsed_section = html_body.xpath(SUB_HERO_COPY_XPATH)
-
-    return unless parsed_section.any?
-
-    parsed_section.children.last.text
   end
 
   def additional_hero_copy
@@ -131,4 +121,3 @@ class JobProfileDecorator < SimpleDelegator
     content_tag :hr, nil, class: 'govuk-section-break govuk-section-break--m govuk-section-break--visible'
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/helpers/job_profiles_helper.rb
+++ b/app/helpers/job_profiles_helper.rb
@@ -8,4 +8,8 @@ module JobProfilesHelper
       )]
     end
   end
+
+  def alternative_names(names)
+    names.join(', ')
+  end
 end

--- a/app/scrapers/job_profile_scraper.rb
+++ b/app/scrapers/job_profile_scraper.rb
@@ -12,6 +12,10 @@ class JobProfileScraper
     max.gsub(/\D/, '').to_i if max =~ /\d/
   end
 
+  alternative_titles css: 'h2.heading-secondary/text()[last()]' do |titles|
+    titles ? titles.split(', ') : []
+  end
+
   content 'css=body', :html
   skills 'css=#Skills ul li', :list
 end

--- a/app/views/categories/_results_list.html.erb
+++ b/app/views/categories/_results_list.html.erb
@@ -1,10 +1,11 @@
 <ul class="govuk-list">
   <% job_profiles.each do |job_profile| %>
-    <li class="govuk-!-padding-bottom-2 govuk-!-padding-top-4">
+    <li class="govuk-!-padding-bottom-1 govuk-!-padding-top-4">
       <h3 class="govuk-!-margin-0">
         <%= link_to job_profile.name, job_profile_path(job_profile.slug, category: params[:id]), class: 'govuk-link no-text-decoration' %>
       </h3>
-      <p class="govuk-!-margin-0"><%= job_profile.description %></p>
+      <p class="govuk-body-s govuk-!-margin-bottom-2 muted-text"><%= alternative_names(job_profile.alternative_titles) %></p>
+      <p class="govuk-!-margin-top-0"><%= job_profile.description %></p>
     </li>
   <% end %>
 </ul>

--- a/app/views/check_your_skills/_results_list.html.erb
+++ b/app/views/check_your_skills/_results_list.html.erb
@@ -1,9 +1,10 @@
 <ul class="govuk-list">
   <% job_profiles.each do |job_profile| %>
-    <li class="govuk-!-padding-bottom-2 govuk-!-padding-top-4">
+    <li class="govuk-!-padding-bottom-3 govuk-!-padding-top-4">
       <h3 class="govuk-!-margin-0">
         <%= link_to job_profile.name, job_profile_skills_path(job_profile.slug, check_your_skills_result: params[:name]), class: 'govuk-link no-text-decoration' %>
       </h3>
+      <p class="govuk-body-s govuk-!-margin-bottom-2 muted-text"><%= alternative_names(job_profile.alternative_titles) %></p>
       <p class="govuk-!-margin-0"><%= job_profile.description %></p>
     </li>
   <% end %>

--- a/app/views/explore_occupations/results.html.erb
+++ b/app/views/explore_occupations/results.html.erb
@@ -21,9 +21,10 @@
       <ul class="govuk-list">
         <% @job_profiles.each do |job_profile| %>
           <li class="govuk-!-padding-bottom-1">
-            <h3 class="govuk-!-margin-0">
+            <h3 class="govuk-!-margin-bottom-0">
                <%= link_to job_profile.name, job_profile_path(job_profile.slug, explore_occupations_result: params[:name]), class: 'govuk-link no-text-decoration' %>
             </h3>
+            <p class="govuk-body-s govuk-!-margin-bottom-2 muted-text"><%= alternative_names(job_profile.alternative_titles) %></p>
             <p class="govuk-!-margin-0 govuk-!-margin-bottom-3"><%= job_profile.description %></p>
             <p class="govuk-body-s govuk-!-margin-bottom-1 strong">Salary: <%= job_profile.salary_range %></p>
             <p class="govuk-body-s muted-text">Found in:

--- a/app/views/job_profiles/_brief.html.erb
+++ b/app/views/job_profiles/_brief.html.erb
@@ -1,6 +1,6 @@
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-2" ><%= @job_profile.hero_copy %></h1>
-<% if @job_profile.sub_hero_copy.present? %>
-  <p class="govuk-body-l muted-text"><%= @job_profile.sub_hero_copy %></p>
+<% if @job_profile.alternative_titles.any? %>
+  <p class="govuk-body-l muted-text"><%= alternative_names(@job_profile.alternative_titles) %></p>
 <% end %>
 <% @job_profile.additional_hero_copy.each do |paragraph| %>
   <p class="govuk-body-l"><%= paragraph %></p>

--- a/db/migrate/20190701155237_add_alternative_titles_to_job_profiles.rb
+++ b/db/migrate/20190701155237_add_alternative_titles_to_job_profiles.rb
@@ -1,0 +1,5 @@
+class AddAlternativeTitlesToJobProfiles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :job_profiles, :alternative_titles, :string, array: true, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_26_115718) do
+ActiveRecord::Schema.define(version: 2019_07_01_155237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 2019_06_26_115718) do
     t.datetime "updated_at", null: false
     t.integer "salary_min"
     t.integer "salary_max"
+    t.string "alternative_titles", default: [], null: false, array: true
     t.index ["slug"], name: "index_job_profiles_on_slug", unique: true
   end
 

--- a/spec/decorators/job_profile_decorator_spec.rb
+++ b/spec/decorators/job_profile_decorator_spec.rb
@@ -96,41 +96,6 @@ RSpec.describe JobProfileDecorator do
       expect(job_profile.hero_copy).to eq 'Archivist'
     end
 
-    context 'when sub hero copy exists' do
-      it 'extracts the sub hero copy' do
-        expect(job_profile.sub_hero_copy).to eq 'Curator, records manager'
-      end
-    end
-
-    context 'when sub hero copy is missing' do
-      let(:html_body) do
-        '<header class="job-profile-hero">
-          <div data-sf-element="Row">
-            <div id="MainContentTop_T41A29498007_Col00" class="sf_colsIn" data-sf-element="Container" data-placeholder-label="Job Profile Hero Container"><div class="content-container">
-              <div class="breadcrumbs govuk-breadcrumbs">
-                <ol class="govuk-breadcrumbs__list">
-                  <li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/">Home: Explore careers</a></li>
-                  <li class="govuk-breadcrumbs__list-item">Archivist</li>
-                </ol>
-              </div>
-            </div>
-            <div class="content-container">
-              <div class="grid-row">
-                <div class="column-desktop-two-thirds">
-                  <h1 class="heading-xlarge"> Archivist</h1>
-                  <p>Archivists look after and preserve documents.</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </header>'
-      end
-
-      it 'returns from the method' do
-        expect(job_profile.sub_hero_copy).to be nil
-      end
-    end
-
     it 'extracts the additional copy' do
       expect(job_profile.additional_hero_copy).to match(
         ['Archivists look after and preserve documents.']

--- a/spec/helpers/job_profiles_helper_spec.rb
+++ b/spec/helpers/job_profiles_helper_spec.rb
@@ -22,4 +22,18 @@ RSpec.describe JobProfilesHelper do
       )
     end
   end
+
+  describe '.alternative_names' do
+    it 'returns a comma delimited list of alternative titles' do
+      expect(helper.alternative_names(['Curator', 'records manager'])).to eq('Curator, records manager')
+    end
+
+    it 'returns a single name of alternative titles if its only one' do
+      expect(helper.alternative_names(['Curator'])).to eq('Curator')
+    end
+
+    it 'returns nothing if no titles included' do
+      expect(helper.alternative_names([])).to be_empty
+    end
+  end
 end

--- a/spec/scrapers/job_profile_scraper_spec.rb
+++ b/spec/scrapers/job_profile_scraper_spec.rb
@@ -84,4 +84,55 @@ RSpec.describe JobProfileScraper, vcr: { cassette_name: 'explore_my_careers_job_
       end
     end
   end
+
+  describe 'alternative_titles' do
+    let(:fake_page) { Mechanize::Page.new nil, nil, body, 200, scraper.mechanize }
+
+    around do |example|
+      scraper.metadata.page fake_page
+      example.run
+      scraper.metadata.page nil
+    end
+
+    context 'with available alternative titles' do
+      let(:body) do
+        '<div class="column-desktop-two-thirds">
+          <h1 class="heading-xlarge"> Admin assistant</h1>
+          <h2 class="heading-secondary"><span class="sr-hidden">Alternative titles for this job include </span>Office administrator, clerical assistant, administrative assistant</h2>
+          <p>Admin assistants give support to offices by organising meetings, typing documents and updating computer records.</p>
+        </div>'
+      end
+
+      it 'parses alternative titles' do
+        expect(scraped['alternative_titles']).to contain_exactly('Office administrator', 'clerical assistant', 'administrative assistant')
+      end
+    end
+
+    context 'with single alternative title' do
+      let(:body) do
+        '<div class="column-desktop-two-thirds">
+          <h1 class="heading-xlarge"> Admin assistant</h1>
+          <h2 class="heading-secondary"><span class="sr-hidden">Alternative titles for this job include </span>Office administrator</h2>
+          <p>Admin assistants give support to offices by organising meetings, typing documents and updating computer records.</p>
+        </div>'
+      end
+
+      it 'parses alternative titles' do
+        expect(scraped['alternative_titles']).to contain_exactly('Office administrator')
+      end
+    end
+
+    context 'with no alternative titles' do
+      let(:body) do
+        '<div class="column-desktop-two-thirds">
+          <h1 class="heading-xlarge"> Admin assistant</h1>
+          <p>Admin assistants give support to offices by organising meetings, typing documents and updating computer records.</p>
+        </div>'
+      end
+
+      it 'returns empty array' do
+        expect(scraped['alternative_titles']).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-169

* When scraping job profile pages Persist alternative titles in the database in an array column
* Remove sub hero content from Job Profile decorator
* Add alternative titles lists in check your skills and explore occupations search results
* Substitute alternative titles for sub hero content in Job Profile page
* fix some styles where we are missing some margins