### PR TITLE
Add loggly for production logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem 'foreman'
 # Canonical meta tag
 gem 'canonical-rails'
 
+# Logging
+gem 'logglier', '~> 0.5'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    logglier (0.5.0)
+      multi_json (~> 1)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -342,6 +344,7 @@ DEPENDENCIES
   foreman
   govuk-lint
   listen (>= 3.0.5, < 3.2)
+  logglier (~> 0.5)
   pg (>= 0.18, < 2.0)
   pry-byebug
   puma (~> 3.12)

--- a/azure/template.json
+++ b/azure/template.json
@@ -73,6 +73,13 @@
         "description": "whether to enable JS page tracking for Application Insights"
       }
     },
+    "logglyToken": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description:": "Optional token for Loggly logging service"
+      }
+    },
     "secretKeyBase": {
       "type": "string",
       "metadata": {
@@ -293,6 +300,10 @@
               {
                 "name": "DB_HOST",
                 "value": "[reference('postgresql-server').outputs.fullyQualifiedDomainName.value]"
+              },
+              {
+                "name": "LOGGLY_TOKEN",
+                "value": "[parameters('logglyToken')]"
               },
               {
                 "name": "POSTGRESQL_SERVICE_PORT",

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/BlockLength
 Rails.application.configure do
   # Verifies that versions and hashed value of the package contents in the project's package.json
   config.webpacker.check_yarn_integrity = false
@@ -77,16 +78,20 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Use a different logger for distributed setups.
-  if ENV['LOGGLY_TOKEN'].present?
-    loggly_url = "https://logs-01.loggly.com/inputs/#{ENV['LOGGLY_TOKEN']}/tag/ruby/"
-    config.logger = Logglier.new(loggly_url, threaded: true)
-    config.logger.formatter = config.log_formatter
-  elsif ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    stdout_logger           = ActiveSupport::Logger.new(STDOUT)
+    stdout_logger.formatter = config.log_formatter
+    config.logger           = ActiveSupport::TaggedLogging.new(stdout_logger)
+
+    if ENV['LOGGLY_TOKEN'].present?
+      loggly_url              = "https://logs-01.loggly.com/inputs/#{ENV['LOGGLY_TOKEN']}/tag/ruby/"
+      loggly_logger           = Logglier.new(loggly_url, threaded: true)
+      loggly_logger.formatter = config.log_formatter
+      config.logger.extend(ActiveSupport::Logger.broadcast(loggly_logger))
+    end
   end
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end
+# rubocop:enable Metrics/BlockLength

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,14 +77,14 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Use a different logger for distributed setups.
-  if ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  elsif ENV['LOGGLY_TOKEN'].present?
+  if ENV['LOGGLY_TOKEN'].present?
     loggly_url = "https://logs-01.loggly.com/inputs/#{ENV['LOGGLY_TOKEN']}/tag/ruby/"
     config.logger = Logglier.new(loggly_url, threaded: true)
     config.logger.formatter = config.log_formatter
+  elsif ENV['RAILS_LOG_TO_STDOUT'].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
 
   # Do not dump schema after migrations.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,13 +77,14 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
   if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  elsif ENV['LOGGLY_TOKEN'].present?
+    loggly_url = "https://logs-01.loggly.com/inputs/#{ENV['LOGGLY_TOKEN']}/tag/ruby/"
+    config.logger = Logglier.new(loggly_url, threaded: true)
+    config.logger.formatter = config.log_formatter
   end
 
   # Do not dump schema after migrations.


### PR DESCRIPTION
### Context
This is a short term solution until we move to a native Azure logging approach.

### Changes proposed in this pull request
I've added support for an optional `LOGGLY_TOKEN` environment variable. If this is set, then loggly is used as the preferred logger, with all log traffic captured and forwarded.

### Guidance to review

