### PR TITLE
GET-183 Remove Turbolinks

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,8 @@
     <%= favicon_link_tag '/assets/images/govuk-apple-touch-icon-152x152.png', rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
     <%= favicon_link_tag '/assets/images/govuk-apple-touch-icon-167x167.png', rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
     <%= favicon_link_tag '/assets/images/govuk-apple-touch-icon-180x180.png', rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
-    <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
+    <%= stylesheet_pack_tag 'application', media: 'all' %>
+    <%= javascript_pack_tag 'application', defer: true %>
   </head>
 
   <body class="govuk-template__body ">

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,11 +1,9 @@
 import '../styles/application.scss';
 import SearchForm from './search-form';
 import Rails from 'rails-ujs';
-import Turbolinks from 'turbolinks';
 import { initAll } from 'govuk-frontend';
 
 
 SearchForm.start();
 Rails.start();
-Turbolinks.start();
 initAll();

--- a/app/webpacker/packs/search-form.js
+++ b/app/webpacker/packs/search-form.js
@@ -1,11 +1,9 @@
 function SearchForm () {
   this.start = function () {
-    document.addEventListener("turbolinks:load", function() {
-      var $jobProfileName = document.querySelector('#name');
-      var $jobProfileSearchForm = document.querySelector('#job-profile-search');
+    const $jobProfileName = document.querySelector('#name');
+    const $jobProfileSearchForm = document.querySelector('#job-profile-search');
 
-      disableEmptyForm($jobProfileSearchForm, $jobProfileName);
-    });
+    disableEmptyForm($jobProfileSearchForm, $jobProfileName);
   }
 
   function disableEmptyForm($form, $field) {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "@rails/webpacker": "^4.0.7",
     "copy-webpack-plugin": "^5.0.3",
     "govuk-frontend": "^2.13.0",
-    "rails-ujs": "^5.2.3",
-    "turbolinks": "^5.2.0"
+    "rails-ujs": "^5.2.3"
   },
   "devDependencies": {
     "webpack-dev-server": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7043,11 +7043,6 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-turbolinks@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
-  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
-
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"


### PR DESCRIPTION
### Context
Turbolinks is intended to improve page load times, by avoiding the need to fetch and parse CSS and JS assets described in the `head` section of the page. In practice this works to a degree, but has complications.

Already we have had to adapt the progressive enhancement for search to listen to custom turbolinks events. The Azure App Insights tracking script is working intermittently since this is only firing on initial page load or manual refresh, not when user navigates to a new page by clicking links.

There are numerous anecdotal reports of various issues with the library, including double loading of pages, accessibility limitations etc. Overall, it's not adding value so good to remove.


### Changes proposed in this pull request
Completely remove turbolinks library and any associated setup. Use standard window load event to hook search functionality.

### Guidance to review

