### PR TITLE
GET-174 Disable indexing on all pages in beta release

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
     <%= tag :meta, property: 'og:image', content: '/assets/images/govuk-opengraph-image.png' %>
     <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
+    <%= tag :meta, name: 'robots', content: 'noindex, nofollow, noarchive, nosnippet, noimageindex' %>
     <%= favicon_link_tag '/assets/images/favicon.ico' %>
     <%= favicon_link_tag '/assets/images/govuk-mask-icon.svg', rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
     <%= favicon_link_tag '/assets/images/govuk-apple-touch-icon.png', rel: 'apple-touch-icon', type: 'image/png' %>


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-174

Add a X-Robots-Tag to all pages to stop search engines indexing pages.

Specifications for this tag are found here:
https://developers.google.com/search/reference/robots_meta_tag

and GovUK recommendation:
https://www.gov.uk/service-manual/technology/get-a-domain-name

