### PR TITLE
Add client side tracking for User Exit Survey Link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,7 @@
           <p class="govuk-phase-banner__content">
             <strong class="govuk-tag govuk-phase-banner__content__tag ">beta</strong>
             <span class="govuk-phase-banner__text">
-              This is a new service – your <%= link_to 'feedback', 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link', target: '_blank', data: { tracked_event: 'User Exit Survey Link', type: 'link' }%> will help us to improve it.
+              This is a new service – your <%= link_to 'feedback', 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link', target: '_blank', data: { tracked_event: 'Banner - User Exit Survey Link' }%> will help us to improve it.
             </span>
           </p>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,7 @@
           <p class="govuk-phase-banner__content">
             <strong class="govuk-tag govuk-phase-banner__content__tag ">beta</strong>
             <span class="govuk-phase-banner__text">
-              This is a new service – your <%= link_to 'feedback', 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link', target: '_blank', data: { tracked__event: 'User Exit Survey Link', type: 'link' }%> will help us to improve it.
+              This is a new service – your <%= link_to 'feedback', 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link', target: '_blank', data: { tracked_event: 'User Exit Survey Link', type: 'link' }%> will help us to improve it.
             </span>
           </p>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,7 @@
           <p class="govuk-phase-banner__content">
             <strong class="govuk-tag govuk-phase-banner__content__tag ">beta</strong>
             <span class="govuk-phase-banner__text">
-              This is a new service – your <%= link_to 'feedback', 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link', target: '_blank'%> will help us to improve it.
+              This is a new service – your <%= link_to 'feedback', 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link', target: '_blank', data: { tracked__event: 'User Exit Survey Link', type: 'link' }%> will help us to improve it.
             </span>
           </p>
         </div>

--- a/app/views/pages/task_list.html.erb
+++ b/app/views/pages/task_list.html.erb
@@ -81,7 +81,7 @@
         <ul class="app-task-list__items">
           <li class="app-task-list__item">
             <div class="app-task-list__task-name">
-              <%= link_to 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link' do %>
+              <%= link_to 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link', data: { tracked_event: 'User Exit Survey Link', type: 'link' } do %>
                 Take a quick survey and tell us about your experience <span class="app-step-nav__context">3 to 5 minutes</span>
               <% end %>
               <p class="govuk-body govuk-!-margin-bottom-0">This is a new service – your feedback will help us improve it</p>

--- a/app/views/pages/task_list.html.erb
+++ b/app/views/pages/task_list.html.erb
@@ -81,7 +81,7 @@
         <ul class="app-task-list__items">
           <li class="app-task-list__item">
             <div class="app-task-list__task-name">
-              <%= link_to 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link', data: { tracked_event: 'TaskList - User Exit Survey Link' } do %>
+              <%= link_to 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link', data: { tracked_event: 'TaskList - User Exit Survey Link' }, target: '_blank' do %>
                 Take a quick survey and tell us about your experience <span class="app-step-nav__context">3 to 5 minutes</span>
               <% end %>
               <p class="govuk-body govuk-!-margin-bottom-0">This is a new service – your feedback will help us improve it</p>

--- a/app/views/pages/task_list.html.erb
+++ b/app/views/pages/task_list.html.erb
@@ -81,7 +81,7 @@
         <ul class="app-task-list__items">
           <li class="app-task-list__item">
             <div class="app-task-list__task-name">
-              <%= link_to 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link', data: { tracked_event: 'User Exit Survey Link', type: 'link' } do %>
+              <%= link_to 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link', data: { tracked_event: 'TaskList - User Exit Survey Link' } do %>
                 Take a quick survey and tell us about your experience <span class="app-step-nav__context">3 to 5 minutes</span>
               <% end %>
               <p class="govuk-body govuk-!-margin-bottom-0">This is a new service – your feedback will help us improve it</p>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,9 +1,11 @@
 import '../styles/application.scss';
 import SearchForm from './search-form';
+import TrackEvents from './track-events';
 import Rails from 'rails-ujs';
 import { initAll } from 'govuk-frontend';
 
 
 SearchForm.start();
+TrackEvents.start();
 Rails.start();
 initAll();

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -4,8 +4,7 @@ import TrackEvents from './track-events';
 import Rails from 'rails-ujs';
 import { initAll } from 'govuk-frontend';
 
-
-SearchForm.start();
 TrackEvents.start();
+SearchForm.start();
 Rails.start();
 initAll();

--- a/app/webpacker/packs/search-form.js
+++ b/app/webpacker/packs/search-form.js
@@ -18,4 +18,4 @@ function SearchForm () {
   }
 }
 
-module.exports = new SearchForm();
+export default new SearchForm();

--- a/app/webpacker/packs/track-events.js
+++ b/app/webpacker/packs/track-events.js
@@ -1,6 +1,6 @@
 function TrackEvents () {
   this.start = function () {
-    if (appInsights) {
+    if (typeof(appInsights) === 'object') {
       document.querySelectorAll('[data-tracked-event]').forEach(function (element) {
         $this = element;
 

--- a/app/webpacker/packs/track-events.js
+++ b/app/webpacker/packs/track-events.js
@@ -1,19 +1,25 @@
 function TrackEvents () {
   this.start = function () {
-    if (typeof(appInsights) === 'object') {
+    if (typeof(appInsights) !== 'undefined') {
       document.querySelectorAll('[data-tracked-event]').forEach(function (element) {
-        if (element.dataset.type === 'link') {
-          element.onclick = function sendEvent() {
-            if (element.dataset.trackedEvent) {
-              setTimeout(function () {
-                appInsights.trackEvent(element.dataset.trackedEvent);
-              }, 0);
-            }
-          };
-        }
+        trackComponentOnClick(element);
       });
     }
   };
+
+  function sendEvent() {
+    var eventLabel = this.dataset.trackedEvent;
+
+    setTimeout(function () {
+      appInsights.trackEvent(eventLabel);
+    }, 0);
+  };
+
+  function trackComponentOnClick(element) {
+    if (element.dataset.trackedEvent) {
+      element.addEventListener('click', sendEvent, false);
+    }
+  }
 }
 
 export default new TrackEvents();

--- a/app/webpacker/packs/track-events.js
+++ b/app/webpacker/packs/track-events.js
@@ -1,0 +1,19 @@
+function TrackEvents () {
+  this.start = function () {
+    if (appInsights) {
+      document.querySelectorAll('[data-tracked-event]').forEach(function (element) {
+        $this = element;
+
+        if ($this.dataset.type === 'link') {
+          $this.onclick = function sendEvent(e) {
+            if ($this.dataset.trackedEvent) {
+              appInsights.trackEvent($this.dataset.trackedEvent)
+            }
+          }
+        }
+      });
+    }
+  }
+}
+
+module.exports = new TrackEvents();

--- a/app/webpacker/packs/track-events.js
+++ b/app/webpacker/packs/track-events.js
@@ -2,18 +2,18 @@ function TrackEvents () {
   this.start = function () {
     if (typeof(appInsights) === 'object') {
       document.querySelectorAll('[data-tracked-event]').forEach(function (element) {
-        $this = element;
-
-        if ($this.dataset.type === 'link') {
-          $this.onclick = function sendEvent(e) {
-            if ($this.dataset.trackedEvent) {
-              appInsights.trackEvent($this.dataset.trackedEvent)
+        if (element.dataset.type === 'link') {
+          element.onclick = function sendEvent() {
+            if (element.dataset.trackedEvent) {
+              setTimeout(function () {
+                appInsights.trackEvent(element.dataset.trackedEvent);
+              }, 0);
             }
-          }
+          };
         }
       });
     }
-  }
+  };
 }
 
-module.exports = new TrackEvents();
+export default new TrackEvents();

--- a/spec/features/task_list_spec.rb
+++ b/spec/features/task_list_spec.rb
@@ -35,4 +35,30 @@ RSpec.feature 'Tasks List', type: :feature do
 
     expect(page).to have_text('Get advice and help in your search for a new role.')
   end
+
+  scenario 'Smart survey link is present on the top banner' do
+    visit(task_list_path)
+
+    link = find_link('feedback')
+
+    expect([link[:href], link[:target]]).to eq(
+      [
+        'https://www.smartsurvey.co.uk/s/get-help-to-retrain/',
+        '_blank'
+      ]
+    )
+  end
+
+  scenario 'Smart survey link is present under Help improve this service section' do
+    visit(task_list_path)
+
+    link = find_link('Take a quick survey and tell us about your experience ')
+
+    expect([link[:href], link[:target]]).to eq(
+      [
+        'https://www.smartsurvey.co.uk/s/get-help-to-retrain/',
+        '_blank'
+      ]
+    )
+  end
 end


### PR DESCRIPTION
### Context

Adding client-side tracking for when the user clicks both of the User Exit Survey links. 
Tracking done inside AppInsights

### Screenshots

![Screen Shot 2019-07-11 at 15 10 39](https://user-images.githubusercontent.com/1955084/61058576-7069bd80-a3ef-11e9-91ce-6333b62225be.png)

![Screen Shot 2019-07-12 at 08 54 51](https://user-images.githubusercontent.com/1955084/61111910-92f8e680-a482-11e9-9d4b-7a782ff6037f.png)


### Ticket

https://dfedigital.atlassian.net/browse/GET-211

