### PR TITLE
GET-101 Add Pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'canonical-rails'
 # Logging
 gem 'logglier', '~> 0.5'
 
+# Pagination
+gem 'kaminari', '~> 1.1', '>= 1.1.1'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,18 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
     json (2.2.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -348,6 +360,7 @@ DEPENDENCIES
   faker (~> 1.9)
   foreman
   govuk-lint
+  kaminari (~> 1.1, >= 1.1.1)
   listen (>= 3.0.5, < 3.2)
   logglier (~> 0.5)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/check_your_skills_controller.rb
+++ b/app/controllers/check_your_skills_controller.rb
@@ -1,6 +1,6 @@
 class CheckYourSkillsController < ApplicationController
   def results
-    @job_profiles = JobProfile.search(job_profile_params[:name])
+    @job_profiles = JobProfile.search(job_profile_params[:name]).page(params[:page])
   end
 
   private

--- a/app/controllers/explore_occupations_controller.rb
+++ b/app/controllers/explore_occupations_controller.rb
@@ -4,7 +4,8 @@ class ExploreOccupationsController < ApplicationController
   end
 
   def results
-    @job_profiles = JobProfile.search(job_profile_params[:name]).includes(:categories).map { |job_profile|
+    @search_results = JobProfile.search(job_profile_params[:name]).includes(:categories).page(params[:page])
+    @job_profiles = @search_results.map { |job_profile|
       JobProfileDecorator.new(job_profile)
     }
   end

--- a/app/views/check_your_skills/results.html.erb
+++ b/app/views/check_your_skills/results.html.erb
@@ -21,8 +21,9 @@
       <p class="govuk-inset-text govuk-!-margin-bottom-2"><%= t('.body') %></p>
       <%= render "results_list", job_profiles: @job_profiles %>
     <% end %>
+    <div class="govuk-grid-column-full govuk-!-padding-top-6 govuk-!-margin-bottom-4 govuk-!-margin-top-6 pagination__section">
+      <%= paginate @job_profiles %>
+    </div>
   </div>
   <%= render "shared/contact_us" %>
 </div>
-
-<%= paginate @job_profiles %>

--- a/app/views/check_your_skills/results.html.erb
+++ b/app/views/check_your_skills/results.html.erb
@@ -17,10 +17,12 @@
     <% if @job_profiles.blank? %>
       <p class="govuk-body-m"><%= render '/shared/search/no_results' %></p>
     <% else %>
-      <p class="govuk-body-m" ><%= t('.results', count: @job_profiles.size) %></p>
+      <p class="govuk-body-m" ><%= t('.results', count: @job_profiles.total_count) %></p>
       <p class="govuk-inset-text govuk-!-margin-bottom-2"><%= t('.body') %></p>
       <%= render "results_list", job_profiles: @job_profiles %>
     <% end %>
   </div>
   <%= render "shared/contact_us" %>
 </div>
+
+<%= paginate @job_profiles %>

--- a/app/views/explore_occupations/results.html.erb
+++ b/app/views/explore_occupations/results.html.erb
@@ -37,8 +37,9 @@
         <% end %>
       </ul>
     <% end %>
+    <div class="govuk-grid-column-full govuk-!-padding-top-6 govuk-!-margin-bottom-4 govuk-!-margin-top-6 pagination__section">
+      <%= paginate @search_results %>
+    </div>
   </div>
   <%= render "shared/contact_us" %>
 </div>
-
-<%= paginate @search_results %>

--- a/app/views/explore_occupations/results.html.erb
+++ b/app/views/explore_occupations/results.html.erb
@@ -17,7 +17,7 @@
     <% if @job_profiles.blank? %>
       <p class="govuk-body-m"><%= render '/shared/search/no_results' %></p>
     <% else %>
-      <p class="govuk-body-m" ><%= t('.results', count: @job_profiles.size) %></p>
+      <p class="govuk-body-m" ><%= t('.results', count: @search_results.total_count) %></p>
       <p class="govuk-inset-text"><%= t('.body') %></p>
       <ul class="govuk-list">
         <% @job_profiles.each do |job_profile| %>
@@ -40,3 +40,5 @@
   </div>
   <%= render "shared/contact_us" %>
 </div>
+
+<%= paginate @search_results %>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,1 @@
+<li class="pagination__item pagination__item--dots"><%= t('pagination.truncate').html_safe %></li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="pagination__item  pagination__item--next">
+  <%= link_to_unless current_page.last?, t('pagination.next').html_safe, url, rel: 'next', remote: remote, class: 'pagination__link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,3 @@
+<li class="pagination__item <%= 'pagination__item--active' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, remote: remote, rel: page.rel, class: 'pagination__link'%>
+</li>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do -%>
+  <nav class="pagination" role="navigation" aria-label="Pagination">
+    <ul class="pagination__list">
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| -%>
+        <% if page.display_tag? -%>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end -%>
+      <% end -%>
+      <% unless current_page.out_of_range? %>
+        <%= next_page_tag unless current_page.last? %>
+      <% end %>
+    </ul>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="pagination__item  pagination__item--prev">
+  <%= link_to_unless current_page.first?, t('pagination.previous').html_safe, url, rel: 'prev', remote: remote, class: 'pagination__link' %>
+</li>

--- a/app/webpacker/images/icon-pagination.svg
+++ b/app/webpacker/images/icon-pagination.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+   viewBox="0 0 22 36" style="enable-background:new 0 0 22 36;" xml:space="preserve">
+  <style type="text/css">
+    .st0{fill-rule:evenodd;clip-rule:evenodd;}
+  </style>
+  <path class="st0" d="M8.9,18L0,9l8.9-9L11,2.1L4.2,9l6.8,6.9L8.9,18z"/>
+  <path class="st0" d="M11,33.9l6.8-6.9L11,20.1l2.1-2.1l8.9,9l-8.9,9L11,33.9z"/>
+</svg>

--- a/app/webpacker/styles/_pagination.scss
+++ b/app/webpacker/styles/_pagination.scss
@@ -1,0 +1,107 @@
+.pagination {
+  padding-right: govuk-spacing(3);
+  text-align: center;
+
+  @include govuk-media-query($from: desktop) {
+    margin-left: - govuk-spacing(1);
+    margin-right: - govuk-spacing(1);
+    font-size: 0;
+
+    &:after {
+      content: '';
+      display: inline-block;
+      width: 100%;
+    }
+  }
+}
+
+.pagination__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  @include govuk-media-query($from: desktop) {
+    display: inline-block;
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+}
+
+.pagination__item {
+  @include govuk-font(19);
+  display: inline-block;
+}
+
+.pagination__item--active,
+.pagination__item--dots {
+  font-weight: bold;
+  height: 25px;
+  padding: govuk-spacing(1) govuk-spacing(2);
+  text-align: center;
+}
+
+.pagination__item--dots {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.pagination__item--prev .pagination__link,
+.pagination__item--next .pagination__link {
+  &:before,
+  &:after {
+    background-image: url("../images/icon-pagination.svg");
+    background-repeat: no-repeat;
+    background-size: 22px 36px;
+    background-position: 0 0;
+    display: inline-block;
+    height: 18px;
+    vertical-align: middle;
+    position: relative;
+    top: -1px;
+    width: 11px;
+  }
+}
+
+.pagination__item--prev .pagination__link {
+  &:before {
+    background-position: 0 0;
+    content: "";
+    margin-right: govuk-spacing(2);
+  }
+}
+
+.pagination__item--next .pagination__link {
+  &:after {
+    background-position: -11px -18px;
+    content: "";
+    margin-left: govuk-spacing(2);
+  }
+}
+
+.pagination__link {
+  display: block;
+  padding: govuk-spacing(1);
+  text-align: center;
+  text-decoration: none;
+  min-width: 25px;
+
+  &:link,
+  &:visited {
+    color: govuk-colour("blue");
+  }
+
+  &:hover {
+    color: govuk-colour("light-blue");
+   }
+
+  &:focus {
+    color: govuk-colour("black");
+  }
+}
+
+.pagination__section {
+  border-top: 1px solid $govuk-border-colour;
+  margin-top: 0 !important;
+  padding-top: govuk-spacing(2);
+  @include govuk-clearfix;
+}

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -2,3 +2,4 @@
 @import "job-profile";
 @import "contact-us";
 @import "task-list";
+@import "pagination";

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,11 @@
+Kaminari.configure do |config|
+  config.default_per_page = 10
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,11 +1,5 @@
 Kaminari.configure do |config|
   config.default_per_page = 10
-  # config.max_per_page = nil
-  # config.window = 4
-  # config.outer_window = 0
-  # config.left = 0
-  # config.right = 0
-  # config.page_method_name = :page
-  # config.param_name = :page
-  # config.params_on_first_page = false
+  config.window = 1
+  config.outer_window = 1
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,3 +73,7 @@ en-GB:
   what_you_can_do_next:
     title: Find out what you can do next
     body: Get more support to help you on your new career path
+  pagination:
+    previous: Previous
+    next: Next
+    truncate: ...

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -34,4 +34,23 @@ RSpec.feature 'Check your skills', type: :feature do
 
     expect(page).to have_text('0 results')
   end
+
+  scenario 'paginates results of search' do
+    create_list(:job_profile, 12, name: 'Hacker')
+    visit(check_your_skills_path)
+    fill_in('name', with: 'Hacker')
+    find('.search-button').click
+
+    expect(page).to have_selector('ul.govuk-list li', count: 10)
+  end
+
+  scenario 'allows user to paginate through results' do
+    create_list(:job_profile, 12, name: 'Hacker')
+    visit(check_your_skills_path)
+    fill_in('name', with: 'Hacker')
+    find('.search-button').click
+    click_on('Next')
+
+    expect(page).to have_selector('ul.govuk-list li', count: 2)
+  end
 end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-101

* Use Kaminari gem to paginate results pages for both check your skills and explore occupations search
* Add Kaminari views and edit styles according to HMRC pagination:
http://hmcts-design-system.herokuapp.com/components/pagination
This has been reviewed by Steve and approved to be used. So disregard ticket stylings

This is deployed to for review: 
https://s108d02-dev-as.azurewebsites.net/check_your_skills/results?utf8=%E2%9C%93&name=e
https://s108d02-dev-as.azurewebsites.net/explore_occupations/results?utf8=%E2%9C%93&name=ex