### PR TITLE
Change query params from name to search across all forms/breadcrumbs

### DIFF
--- a/app/controllers/check_your_skills_controller.rb
+++ b/app/controllers/check_your_skills_controller.rb
@@ -1,11 +1,11 @@
 class CheckYourSkillsController < ApplicationController
   def results
-    @job_profiles = JobProfile.search(job_profile_params[:name]).page(params[:page])
+    @job_profiles = JobProfile.search(job_profile_params[:search]).page(params[:page])
   end
 
   private
 
   def job_profile_params
-    params.permit(:name)
+    params.permit(:search)
   end
 end

--- a/app/controllers/explore_occupations_controller.rb
+++ b/app/controllers/explore_occupations_controller.rb
@@ -4,7 +4,7 @@ class ExploreOccupationsController < ApplicationController
   end
 
   def results
-    @search_results = JobProfile.search(job_profile_params[:name]).includes(:categories).page(params[:page])
+    @search_results = JobProfile.search(job_profile_params[:search]).includes(:categories).page(params[:page])
     @job_profiles = @search_results.map { |job_profile|
       JobProfileDecorator.new(job_profile)
     }
@@ -13,6 +13,6 @@ class ExploreOccupationsController < ApplicationController
   private
 
   def job_profile_params
-    params.permit(:name)
+    params.permit(:search)
   end
 end

--- a/app/helpers/job_profiles_helper.rb
+++ b/app/helpers/job_profiles_helper.rb
@@ -4,7 +4,7 @@ module JobProfilesHelper
       [t('breadcrumb.job_category'), category_path(params[:category])]
     else
       [t('breadcrumb.search_results'), results_explore_occupations_path(
-        name: params[:search]
+        search: params[:search]
       )]
     end
   end

--- a/app/views/check_your_skills/_results_list.html.erb
+++ b/app/views/check_your_skills/_results_list.html.erb
@@ -2,7 +2,7 @@
   <% job_profiles.each do |job_profile| %>
     <li class="govuk-!-padding-bottom-3 govuk-!-padding-top-4">
       <h3 class="govuk-!-margin-0">
-        <%= link_to job_profile.name, job_profile_skills_path(job_profile.slug, search: params[:name]), class: 'govuk-link no-text-decoration' %>
+        <%= link_to job_profile.name, job_profile_skills_path(job_profile.slug, search: params[:search]), class: 'govuk-link no-text-decoration' %>
       </h3>
       <% if job_profile.alternative_titles.present? %>
         <p class="govuk-body-s govuk-!-margin-bottom-2 muted-text"><%= job_profile.alternative_titles %></p>

--- a/app/views/explore_occupations/results.html.erb
+++ b/app/views/explore_occupations/results.html.erb
@@ -23,7 +23,7 @@
         <% @job_profiles.each do |job_profile| %>
           <li class="govuk-!-padding-bottom-1">
             <h3 class="govuk-!-margin-bottom-0">
-               <%= link_to job_profile.name, job_profile_path(job_profile.slug, search: params[:name]), class: 'govuk-link no-text-decoration' %>
+               <%= link_to job_profile.name, job_profile_path(job_profile.slug, search: params[:search]), class: 'govuk-link no-text-decoration' %>
             </h3>
             <% if job_profile.alternative_titles.present? %>
               <p class="govuk-body-s govuk-!-margin-bottom-2 muted-text"><%= job_profile.alternative_titles %></p>

--- a/app/views/shared/search/_form.html.erb
+++ b/app/views/shared/search/_form.html.erb
@@ -3,7 +3,7 @@
   <p class="govuk-body-l"><%= t('body', scope: scope) %></p>
   <%= form_tag search_path, method: 'get', id: 'job-profile-search' do %>
     <div class="govuk-form-group govuk-!-margin-bottom-0">
-      <%= text_field(nil, :name, class: 'search-input govuk-input govuk-!-width-one-half', placeholder: t('placeholder', scope: scope), required: true) %>
+      <%= text_field(nil, :search, class: 'search-input govuk-input govuk-!-width-one-half', placeholder: t('placeholder', scope: scope), required: true) %>
       <%= button_tag('', class: 'search-button', name: nil) %>
     </div>
   <% end %>

--- a/app/views/shared/search/_results_form.html.erb
+++ b/app/views/shared/search/_results_form.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-column-full govuk-!-padding-0">
   <%= form_tag search_path, method: 'get', id: 'job-profile-search' do %>
     <div class="govuk-form-group">
-      <%= text_field(nil, :name, value: params[:name], class: 'search-input govuk-input govuk-!-width-one-half', placeholder: t('placeholder', scope: scope), required: true) %>
+      <%= text_field(nil, :search, value: params[:search], class: 'search-input govuk-input govuk-!-width-one-half', placeholder: t('placeholder', scope: scope), required: true) %>
       <%= button_tag('', class: 'search-button-results', name: nil) %>
     </div>
   <% end %>

--- a/app/views/skills/index.html.erb
+++ b/app/views/skills/index.html.erb
@@ -5,7 +5,7 @@
       [
         [t('breadcrumb.task_list_home'), task_list_path],
         [t('breadcrumb.check_your_skills'), check_your_skills_path],
-        [t('breadcrumb.search_results'), results_check_your_skills_path(name: params[:search])]
+        [t('breadcrumb.search_results'), results_check_your_skills_path(search: params[:search])]
       ]
     )
   end

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Check your skills', type: :feature do
 
   scenario 'User checks their current skills' do
     visit(check_your_skills_path)
-    fill_in('name', with: 'Bodyguard')
+    fill_in('search', with: 'Bodyguard')
     find('.search-button').click
     click_on('Bodyguard')
 
@@ -29,7 +29,7 @@ RSpec.feature 'Check your skills', type: :feature do
 
   scenario 'User cannot find occupation through search' do
     visit(check_your_skills_path)
-    fill_in('name', with: 'Embalmer')
+    fill_in('search', with: 'Embalmer')
     find('.search-button').click
 
     expect(page).to have_text('0 results')
@@ -38,7 +38,7 @@ RSpec.feature 'Check your skills', type: :feature do
   scenario 'paginates results of search' do
     create_list(:job_profile, 12, name: 'Hacker')
     visit(check_your_skills_path)
-    fill_in('name', with: 'Hacker')
+    fill_in('search', with: 'Hacker')
     find('.search-button').click
 
     expect(page).to have_selector('ul.govuk-list li', count: 10)
@@ -47,7 +47,7 @@ RSpec.feature 'Check your skills', type: :feature do
   scenario 'allows user to paginate through results' do
     create_list(:job_profile, 12, name: 'Hacker')
     visit(check_your_skills_path)
-    fill_in('name', with: 'Hacker')
+    fill_in('search', with: 'Hacker')
     find('.search-button').click
     click_on('Next')
 

--- a/spec/features/explore_occupations_spec.rb
+++ b/spec/features/explore_occupations_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Explore Occupations', type: :feature do
 
   scenario 'User explores their occupations through search' do
     visit(explore_occupations_path)
-    fill_in('name', with: 'Zombie Killer')
+    fill_in('search', with: 'Zombie Killer')
     find('.search-button').click
     click_on('Zombie Killer')
 
@@ -34,7 +34,7 @@ RSpec.feature 'Explore Occupations', type: :feature do
 
   scenario 'User cannot find occupation through search' do
     visit(explore_occupations_path)
-    fill_in('name', with: 'Embalmer')
+    fill_in('search', with: 'Embalmer')
     find('.search-button').click
 
     expect(page).to have_text('0 results')
@@ -45,5 +45,24 @@ RSpec.feature 'Explore Occupations', type: :feature do
     click_on('Find a training course')
 
     expect(page).to have_text('Find and apply to a training course near you')
+  end
+
+  scenario 'paginates results of search' do
+    create_list(:job_profile, 12, name: 'Hacker')
+    visit(explore_occupations_path)
+    fill_in('search', with: 'Hacker')
+    find('.search-button').click
+
+    expect(page).to have_selector('ul.govuk-list li', count: 10)
+  end
+
+  scenario 'allows user to paginate through results' do
+    create_list(:job_profile, 12, name: 'Hacker')
+    visit(explore_occupations_path)
+    fill_in('search', with: 'Hacker')
+    find('.search-button').click
+    click_on('Next')
+
+    expect(page).to have_selector('ul.govuk-list li', count: 2)
   end
 end

--- a/spec/helpers/job_profiles_helper_spec.rb
+++ b/spec/helpers/job_profiles_helper_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe JobProfilesHelper do
     it 'returns explore occupations results breadcrumbs if referer path is a defined result' do
       params = { search: 'Developer' }
       expect(helper.job_profile_breadcrumbs_for(params)).to eq(
-        [t('breadcrumb.search_results'), results_explore_occupations_path(name: 'Developer')]
+        [t('breadcrumb.search_results'), results_explore_occupations_path(search: 'Developer')]
       )
     end
 


### PR DESCRIPTION
We should use the same query string across all searches and
breadcrumbs. Switch name to search in form input,
breadcrumbs and all tests.

Also add tests for pagination for explore occupations which were
missed last time

deployed to https://s108d01-dev-as.azurewebsites.net/ for testing