### PR TITLE
Add Javascript RSpec Feature Support and missing tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,12 @@ resources:
       POSTGRES_DB: 'get-help-to-retrain'
       POSTGRES_USER: 'test'
       POSTGRES_PASSWORD: 'test'
+  - container: 'selenium'
+    image: 'selenium/standalone-chrome:3'
+    ports:
+      - 4444:4444/tcp
+    volumes:
+      - /dev/shm:/dev/shm
 
 stages:
 - stage: Build
@@ -33,13 +39,18 @@ stages:
 
     services:
       postgres: postgres
+      selenium: selenium
 
     steps:
       - script: |
           git_sha=$(git rev-parse --short HEAD)
           echo "##vso[build.updatebuildnumber]$git_sha"
-          echo "##vso[task.setvariable variable=ImageTag;]$git_sha"
         displayName: 'Set Image Tags'
+
+      - script: |
+          gateway_ip=$(docker network inspect bridge --format='{{range .IPAM.Config}}{{.Gateway}}{{end}}')
+          echo "##vso[task.setvariable variable=SeleniumRemoteAddress;]$gateway_ip"
+        displayName: 'Set Task Variables'
 
       - task: Docker@1
         displayName: Docker Hub login
@@ -103,7 +114,7 @@ stages:
           volumes: $(Build.SourcesDirectory):/build
           containerCommand: bundle exec rspec --format RspecJunitFormatter --out /build/TEST-rspec.xml
           runInBackground: false
-          arguments: --net host -e DATABASE_URL=$(postgresUrl) -e RAILS_ENV=test -e RACK_ENV=test -e NODE_ENV=test
+          arguments: --net host -e SELENIUM_REMOTE_ADDRESS=$(SeleniumRemoteAddress) -e DATABASE_URL=$(postgresUrl) -e RAILS_ENV=test -e RACK_ENV=test -e NODE_ENV=test
 
       - task: PublishTestResults@2
         condition: succeededOrFailed()

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -54,6 +54,18 @@ RSpec.feature 'Check your skills', type: :feature do
     expect(page).to have_selector('ul.govuk-list li', count: 2)
   end
 
+  scenario 'search form required field available when no js running' do
+    visit(check_your_skills_path)
+
+    expect(page).to have_selector('#search[required]')
+  end
+
+  scenario 'search form required field disabled by default', js: true do
+    visit(check_your_skills_path)
+
+    expect(page).not_to have_selector('#search[required]')
+  end
+
   scenario 'cannot send search form with no input', js: true do
     visit(check_your_skills_path)
     fill_in('search', with: '')

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -53,4 +53,21 @@ RSpec.feature 'Check your skills', type: :feature do
 
     expect(page).to have_selector('ul.govuk-list li', count: 2)
   end
+
+  scenario 'cannot send search form with no input', js: true do
+    visit(check_your_skills_path)
+    fill_in('search', with: '')
+    find('.search-button').click
+
+    expect(page).to have_current_path(check_your_skills_path)
+  end
+
+  scenario 'cannot send results search form with no input', js: true do
+    create(:job_profile, name: 'Hacker')
+    visit(results_check_your_skills_path(search: 'Hacker'))
+    fill_in('search', with: '')
+    find('.search-button-results').click
+
+    expect(page).to have_text('1 results found')
+  end
 end

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -60,13 +60,13 @@ RSpec.feature 'Check your skills', type: :feature do
     expect(page).to have_selector('#search[required]')
   end
 
-  scenario 'search form required field disabled by default', js: true do
+  scenario 'search form required field disabled by default', :js do
     visit(check_your_skills_path)
 
     expect(page).not_to have_selector('#search[required]')
   end
 
-  scenario 'cannot send search form with no input', js: true do
+  scenario 'cannot send search form with no input', :js do
     visit(check_your_skills_path)
     fill_in('search', with: '')
     find('.search-button').click
@@ -74,7 +74,7 @@ RSpec.feature 'Check your skills', type: :feature do
     expect(page).to have_current_path(check_your_skills_path)
   end
 
-  scenario 'cannot send results search form with no input', js: true do
+  scenario 'cannot send results search form with no input', :js do
     create(:job_profile, name: 'Hacker')
     visit(results_check_your_skills_path(search: 'Hacker'))
     fill_in('search', with: '')

--- a/spec/features/explore_occupations_spec.rb
+++ b/spec/features/explore_occupations_spec.rb
@@ -72,13 +72,13 @@ RSpec.feature 'Explore Occupations', type: :feature do
     expect(page).to have_selector('#search[required]')
   end
 
-  scenario 'search form required field disabled by default', js: true do
+  scenario 'search form required field disabled by default', :js do
     visit(explore_occupations_path)
 
     expect(page).not_to have_selector('#search[required]')
   end
 
-  scenario 'cannot send search form with no input', js: true do
+  scenario 'cannot send search form with no input', :js do
     visit(explore_occupations_path)
     fill_in('search', with: '')
     find('.search-button').click
@@ -86,7 +86,7 @@ RSpec.feature 'Explore Occupations', type: :feature do
     expect(page).to have_current_path(explore_occupations_path)
   end
 
-  scenario 'cannot send results search form with no input', js: true do
+  scenario 'cannot send results search form with no input', :js do
     create(:job_profile, name: 'Hacker')
     visit(results_explore_occupations_path(search: 'Hacker'))
     fill_in('search', with: '')

--- a/spec/features/explore_occupations_spec.rb
+++ b/spec/features/explore_occupations_spec.rb
@@ -65,4 +65,21 @@ RSpec.feature 'Explore Occupations', type: :feature do
 
     expect(page).to have_selector('ul.govuk-list li', count: 2)
   end
+
+  scenario 'cannot send search form with no input', js: true do
+    visit(explore_occupations_path)
+    fill_in('search', with: '')
+    find('.search-button').click
+
+    expect(page).to have_current_path(explore_occupations_path)
+  end
+
+  scenario 'cannot send results search form with no input', js: true do
+    create(:job_profile, name: 'Hacker')
+    visit(results_explore_occupations_path(search: 'Hacker'))
+    fill_in('search', with: '')
+    find('.search-button-results').click
+
+    expect(page).to have_text('1 results found')
+  end
 end

--- a/spec/features/explore_occupations_spec.rb
+++ b/spec/features/explore_occupations_spec.rb
@@ -66,6 +66,18 @@ RSpec.feature 'Explore Occupations', type: :feature do
     expect(page).to have_selector('ul.govuk-list li', count: 2)
   end
 
+  scenario 'search form required field available when no js running' do
+    visit(explore_occupations_path)
+
+    expect(page).to have_selector('#search[required]')
+  end
+
+  scenario 'search form required field disabled by default', js: true do
+    visit(explore_occupations_path)
+
+    expect(page).not_to have_selector('#search[required]')
+  end
+
   scenario 'cannot send search form with no input', js: true do
     visit(explore_occupations_path)
     fill_in('search', with: '')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'support/capybara'
 require 'simplecov'
 require 'vcr'
 SimpleCov.start

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,25 @@
+RSpec.configure do
+  if ENV['SELENIUM_REMOTE_ADDRESS']
+    Capybara.register_driver :headless_chrome do |app|
+      options = Selenium::WebDriver::Chrome::Options.new(
+        args: %w[headless disable-gpu window-size=1280,2000 no-sandbox]
+      )
+      capabilities = Selenium::WebDriver::Remote::Capabilities.chrome
+
+      Capybara::Selenium::Driver.new(
+        app,
+        browser: :remote,
+        url: 'http://localhost:4444/wd/hub',
+        desired_capabilities: capabilities,
+        options: options
+      )
+    end
+
+    Capybara.app_host = "http://#{ENV['SELENIUM_REMOTE_ADDRESS']}:3000"
+    Capybara.javascript_driver = :headless_chrome
+    Capybara.server_host = '0.0.0.0'
+    Capybara.server_port = '3000'
+  else
+    Capybara.javascript_driver = :selenium_chrome_headless
+  end
+end


### PR DESCRIPTION
* Set default Capybara driver to selenium headless chrome
* Add container for selenium standalone chrome to run as a service in CI
* When running in CI, set Capybara chrome driver to read from remote selenium chrome url running in container
* Pass in docker bridge ip to allow selenium chrome container access to the running instance
* Add missing JS tests for check your skills and explore occupations

