### PR TITLE
GET-123 Add Geocoding to Courses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,12 @@ gem 'logglier', '~> 0.5'
 # Pagination
 gem 'kaminari', '~> 1.1', '>= 1.1.1'
 
+# Postcode geocoding and geospatial queries
+gem 'geocoder', '~> 1.5', '>= 1.5.1'
+
+# Postcode validation
+gem 'uk_postcode', '~> 2.1', '>= 2.1.4'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ GEM
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
+    geocoder (1.5.1)
     gherkin (5.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -367,6 +368,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    uk_postcode (2.1.4)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
@@ -417,6 +419,7 @@ DEPENDENCIES
   factory_bot_rails (~> 5.0)
   faker (~> 1.9)
   foreman
+  geocoder (~> 1.5, >= 1.5.1)
   govuk-lint
   kaminari (~> 1.1, >= 1.1.1)
   listen (>= 3.0.5, < 3.2)
@@ -436,6 +439,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   uglifier (>= 1.3.0)
+  uk_postcode (~> 2.1, >= 2.1.4)
   vcr (~> 5.0)
   web-console (>= 3.3.0)
   webdrivers (~> 4.0)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,6 +1,15 @@
 class Course < ApplicationRecord
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :postcode, presence: true, postcode: true
+  validates_presence_of :title, :url, :provider, :topic
 
-  validates_presence_of :title, :url, :provider, :topic, :postcode
+  geocoded_by :postcode
+  after_validation :format_postcode
+  after_validation :geocode, if: -> { postcode_changed? && !latitude_changed? && !latitude_changed? }
 
+  def format_postcode
+    return unless postcode
+
+    self.postcode = UKPostcode.parse(postcode).to_s
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,4 +1,7 @@
 class Course < ApplicationRecord
+  InvalidAddressError = Class.new(StandardError)
+  GeocoderAPIError = Class.new(StandardError)
+
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :postcode, presence: true, postcode: true
   validates_presence_of :title, :url, :provider, :topic
@@ -6,6 +9,23 @@ class Course < ApplicationRecord
   geocoded_by :postcode
   after_validation :format_postcode
   after_validation :geocode, if: -> { postcode_changed? && !latitude_changed? && !latitude_changed? }
+
+  def self.find_courses_near(address:, distance: 5)
+    return none unless address.present?
+
+    coordinates = Geocoder.coordinates(parse_postcode(address))
+    near(coordinates, distance, units: :mi, order: :distance)
+  rescue SocketError, Timeout::Error, Geocoder::Error => e
+    Rails.logger.error("Geocoder API error: #{e.message}")
+    raise GeocoderAPIError
+  end
+
+  def self.parse_postcode(address)
+    uk_postcode = UKPostcode.parse(address)
+    raise InvalidAddressError unless uk_postcode.full_valid?
+
+    uk_postcode.to_s
+  end
 
   def format_postcode
     return unless postcode

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,5 +1,5 @@
 class Course < ApplicationRecord
-  InvalidAddressError = Class.new(StandardError)
+  InvalidPostcodeError = Class.new(StandardError)
   GeocoderAPIError = Class.new(StandardError)
 
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
@@ -8,21 +8,24 @@ class Course < ApplicationRecord
 
   geocoded_by :postcode
   after_validation :format_postcode
-  after_validation :geocode, if: -> { postcode_changed? && !latitude_changed? && !latitude_changed? }
+  after_validation :geocode, if: -> { postcode_changed? && !latitude_changed? && !longitude_changed? }
 
-  def self.find_courses_near(address:, distance: 5)
-    return none unless address.present?
+  def self.find_courses_near(search_postcode:, topic: nil, distance: 5)
+    return none unless search_postcode.present?
 
-    coordinates = Geocoder.coordinates(parse_postcode(address))
-    near(coordinates, distance, units: :mi, order: :distance)
+    coordinates = Geocoder.coordinates(parse_postcode(search_postcode))
+
+    courses = near(coordinates, distance, units: :mi, order: :distance)
+    courses = courses.where(topic: topic) if topic.present?
+    courses
   rescue SocketError, Timeout::Error, Geocoder::Error => e
     Rails.logger.error("Geocoder API error: #{e.message}")
     raise GeocoderAPIError
   end
 
-  def self.parse_postcode(address)
-    uk_postcode = UKPostcode.parse(address)
-    raise InvalidAddressError unless uk_postcode.full_valid?
+  def self.parse_postcode(str)
+    uk_postcode = UKPostcode.parse(str)
+    raise InvalidPostcodeError unless uk_postcode.full_valid?
 
     uk_postcode.to_s
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,5 +1,6 @@
 class Course < ApplicationRecord
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
 
-  validates_presence_of :title, :url, :provider, :topic
+  validates_presence_of :title, :url, :provider, :topic, :postcode
+
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,7 +1,4 @@
 class Course < ApplicationRecord
-  InvalidPostcodeError = Class.new(StandardError)
-  GeocoderAPIError = Class.new(StandardError)
-
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :postcode, presence: true, postcode: true
   validates_presence_of :title, :url, :provider, :topic
@@ -10,24 +7,8 @@ class Course < ApplicationRecord
   after_validation :format_postcode
   after_validation :geocode, if: -> { postcode_changed? && !latitude_changed? && !longitude_changed? }
 
-  def self.find_courses_near(search_postcode:, topic: nil, distance: 5)
-    return none unless search_postcode.present?
-
-    coordinates = Geocoder.coordinates(parse_postcode(search_postcode))
-
-    courses = near(coordinates, distance, units: :mi, order: :distance)
-    courses = courses.where(topic: topic) if topic.present?
-    courses
-  rescue SocketError, Timeout::Error, Geocoder::Error => e
-    Rails.logger.error("Geocoder API error: #{e.message}")
-    raise GeocoderAPIError
-  end
-
-  def self.parse_postcode(str)
-    uk_postcode = UKPostcode.parse(str)
-    raise InvalidPostcodeError unless uk_postcode.full_valid?
-
-    uk_postcode.to_s
+  def self.find_courses_near(postcode:, topic: nil, distance: 5)
+    CourseGeospatialSearch.new(postcode: postcode, topic: topic, distance: distance).find_courses
   end
 
   def format_postcode

--- a/app/models/course_geospatial_search.rb
+++ b/app/models/course_geospatial_search.rb
@@ -1,0 +1,38 @@
+class CourseGeospatialSearch
+  InvalidPostcodeError = Class.new(StandardError)
+  GeocoderAPIError = Class.new(StandardError)
+
+  attr_reader :postcode, :topic, :distance
+
+  def initialize(postcode:, topic:, distance:)
+    @postcode = postcode
+    @topic = topic
+    @distance = distance
+  end
+
+  def find_courses
+    return Course.none unless postcode.present?
+
+    courses.near(coordinates, distance, units: :mi, order: :distance)
+  end
+
+  private
+
+  def uk_postcode
+    uk_postcode = UKPostcode.parse(postcode)
+    raise InvalidPostcodeError unless uk_postcode.full_valid?
+
+    uk_postcode.to_s
+  end
+
+  def coordinates
+    Geocoder.coordinates(uk_postcode)
+  rescue SocketError, Timeout::Error, Geocoder::Error => e
+    Rails.logger.error("Geocoder API error: #{e.message}")
+    raise GeocoderAPIError
+  end
+
+  def courses
+    topic.present? ? Course.where(topic: topic) : Course.all
+  end
+end

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -1,0 +1,8 @@
+class PostcodeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless value
+
+    uk_postcode = UKPostcode.parse(value)
+    record.errors[attribute] << 'Invalid UK postcode' unless uk_postcode.full_valid?
+  end
+end

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -4,5 +4,6 @@ Geocoder.configure(
   language: :en,
   use_https: true,
   units: :mi,
-  distances: :spherical
+  distances: :spherical,
+  always_raise: :all
 )

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,8 @@
+Geocoder.configure(
+  timeout: 5,
+  lookup: :postcodes_io,
+  language: :en,
+  use_https: true,
+  units: :mi,
+  distances: :spherical
+)

--- a/db/migrate/20190719081758_add_geocode_columns_to_courses.rb
+++ b/db/migrate/20190719081758_add_geocode_columns_to_courses.rb
@@ -1,0 +1,18 @@
+class AddGeocodeColumnsToCourses < ActiveRecord::Migration[5.2]
+  def up
+    change_column :courses, :postcode, :string, null: false
+    add_column :courses, :latitude, :float, default: 0.0, null: false
+    add_column :courses, :longitude, :float, default: 0.0, null: false
+
+    add_index :courses, :postcode
+    add_index :courses, [:longitude, :latitude]
+  end
+
+  def down
+    change_column :courses, :postcode, :string, null: true
+    remove_column :courses, :latitude
+    remove_column :courses, :longitude
+
+    remove_index :courses, name: 'index_courses_on_postcode'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_18_095913) do
+ActiveRecord::Schema.define(version: 2019_07_19_081758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,11 +32,15 @@ ActiveRecord::Schema.define(version: 2019_07_18_095913) do
     t.string "address_line_2"
     t.string "town"
     t.string "county"
-    t.string "postcode"
+    t.string "postcode", null: false
     t.string "email"
     t.string "topic", null: false
     t.string "phone_number"
     t.boolean "active", default: false
+    t.float "latitude", default: 0.0, null: false
+    t.float "longitude", default: 0.0, null: false
+    t.index ["longitude", "latitude"], name: "index_courses_on_longitude_and_latitude"
+    t.index ["postcode"], name: "index_courses_on_postcode"
     t.index ["topic"], name: "index_courses_on_topic"
   end
 

--- a/spec/models/course_geospatial_search_spec.rb
+++ b/spec/models/course_geospatial_search_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe CourseGeospatialSearch do
+  describe '#find_courses' do
+    it 'returns nothing if no postcode entered' do
+      search = described_class.new(postcode: nil, topic: nil, distance: 5)
+      expect(search.find_courses).to be_empty
+    end
+
+    it 'returns nothing if empty postcode entered' do
+      search = described_class.new(postcode: '', topic: nil, distance: 5)
+      expect(search.find_courses).to be_empty
+    end
+
+    it 'returns courses ordered by distance to postcode entered' do
+      Geocoder::Lookup::Test.add_stub(
+        'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+      )
+
+      course1 = create(:course, latitude: 0.1, longitude: 1.001)
+      course2 = create(:course, latitude: 0.1, longitude: 1.003)
+      course3 = create(:course, latitude: 0.1, longitude: 1.002)
+
+      search = described_class.new(postcode: 'NW6 8ET', distance: 2, topic: nil)
+
+      expect(search.find_courses).to eq(
+        [course1, course3, course2]
+      )
+    end
+
+    it 'scopes courses by topic if topic defined' do
+      Geocoder::Lookup::Test.add_stub(
+        'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+      )
+
+      create(:course, latitude: 0.1, longitude: 1, topic: 'maths')
+      course2 = create(:course, latitude: 0.1, longitude: 1, topic: 'english')
+      create(:course, latitude: 0.1, longitude: 1, topic: 'maths')
+      search = described_class.new(postcode: 'NW6 8ET', distance: 2, topic: 'english')
+
+      expect(search.find_courses).to contain_exactly(
+        course2
+      )
+    end
+
+    it 'limits courses to distance entered from postcode' do
+      Geocoder::Lookup::Test.add_stub(
+        'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+      )
+
+      course1 = create(:course, latitude: 0.1, longitude: 1.001)
+      create(:course, latitude: 0.1, longitude: 1.2)
+      create(:course, latitude: 0.1, longitude: 1.3)
+      search = described_class.new(postcode: 'NW6 8ET', distance: 1, topic: nil)
+
+      expect(search.find_courses).to eq(
+        [course1]
+      )
+    end
+
+    it 'returns nothing if postcode entered is too far' do
+      Geocoder::Lookup::Test.add_stub(
+        'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+      )
+
+      create(:course, latitude: 0.1, longitude: 2)
+      create(:course, latitude: 0.1, longitude: 3)
+      create(:course, latitude: 0.1, longitude: 4)
+      search = described_class.new(postcode: 'NW6 8ET', distance: 10, topic: nil)
+
+      expect(search.find_courses).to be_empty
+    end
+
+    it 'raises error if postcode entered if invalid' do
+      search = described_class.new(postcode: 'NW6 8E', distance: nil, topic: nil)
+
+      expect { search.find_courses }.to raise_error(described_class::InvalidPostcodeError)
+    end
+
+    it 'raises error if API for geocoding not available' do
+      allow(Geocoder).to receive(:coordinates).and_raise(Geocoder::ServiceUnavailable)
+      search = described_class.new(postcode: 'NW6 8ET', distance: nil, topic: nil)
+
+      expect { search.find_courses }.to raise_error(described_class::GeocoderAPIError)
+    end
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2,14 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Course, type: :model do
   describe '.find_courses_near' do
-    it 'returns nothing if no postcode entered' do
-      expect(described_class.find_courses_near(search_postcode: nil)).to be_empty
-    end
-
-    it 'returns nothing if empty postcode entered' do
-      expect(described_class.find_courses_near(search_postcode: '')).to be_empty
-    end
-
     it 'returns courses ordered by distance to postcode entered' do
       Geocoder::Lookup::Test.add_stub(
         'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
@@ -19,12 +11,12 @@ RSpec.describe Course, type: :model do
       course2 = create(:course, latitude: 0.1, longitude: 1.003)
       course3 = create(:course, latitude: 0.1, longitude: 1.002)
 
-      expect(described_class.find_courses_near(search_postcode: 'NW6 8ET', distance: 2)).to eq(
+      expect(described_class.find_courses_near(postcode: 'NW6 8ET', distance: 2)).to eq(
         [course1, course3, course2]
       )
     end
 
-    it 'scopes courses by topic' do
+    it 'returns courses ordered by distance to postcode entered and scoped by topic' do
       Geocoder::Lookup::Test.add_stub(
         'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
       )
@@ -33,45 +25,9 @@ RSpec.describe Course, type: :model do
       course2 = create(:course, latitude: 0.1, longitude: 1, topic: 'english')
       create(:course, latitude: 0.1, longitude: 1, topic: 'maths')
 
-      expect(described_class.find_courses_near(search_postcode: 'NW6 8ET', distance: 2, topic: 'english')).to contain_exactly(
+      expect(described_class.find_courses_near(postcode: 'NW6 8ET', distance: 2, topic: 'english')).to contain_exactly(
         course2
       )
-    end
-
-    it 'limist courses to distance entered from postcode' do
-      Geocoder::Lookup::Test.add_stub(
-        'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
-      )
-
-      course1 = create(:course, latitude: 0.1, longitude: 1.001)
-      create(:course, latitude: 0.1, longitude: 1.2)
-      create(:course, latitude: 0.1, longitude: 1.3)
-
-      expect(described_class.find_courses_near(search_postcode: 'NW6 8ET', distance: 1)).to eq(
-        [course1]
-      )
-    end
-
-    it 'returns nothing if postcode entered is too far' do
-      Geocoder::Lookup::Test.add_stub(
-        'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
-      )
-
-      create(:course, latitude: 0.1, longitude: 2)
-      create(:course, latitude: 0.1, longitude: 3)
-      create(:course, latitude: 0.1, longitude: 4)
-
-      expect(described_class.find_courses_near(search_postcode: 'NW6 8ET', distance: 10)).to be_empty
-    end
-
-    it 'raises error if postcode entered if invalid' do
-      expect { described_class.find_courses_near(search_postcode: 'NW6 ET') }.to raise_error(described_class::InvalidPostcodeError)
-    end
-
-    it 'raises error if API for geocoding not available' do
-      allow(Geocoder).to receive(:coordinates).and_raise(Geocoder::ServiceUnavailable)
-
-      expect { described_class.find_courses_near(search_postcode: 'NW6 8ET') }.to raise_error(described_class::GeocoderAPIError)
     end
   end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,13 +1,101 @@
 require 'rails_helper'
 
 RSpec.describe Course, type: :model do
-  describe 'validations' do
-    describe '#email' do
-      let(:course) { build(:course, email: 'weirdemail@') }
+  describe '#format_postcode' do
+    it 'formats postcode on creation' do
+      course = create(:course, postcode: 'nw6  8et')
+      expect(course.postcode).to eq('NW6 8ET')
+    end
 
-      it 'is not valid' do
-        expect(course).not_to be_valid
-      end
+    it 'formats postcode on update' do
+      course = create(:course, postcode: 'NW6 9ET')
+      course.update_attributes(postcode: ' ne10PT ')
+      expect(course.postcode).to eq('NE1 0PT')
+    end
+  end
+
+  context 'with validations' do
+    it 'is not valid if email format is incorrect' do
+      course = build(:course, email: 'weirdemail@')
+      expect(course).not_to be_valid
+    end
+
+    it 'is not valid if postcode is incorrect' do
+      course = build(:course, postcode: 'NW9 9l')
+      expect(course).not_to be_valid
+    end
+
+    it 'is not valid if postcode is not full' do
+      course = build(:course, postcode: 'NW9')
+      expect(course).not_to be_valid
+    end
+
+    it 'is not valid if postcode is not present' do
+      course = build(:course, postcode: nil)
+      expect(course).not_to be_valid
+    end
+
+    it 'is not valid if postcode is empty' do
+      course = build(:course, postcode: '')
+      expect(course).not_to be_valid
+    end
+  end
+
+  context 'when geocoding' do
+    it 'adds latitude and longitude values when empty' do
+      course = create(:course, postcode: 'sw1p3bt')
+      expect(course.attributes).to include(
+        'latitude' => 40.7143528,
+        'longitude' => -74.0059731
+      )
+    end
+
+    it 'does not change lat/long values when they exist' do
+      course = create(:course, postcode: 'sw1p3bt', latitude: 51.498029, longitude: -0.130039)
+      expect(course.attributes).to include(
+        'latitude' => 51.498029,
+        'longitude' => -0.130039
+      )
+    end
+
+    it 'does not change lat/long values when course data is updated' do
+      course = create(:course, postcode: 'sw1p3bt', latitude: 51.498029, longitude: -0.130039)
+      course.update_attributes(title: 'New Course title')
+
+      expect(course.attributes).to include(
+        'latitude' => 51.498029,
+        'longitude' => -0.130039
+      )
+    end
+
+    it 'changes lat/long values when postcode is updated' do
+      course = create(:course, postcode: 'sw1p3bt', latitude: 51.498029, longitude: -0.130039)
+      course.update_attributes(postcode: 'sw1p3bs')
+
+      expect(course.attributes).to include(
+        'latitude' => 40.7143528,
+        'longitude' => -74.0059731
+      )
+    end
+
+    it 'does not set lat/long if postcode does not exist' do
+      Geocoder::Lookup::Test.add_stub(
+        'NW6 8ET',
+        [
+          {
+            'coordinates' => [nil, nil],
+            'address' => 'NW6 8ET',
+            'country' => 'United Kingdom',
+            'country_code' => 'UK'
+          }
+        ]
+      )
+
+      course = create(:course, postcode: 'nw68et')
+      expect(course.attributes).to include(
+        'latitude' => 0.0,
+        'longitude' => 0.0
+      )
     end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2,15 +2,15 @@ require 'rails_helper'
 
 RSpec.describe Course, type: :model do
   describe '.find_courses_near' do
-    it 'returns nothing if no address entered' do
-      expect(described_class.find_courses_near(address: nil)).to be_empty
+    it 'returns nothing if no postcode entered' do
+      expect(described_class.find_courses_near(search_postcode: nil)).to be_empty
     end
 
-    it 'returns nothing if empty address entered' do
-      expect(described_class.find_courses_near(address: '')).to be_empty
+    it 'returns nothing if empty postcode entered' do
+      expect(described_class.find_courses_near(search_postcode: '')).to be_empty
     end
 
-    it 'returns courses ordered by distance to address entered' do
+    it 'returns courses ordered by distance to postcode entered' do
       Geocoder::Lookup::Test.add_stub(
         'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
       )
@@ -19,12 +19,26 @@ RSpec.describe Course, type: :model do
       course2 = create(:course, latitude: 0.1, longitude: 1.003)
       course3 = create(:course, latitude: 0.1, longitude: 1.002)
 
-      expect(described_class.find_courses_near(address: 'NW6 8ET', distance: 2)).to eq(
+      expect(described_class.find_courses_near(search_postcode: 'NW6 8ET', distance: 2)).to eq(
         [course1, course3, course2]
       )
     end
 
-    it 'limist courses to distance entered from address' do
+    it 'scopes courses by topic' do
+      Geocoder::Lookup::Test.add_stub(
+        'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+      )
+
+      create(:course, latitude: 0.1, longitude: 1, topic: 'maths')
+      course2 = create(:course, latitude: 0.1, longitude: 1, topic: 'english')
+      create(:course, latitude: 0.1, longitude: 1, topic: 'maths')
+
+      expect(described_class.find_courses_near(search_postcode: 'NW6 8ET', distance: 2, topic: 'english')).to contain_exactly(
+        course2
+      )
+    end
+
+    it 'limist courses to distance entered from postcode' do
       Geocoder::Lookup::Test.add_stub(
         'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
       )
@@ -33,12 +47,12 @@ RSpec.describe Course, type: :model do
       create(:course, latitude: 0.1, longitude: 1.2)
       create(:course, latitude: 0.1, longitude: 1.3)
 
-      expect(described_class.find_courses_near(address: 'NW6 8ET', distance: 1)).to eq(
+      expect(described_class.find_courses_near(search_postcode: 'NW6 8ET', distance: 1)).to eq(
         [course1]
       )
     end
 
-    it 'returns nothing if address entered is too far' do
+    it 'returns nothing if postcode entered is too far' do
       Geocoder::Lookup::Test.add_stub(
         'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
       )
@@ -47,17 +61,17 @@ RSpec.describe Course, type: :model do
       create(:course, latitude: 0.1, longitude: 3)
       create(:course, latitude: 0.1, longitude: 4)
 
-      expect(described_class.find_courses_near(address: 'NW6 8ET', distance: 10)).to be_empty
+      expect(described_class.find_courses_near(search_postcode: 'NW6 8ET', distance: 10)).to be_empty
     end
 
-    it 'raises error if address entered if invalid' do
-      expect { described_class.find_courses_near(address: 'NW6 ET') }.to raise_error(described_class::InvalidAddressError)
+    it 'raises error if postcode entered if invalid' do
+      expect { described_class.find_courses_near(search_postcode: 'NW6 ET') }.to raise_error(described_class::InvalidPostcodeError)
     end
 
     it 'raises error if API for geocoding not available' do
       allow(Geocoder).to receive(:coordinates).and_raise(Geocoder::ServiceUnavailable)
 
-      expect { described_class.find_courses_near(address: 'NW6 8ET') }.to raise_error(described_class::GeocoderAPIError)
+      expect { described_class.find_courses_near(search_postcode: 'NW6 8ET') }.to raise_error(described_class::GeocoderAPIError)
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 require 'support/capybara'
+require 'support/geocoder'
 require 'simplecov'
 require 'vcr'
 SimpleCov.start

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,6 +20,7 @@ VCR.configure do |vcr|
   vcr.hook_into :webmock
   vcr.ignore_localhost = true
   vcr.configure_rspec_metadata!
+  vcr.allow_http_connections_when_no_cassette = true
 end
 
 RSpec.configure do |config|

--- a/spec/support/geocoder.rb
+++ b/spec/support/geocoder.rb
@@ -1,0 +1,12 @@
+Geocoder.configure(lookup: :test, ip_lookup: :test)
+
+Geocoder::Lookup::Test.set_default_stub(
+  [
+    {
+      'coordinates' => [40.7143528, -74.0059731],
+      'address' => 'sw1p3bt',
+      'country' => 'United Kingdom',
+      'country_code' => 'UK'
+    }
+  ]
+)


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-123

* Add latitude longitude columns to courses table to allow geocoding of postcodes of courses
* Validate postcode on course model against uk postcodes
* Format postcode on course model against uk postcodes to be in capital letter format, and a space in the middle
* Add callback to geocode the postcodes after validation on courses model. This means latitude and longitude values will be populated by the Geocoder gem
* Add method to return courses ordered by distance to an address
* Distance can be defined and defaults to 5 miles
* Validate address before geocoding and performing a geospatial
  query to get all courses within the distance defined
* Return custom errors for invalid address and Geocoder API errors  so we can create validations on the FE
* Allow Geocoder to return all errors rather than hide them behind nil values so we have the correct messaging on the FE