### PR TITLE
Ensure that active admin custom pages are not loaded outside dev mode

### DIFF
--- a/app/admin/categories.rb
+++ b/app/admin/categories.rb
@@ -1,15 +1,17 @@
-ActiveAdmin.register Category do
-  actions :index
+if defined?(ActiveAdmin)
+  ActiveAdmin.register Category do
+    actions :index
 
-  filter :slug
-  filter :name
-  filter :source_url
+    filter :slug
+    filter :name
+    filter :source_url
 
-  index do
-    column :id
-    column :slug
-    column :name
-    column :created_at
-    column :updated_at
+    index do
+      column :id
+      column :slug
+      column :name
+      column :created_at
+      column :updated_at
+    end
   end
 end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,24 +1,26 @@
-ActiveAdmin.register_page 'Dashboard' do
-  menu priority: 1, label: proc { I18n.t('active_admin.dashboard') }
+if defined?(ActiveAdmin)
+  ActiveAdmin.register_page 'Dashboard' do
+    menu priority: 1, label: proc { I18n.t('active_admin.dashboard') }
 
-  content title: proc { I18n.t('active_admin.dashboard') } do
-    columns do
-      column do
-        panel 'Job Profiles' do
-          h1 do
-            link_to JobProfile.count, admin_job_profiles_path
+    content title: proc { I18n.t('active_admin.dashboard') } do
+      columns do
+        column do
+          panel 'Job Profiles' do
+            h1 do
+              link_to JobProfile.count, admin_job_profiles_path
+            end
+          end
+          panel 'Categories' do
+            h1 do
+              link_to Category.count, admin_categories_path
+            end
           end
         end
-        panel 'Categories' do
-          h1 do
-            link_to Category.count, admin_categories_path
-          end
-        end
-      end
-      column do
-        panel 'Skills' do
-          h1 do
-            link_to Skill.count, admin_skills_path
+        column do
+          panel 'Skills' do
+            h1 do
+              link_to Skill.count, admin_skills_path
+            end
           end
         end
       end

--- a/app/admin/job_profiles.rb
+++ b/app/admin/job_profiles.rb
@@ -1,70 +1,72 @@
-# rubocop:disable Metrics/BlockLength
-ActiveAdmin.register JobProfile do
-  menu priority: 2
+if defined?(ActiveAdmin)
+  # rubocop:disable Metrics/BlockLength
+  ActiveAdmin.register JobProfile do
+    menu priority: 2
 
-  actions :all, except: %i[new destroy]
+    actions :all, except: %i[new destroy]
 
-  permit_params :recommended
+    permit_params :recommended
 
-  filter :categories
-  filter :skills
-  filter :related_job_profiles
-  filter :slug
-  filter :name
-  filter :source_url
-  filter :description
-  filter :recommended
-  filter :content
-  filter :salary_min
-  filter :salary_max
-  filter :alternative_titles
+    filter :categories
+    filter :skills
+    filter :related_job_profiles
+    filter :slug
+    filter :name
+    filter :source_url
+    filter :description
+    filter :recommended
+    filter :content
+    filter :salary_min
+    filter :salary_max
+    filter :alternative_titles
 
-  index do
-    column :id
-    column :slug
-    column :name
-    column :recommended
-    column :created_at
-    column :updated_at
-    column :salary_min
-    column :salary_max
-    column :alternative_titles
-    actions
-  end
+    index do
+      column :id
+      column :slug
+      column :name
+      column :recommended
+      column :created_at
+      column :updated_at
+      column :salary_min
+      column :salary_max
+      column :alternative_titles
+      actions
+    end
 
-  show do
-    attributes_table do
-      row :slug
-      row :name
-      row :source_url
-      row :description
-      row :recommended
-      row :content do |job_profile|
-        div class: 'content-preview' do
-          simple_format job_profile.content
+    show do
+      attributes_table do
+        row :slug
+        row :name
+        row :source_url
+        row :description
+        row :recommended
+        row :content do |job_profile|
+          div class: 'content-preview' do
+            simple_format job_profile.content
+          end
         end
+        row :created_at
+        row :updated_at
+        row :salary_min
+        row :salary_max
+        row :alternative_titles
       end
-      row :created_at
-      row :updated_at
-      row :salary_min
-      row :salary_max
-      row :alternative_titles
     end
-  end
 
-  form do |f|
-    f.semantic_errors
-    f.inputs do
-      f.input :slug, input_html: { disabled: true, readonly: true }
-      f.input :name, input_html: { disabled: true, readonly: true }
-      f.input :source_url, input_html: { disabled: true, readonly: true }
-      f.input :description, input_html: { disabled: true, readonly: true }
-      f.input :salary_min, input_html: { disabled: true, readonly: true }
-      f.input :salary_max, input_html: { disabled: true, readonly: true }
-      f.input :alternative_titles, input_html: { disabled: true, readonly: true }
-      f.input :recommended
+    form do |f|
+      f.semantic_errors
+      f.inputs do
+        f.input :slug, input_html: { disabled: true, readonly: true }
+        f.input :name, input_html: { disabled: true, readonly: true }
+        f.input :source_url, input_html: { disabled: true, readonly: true }
+        f.input :description, input_html: { disabled: true, readonly: true }
+        f.input :salary_min, input_html: { disabled: true, readonly: true }
+        f.input :salary_max, input_html: { disabled: true, readonly: true }
+        f.input :alternative_titles, input_html: { disabled: true, readonly: true }
+        f.input :recommended
+      end
+      f.actions
     end
-    f.actions
   end
+  # rubocop:enable Metrics/BlockLength
 end
-# rubocop:enable Metrics/BlockLength

--- a/app/admin/skills.rb
+++ b/app/admin/skills.rb
@@ -1,12 +1,14 @@
-ActiveAdmin.register Skill do
-  actions :index
+if defined?(ActiveAdmin)
+  ActiveAdmin.register Skill do
+    actions :index
 
-  filter :name
+    filter :name
 
-  index do
-    column :id
-    column :name
-    column :created_at
-    column :updated_at
+    index do
+      column :id
+      column :name
+      column :created_at
+      column :updated_at
+    end
   end
 end


### PR DESCRIPTION
### Context
These seem to be causing issues with bootsnap in production; that is eager loading all of the ruby code so tries to reference the admin pages, which in turn reference `ActiveAdmin` which is not installed in the production bundle. Added guards around each of these to ensure they are only parsed if the gem is installed.
