### PR TITLE
Get 233 enable skills admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,13 @@ If job profiles have been previously scraped and `content` is populated, it's po
 ```bash
   bundle exec rails data_import:refresh_job_profiles
 ```
+
+## Courses data
+
+Courses are currently persisted locally within the database. These are presently being collated for subsequent import into the service. In the meantime, sample data using fake attributes can be populated by running:
+
+```bash
+  bundle exec rails data_import:sample_courses
+```
+
+**Note** that this will erase any existing course data first

--- a/app/admin/courses.rb
+++ b/app/admin/courses.rb
@@ -1,0 +1,1 @@
+ActiveAdmin.register Course if defined?(ActiveAdmin)

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,4 +1,5 @@
 if defined?(ActiveAdmin)
+  # rubocop:disable Metrics/BlockLength
   ActiveAdmin.register_page 'Dashboard' do
     menu priority: 1, label: proc { I18n.t('active_admin.dashboard') }
 
@@ -22,8 +23,14 @@ if defined?(ActiveAdmin)
               link_to Skill.count, admin_skills_path
             end
           end
+          panel 'Courses' do
+            h1 do
+              link_to Course.count, admin_courses_path
+            end
+          end
         end
       end
     end
   end
+  # rubocop:enable Metrics/BlockLength
 end

--- a/app/admin/job_profiles.rb
+++ b/app/admin/job_profiles.rb
@@ -67,6 +67,25 @@ if defined?(ActiveAdmin)
       end
       f.actions
     end
+
+    controller do
+      def scoped_collection
+        super.includes :skills
+      end
+    end
+
+    csv do
+      column :id
+      column :slug
+      column :name
+      column :recommended
+      column :salary_min
+      column :salary_max
+      column :alternative_titles
+      column :skills do |job_profile|
+        job_profile.skills.map(&:name)
+      end
+    end
   end
   # rubocop:enable Metrics/BlockLength
 end

--- a/app/admin/skills.rb
+++ b/app/admin/skills.rb
@@ -6,9 +6,26 @@ if defined?(ActiveAdmin)
 
     index do
       column :id
+      column :enabled
       column :name
+      column :job_profiles
       column :created_at
       column :updated_at
+    end
+
+    controller do
+      def scoped_collection
+        super.includes :job_profiles
+      end
+    end
+
+    csv do
+      column :id
+      column :enabled
+      column :name
+      column :job_profiles do |skill|
+        skill.job_profiles.map(&:name)
+      end
     end
   end
 end

--- a/app/services/courses_service.rb
+++ b/app/services/courses_service.rb
@@ -7,13 +7,17 @@ class CoursesService
     answer = prompt 'This will delete all your currently stored courses! Are you sure you want to continue? [Yn]: '
 
     if answer.strip == 'Y'
-      Course.delete_all
-
-      create_fake_courses_for(:maths)
-      create_fake_courses_for(:english)
+      seed!
     else
       'Operation cancelled'
     end
+  end
+
+  def seed!
+    Course.delete_all
+
+    create_fake_courses_for(:maths)
+    create_fake_courses_for(:english)
   end
 
   private

--- a/db/migrate/20190724160424_add_enabled_to_skills.rb
+++ b/db/migrate/20190724160424_add_enabled_to_skills.rb
@@ -1,0 +1,6 @@
+class AddEnabledToSkills < ActiveRecord::Migration[5.2]
+  def change
+    add_column :skills, :enabled, :boolean, default: true, null: false
+    add_index :skills, :enabled
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_19_081758) do
+ActiveRecord::Schema.define(version: 2019_07_24_160424) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,6 +94,8 @@ ActiveRecord::Schema.define(version: 2019_07_19_081758) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "enabled", default: true, null: false
+    t.index ["enabled"], name: "index_skills_on_enabled"
     t.index ["name"], name: "index_skills_on_name"
   end
 

--- a/lib/tasks/data_import/sample_courses.rake
+++ b/lib/tasks/data_import/sample_courses.rake
@@ -1,0 +1,8 @@
+namespace :data_import do
+  # bin/rails data_import:sample_courses
+  desc 'Populate sample courses data'
+  task sample_courses: :environment do
+    print 'Populating sample courses data'
+    CoursesService.new.seed!
+  end
+end


### PR DESCRIPTION
### Context
Adds `enabled` attribute for skills, improves admin pages functionality and courses data setup.

### Changes proposed in this pull request
* New `enabled` attribute for skills will be used during the forthcoming spike to explore use of skills for matching job profiles. We know that not all of the skills will be used for this, so this adds the ability to disable some of those. This capability won't be used programatically yet, but adding the column allows the data to be setup in advance and exposed via the admin interface.
* Improved data export (CSV) for job profile and skills in admin pages. Now includes a list of job profiles for each skill, and skills for each job profile. Some additional tweaks to achieve that without N+1 query issues.
* Added a rake task and some docs around setting up sample course data
* Added courses to the admin pages

### Guidance to review
Mostly admin stuff, so best to pull locally and explore; the admin pages only work with `RAILS_ENV=development`.
