### PR TITLE
Add splitApiKey configs for dev and test environments

### DIFF
--- a/azure/config/dev2.parameters.json
+++ b/azure/config/dev2.parameters.json
@@ -32,6 +32,13 @@
             "secretName": "dev-secretKeyBase"
           }
         },
+        "splitApiKey": {
+          "reference": {
+            "keyVault": {
+              "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"},
+            "secretName": "dev-splitApiKey"
+          }
+        },
         "dockerHubOrg": {
             "value": "dfedigital"
         },

--- a/azure/config/dev3.parameters.json
+++ b/azure/config/dev3.parameters.json
@@ -32,6 +32,13 @@
             "secretName": "dev-secretKeyBase"
           }
         },
+        "splitApiKey": {
+          "reference": {
+            "keyVault": {
+              "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"},
+            "secretName": "dev-splitApiKey"
+          }
+        },
         "dockerHubOrg": {
             "value": "dfedigital"
         },

--- a/azure/config/test.parameters.json
+++ b/azure/config/test.parameters.json
@@ -32,6 +32,13 @@
             "secretName": "test-secretKeyBase"
           }
         },
+        "splitApiKey": {
+          "reference": {
+            "keyVault": {
+              "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"},
+            "secretName": "test-splitApiKey"
+          }
+        },
         "dockerHubOrg": {
             "value": "dfedigital"
         },


### PR DESCRIPTION
### Context
Dev environments all share the same vault entry. Test environment has a different vault with a custom key name, but is actually the same API token as dev.

For production another vault entry will be added, but not until that environment has been migrated across to the new config approach.