### PR TITLE
Fix intermittent spec failures

### DIFF
--- a/spec/features/course_overview_pages_spec.rb
+++ b/spec/features/course_overview_pages_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.feature 'Course overview page', type: :feature do
+  background do
+    enable_feature! :course_directory
+  end
+
   scenario 'User navigates to maths overview page' do
     visit(maths_course_overview_path)
 


### PR DESCRIPTION
Introducing feature flagging capability seems to
have made some of our specs intermittently fail.

We need to enforce the feature is ON for those specs.