### PR TITLE
Fix flakey test that fails because of Geocoder gem ActiveRecord/normal coordinates stub

### DIFF
--- a/spec/features/find_training_courses_spec.rb
+++ b/spec/features/find_training_courses_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Find training courses', type: :feature do
 
   scenario 'User gets relevant messaging if their address is valid but not real' do
     Geocoder::Lookup::Test.add_stub(
-      'NW6 8ET', [{ 'coordinates' => nil }]
+      'NW6 8ET', [{ 'coordinates' => [] }]
     )
     create(:course, topic: 'maths')
 

--- a/spec/features/location_eligibility_spec.rb
+++ b/spec/features/location_eligibility_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature 'Check your location is eligible', type: :feature do
 
   scenario 'User gets relevant messaging if their address is valid but not real' do
     Geocoder::Lookup::Test.add_stub(
-      'NW6 8ET', [{ 'coordinates' => nil }]
+      'NW6 8ET', [{ 'coordinates' => [] }]
     )
 
     visit(location_eligibility_path)

--- a/spec/models/course_geospatial_search_spec.rb
+++ b/spec/models/course_geospatial_search_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe CourseGeospatialSearch do
 
     it 'is invalid if postcode is valid but does not exist' do
       Geocoder::Lookup::Test.add_stub(
-        'NW6 8ET', [{ 'coordinates' => nil }]
+        'NW6 8ET', [{ 'coordinates' => [] }]
       )
 
       search = described_class.new(postcode: 'NW6 8ET')

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Course, type: :model do
 
     it 'does not set lat/long if postcode does not exist' do
       Geocoder::Lookup::Test.add_stub(
-        'NW6 8ET', [{ 'coordinates' => [nil, nil] }]
+        'NW6 8ET', [{ 'coordinates' => [] }]
       )
 
       course = create(:course, postcode: 'nw68et')


### PR DESCRIPTION
The test was failing with
```
NoMethodError:
  undefined method `[]' for nil:NilClass
# /Users/abeersalameh/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/geocoder-1.5.1/lib/geocoder/results/base.rb:47:in `latitude'
# /Users/abeersalameh/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/geocoder-1.5.1/lib/geocoder/stores/active_record.rb:300:in `block in geocode'
```
where in the gem file `geocoder-1.5.1/lib/geocoder/results/base.rb`:
```
def coordinates
  [@data['latitude'].to_f, @data['longitude'].to_f]
 end

 def latitude
   coordinates[0]
 end

 def longitude
   coordinates[1]
 end
```
Running bisect on the rspec seed yields the following:
```
The minimal reproduction command is:
  rspec ./spec/features/location_eligibility_spec.rb[1:5] ./spec/models/course_spec.rb[1:1:1] -b --seed 20702
```

This shows us that the geocoder stub is being leaked across tests where https://github.com/DFE-Digital/get-help-to-retrain/blob/master/spec/features/location_eligibility_spec.rb#L53 is  being read instead of the default test stub.

When calling `Geocoder.coordinates` vs ActiveRecord geocoder behaviour, the stub behaves differently. The ActiveRecord version does not expect nil, while the normal one does. Change stubs to always return an empty array instead of nil to avoid any unsuspected behaviour. We will not lose any validation as we are calling `.present?` on the response which will return false both ways

