### PR TITLE
GET-39 Location Ineligible page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,14 +8,18 @@ class PagesController < ApplicationController
       postcode: eligibility_params[:postcode]
     )
 
-    if eligibility_params[:postcode].present? && @search.valid?
-      @search.find_courses.any? ? redirect_to(task_list_path) : redirect_to(location_ineligible_path)
-    end
+    location_eligibility_through_courses if eligibility_params[:postcode].present? && @search.valid?
+  rescue CourseGeospatialSearch::GeocoderAPIError
+    redirect_to postcode_search_error_path
   end
 
   private
 
   def eligibility_params
     params.permit(:postcode)
+  end
+
+  def location_eligibility_through_courses
+    @search.find_courses.any? ? redirect_to(task_list_path) : redirect_to(location_ineligible_path)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,7 +9,7 @@ class PagesController < ApplicationController
     )
 
     if eligibility_params[:postcode].present? && @search.valid?
-      @search.find_courses.any? ? redirect_to(task_list_path) : redirect_to(root_path)
+      @search.find_courses.any? ? redirect_to(task_list_path) : redirect_to(location_ineligible_path)
     end
   end
 

--- a/app/views/errors/postcode_search_error.html.erb
+++ b/app/views/errors/postcode_search_error.html.erb
@@ -1,0 +1,12 @@
+<% page_title :errors_postcode_search_error %>
+
+<main role="main" class="govuk-main-wrapper" id="main-content">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Sorry, there is a problem with this service</h1>
+      <p class="govuk-body">Postcode search isn't working right now.</p>
+      <p class="govuk-body-m">You can continue using this service to check your existing skills and explore the types of jobs you could apply to do.</p>
+      <%= link_to 'Continue', task_list_path, class: 'govuk-button' %>
+    </div>
+  </div>
+</main>

--- a/app/views/pages/location_ineligible.html.erb
+++ b/app/views/pages/location_ineligible.html.erb
@@ -1,0 +1,19 @@
+<% page_title :pages_location_ineligible %>
+<% content_for :breadcrumb do
+    generate_breadcrumbs(
+      t('breadcrumb.location_ineligible'),
+      [
+        [t('breadcrumb._home'), root_path]
+      ]
+    )
+  end
+%>
+
+<div class="govuk-grid-row govuk-!-margin-top-7">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
+    <p class="govuk-body-m">We're a new service and currently do not offer any training courses in your area.</p>
+    <p class="govuk-body-m">You can continue using this service to check your existing skills and explore the types of jobs you could apply to do.</p>
+    <%= link_to 'Continue', task_list_path, class: 'govuk-button' %>
+  </div>
+</div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -23,6 +23,47 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
+      "fingerprint": "365fd9ea8cee0c69534a037daf9ffb9a53443fce909bcbf94046dc52347fc842",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/courses/_course.html.erb",
+      "line": 7,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(\"Visit website\", Course.new.url, :class => \"govuk-!-margin-bottom-6 govuk-button\", :target => \"_blank\", :data => ({ :tracked_event => (\"Courses - Clicked course link: #{Course.new.url}\") }))",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "CoursesController",
+          "method": "index",
+          "line": 6,
+          "file": "app/controllers/courses_controller.rb",
+          "rendered": {
+            "name": "courses/index",
+            "file": "app/views/courses/index.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "courses/index",
+          "line": 40,
+          "file": "app/views/courses/index.html.erb",
+          "rendered": {
+            "name": "courses/_course",
+            "file": "app/views/courses/_course.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "courses/_course"
+      },
+      "user_input": "Course.new.url",
+      "confidence": "Weak",
+      "note": "This is a known false positive from brakeman. We trust our data."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
       "fingerprint": "ebb71a6ea809f271551663c77d050194229ee6d7f84e683cb7c36550890d2393",
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
@@ -51,6 +92,6 @@
       "note": "This is a known false positive from brakeman. We trust our data."
     }
   ],
-  "updated": "2019-07-29 17:42:49 +0100",
+  "updated": "2019-07-31 14:59:22 +0100",
   "brakeman_version": "4.5.1"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en-GB:
     errors_not_found: Get help to retrain - Not found
     errors_unprocessable_entity: Get help to retrain - Unprocessable entity
     errors_internal_server_error: Get help to retrain - Internal server error
+    errors_postcode_search_error: Get help to retrain - Postcode search error
 
   contact_us:
     title: Want to speak with an adviser?
@@ -100,7 +101,6 @@ en-GB:
   courses:
     invalid_postcode_error: Enter a valid postcode.
     nonexisting_postcode_error: Enter a real postcode.
-    api_down_error: We cannot verify your postcode at the current time
 
   pagination:
     previous: Previous

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,7 @@ en-GB:
     english_overview: Benefits of English
     training_hub: Training hub
     location_eligibility: Your location
+    location_ineligible: No courses in your area
 
   page_titles:
     default: Get help to retrain
@@ -35,6 +36,7 @@ en-GB:
     pages_english_overview: Get help to retrain - Benefits of English
     pages_training_hub: Get help to retrain - Training Hub
     pages_location_eligibility: Get help to retrain - Your location
+    pages_location_ineligible: Get help to retrain - No courses in your area
     errors_not_found: Get help to retrain - Not found
     errors_unprocessable_entity: Get help to retrain - Unprocessable entity
     errors_internal_server_error: Get help to retrain - Internal server error
@@ -87,6 +89,8 @@ en-GB:
       title: Benefits of doing an English course
     location_eligibility:
       title: What is your postcode?
+    location_ineligible:
+      title: No courses are available in your area yet
   what_you_can_do_next:
     title: Find out what you can do next
     body: Get more support to help you on your new career path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,8 @@ Rails.application.routes.draw do
   constraints(->(_req) { Flipflop.location_eligibility? }) do
     get 'location-eligibility', to: 'pages#location_eligibility'
     get 'location-ineligible', to: 'pages#location_ineligible'
+    get 'postcode-search-error', to: 'errors#postcode_search_error'
   end
-
 
   resources :courses, path: 'courses/:topic_id', only: %i[index], constraints: { topic_id: /maths|english/ }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,11 @@ Rails.application.routes.draw do
     get 'training-hub', to: 'pages#training_hub'
   end
 
-  get 'location-eligibility', to: 'pages#location_eligibility', constraints: ->(_req) { Flipflop.location_eligibility? }
+  constraints(->(_req) { Flipflop.location_eligibility? }) do
+    get 'location-eligibility', to: 'pages#location_eligibility'
+    get 'location-ineligible', to: 'pages#location_ineligible'
+  end
+
 
   resources :courses, path: 'courses/:topic_id', only: %i[index], constraints: { topic_id: /maths|english/ }
 

--- a/spec/features/location_eligibility_spec.rb
+++ b/spec/features/location_eligibility_spec.rb
@@ -67,14 +67,21 @@ RSpec.feature 'Check your location is eligible', type: :feature do
     expect(page).to have_text(/Enter a real postcode/)
   end
 
-  xscenario 'User gets relevant messaging if their address coordinates could not be retrieved' do
+  scenario 'User is redirected to error page if their postcode coordinates could not be retrieved' do
     allow(Geocoder).to receive(:coordinates).and_raise(Geocoder::ServiceUnavailable)
 
     visit(location_eligibility_path)
     fill_in('postcode', with: 'NW6 8ET')
     find('.govuk-button').click
 
-    expect(page).to have_text(/We cannot verify your postcode/)
+    expect(page).to have_text(/Sorry, there is a problem with this service/)
+  end
+
+  scenario 'User can continue to task list even if postcode service is down' do
+    visit(postcode_search_error_path)
+    find('.govuk-button').click
+
+    expect(page).to have_current_path(task_list_path)
   end
 
   scenario 'search form required field available when no js running' do

--- a/spec/features/location_eligibility_spec.rb
+++ b/spec/features/location_eligibility_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Check your location is eligible', type: :feature do
     expect(page).to have_current_path(location_eligibility_path)
   end
 
-  scenario 'User is taken back to start page if postcode is not eligible' do
+  scenario 'User is taken to location ineligible page if postcode is not eligible' do
     Geocoder::Lookup::Test.add_stub(
       'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
     )
@@ -23,7 +23,14 @@ RSpec.feature 'Check your location is eligible', type: :feature do
     fill_in('postcode', with: 'NW6 8ET')
     find('.govuk-button').click
 
-    expect(page).to have_current_path(root_path)
+    expect(page).to have_current_path(location_ineligible_path)
+  end
+
+  scenario 'User can proceed to tasklist if postcode is not eligible' do
+    visit(location_ineligible_path)
+    find('.govuk-button').click
+
+    expect(page).to have_current_path(task_list_path)
   end
 
   scenario 'User follows through to task list page if postcode eligible' do

--- a/spec/routing/location_eligibility_spec.rb
+++ b/spec/routing/location_eligibility_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'routes for Location Eligibility', type: :routing do
+  context 'when :location_eligibility feature is ON' do
+    before do
+      enable_feature! :location_eligibility
+    end
+
+    it 'successfully routes to pages#location_eligibility' do
+      expect(get(location_eligibility_path)).to route_to('pages#location_eligibility')
+    end
+
+    it 'successfully routes to pages#location_ineligible' do
+      expect(get(location_ineligible_path)).to route_to('pages#location_ineligible')
+    end
+
+    it 'successfully routes to errors#postcode_search_error' do
+      expect(get(postcode_search_error_path)).to route_to('errors#postcode_search_error')
+    end
+  end
+
+  context 'when :location_eligibility feature is OFF' do
+    before do
+      disable_feature! :location_eligibility
+    end
+
+    it 'does not route to pages#location_eligibility' do
+      expect(get(location_eligibility_path)).not_to be_routable
+    end
+
+    it 'does not route to pages#location_ineligible' do
+      expect(get(location_ineligible_path)).not_to be_routable
+    end
+
+    it 'does not route to errors#postcode_search_error' do
+      expect(get(postcode_search_error_path)).not_to be_routable
+    end
+  end
+end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-39

Add location ineligible page, when there are no courses close to user, which allows user to go to task list page anyway. based on https://get-help-to-retrain-prototype.herokuapp.com/main/release2_e2e_v2/location_ineligible
Also add error page incase API is down on the location eligibility path, we are still holding off on that one on the courses path as designs/journey not ready

ready to test on: https://dev2.nrs-ghtr.org.uk/

