### PR TITLE
Add custom track events for postcode and job searches

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,9 @@ class ApplicationController < ActionController::Base
   private
 
   def track_event(event_key, properties = {})
-    TELEMETRY_CLIENT.track_event I18n.t(event_key), properties: properties if defined?(TELEMETRY_CLIENT)
+    return unless defined?(TELEMETRY_CLIENT)
+
+    TELEMETRY_CLIENT.track_event(I18n.t(event_key, scope: :events), properties: properties)
   end
 
   def protect_feature(feature)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::Base
   private
 
+  def track_event(event_key, properties = {})
+    TELEMETRY_CLIENT.track_event I18n.t(event_key), properties: properties if defined?(TELEMETRY_CLIENT)
+  end
+
   def protect_feature(feature)
     redirect_to task_list_path unless Flipflop.enabled?(feature)
   end

--- a/app/controllers/check_your_skills_controller.rb
+++ b/app/controllers/check_your_skills_controller.rb
@@ -1,9 +1,14 @@
 class CheckYourSkillsController < ApplicationController
   def results
-    @job_profiles = JobProfile.search(job_profile_params[:search]).page(params[:page])
+    track_event :check_your_skills_index_search, search: search
+    @job_profiles = JobProfile.search(search).page(params[:page])
   end
 
   private
+
+  def search
+    job_profile_params[:search]
+  end
 
   def job_profile_params
     params.permit(:search)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -2,8 +2,9 @@ class CoursesController < ApplicationController
   before_action :handle_missing_courses
 
   def index
+    track_event :courses_index_search, search: postcode
     @search = CourseGeospatialSearch.new(
-      postcode: courses_params[:postcode],
+      postcode: postcode,
       topic: courses_params[:topic_id]
     )
     @courses = @search.find_courses.map { |c| CourseDecorator.new(c) }
@@ -13,6 +14,10 @@ class CoursesController < ApplicationController
 
   def handle_missing_courses
     protect_feature(:course_directory)
+  end
+
+  def postcode
+    courses_params[:postcode]
   end
 
   def courses_params

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -2,7 +2,8 @@ class CoursesController < ApplicationController
   before_action :handle_missing_courses
 
   def index
-    track_event :courses_index_search, search: postcode
+    track_event(:courses_index_search, search: postcode) if postcode.present?
+
     @search = CourseGeospatialSearch.new(
       postcode: postcode,
       topic: courses_params[:topic_id]

--- a/app/controllers/explore_occupations_controller.rb
+++ b/app/controllers/explore_occupations_controller.rb
@@ -4,13 +4,18 @@ class ExploreOccupationsController < ApplicationController
   end
 
   def results
-    @search_results = JobProfile.search(job_profile_params[:search]).includes(:categories).page(params[:page])
+    track_event :explore_occupations_index_search, search: search
+    @search_results = JobProfile.search(search).includes(:categories).page(params[:page])
     @job_profiles = @search_results.map { |job_profile|
       JobProfileDecorator.new(job_profile)
     }
   end
 
   private
+
+  def search
+    job_profile_params[:search]
+  end
 
   def job_profile_params
     params.permit(:search)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,16 +4,20 @@ class PagesController < ApplicationController
   end
 
   def location_eligibility
-    @search = CourseGeospatialSearch.new(
-      postcode: eligibility_params[:postcode]
-    )
+    track_event(:pages_location_eligibility_search, search: postcode) if postcode.present?
 
-    location_eligibility_through_courses if eligibility_params[:postcode].present? && @search.valid?
+    @search = CourseGeospatialSearch.new(postcode: postcode)
+
+    location_eligibility_through_courses if postcode.present? && @search.valid?
   rescue CourseGeospatialSearch::GeocoderAPIError
     redirect_to postcode_search_error_path
   end
 
   private
+
+  def postcode
+    eligibility_params[:postcode]
+  end
 
   def eligibility_params
     params.permit(:postcode)

--- a/config/initializers/application_insights.rb
+++ b/config/initializers/application_insights.rb
@@ -1,38 +1,30 @@
 if Rails.env.production?
   Rails.application.configure do
     if (app_insights_key = ENV['APPINSIGHTS_INSTRUMENTATIONKEY']) && app_insights_key.present?
-      # the optional extra params are buffer_size (= 500) and send_interval (= 60),
-      # leaving for now as they appear sensible
       config.middleware.use(ApplicationInsights::Rack::TrackRequest, app_insights_key)
       if ENV['APPINSIGHTS_JAVASCRIPT_ENABLED'] == 'true'
         config.middleware.use(ApplicationInsights::Rack::InjectJavaScriptTracking, app_insights_key)
       end
+
+      # setup asynchronous sender and channel for use with telemetry client
+      sender = ApplicationInsights::Channel::AsynchronousSender.new
+      queue = ApplicationInsights::Channel::AsynchronousQueue.new(sender)
+      channel = ApplicationInsights::Channel::TelemetryChannel.new(nil, queue)
+
+      TELEMETRY_CLIENT = ApplicationInsights::TelemetryClient.new(app_insights_key, channel).tap do |tc|
+        # flush telemetry if we have 10 or more telemetry items in our queue
+        tc.channel.queue.max_queue_length = 10
+        # send telemetry to the service in batches of 5
+        tc.channel.sender.send_buffer_size = 5
+        # the background worker thread will be active for 5 seconds before it shuts down. if
+        # during this time items are picked up from the queue, the timer is reset.
+        tc.channel.sender.send_time = 5
+        # the background worker thread will poll the queue every 0.5 seconds for new items
+        tc.channel.sender.send_interval = 0.5
+      end
+
+      # setup unhandled exception handler
+      ApplicationInsights::UnhandledException.collect(app_insights_key)
     end
-
-    # # This isn't needed _until_ we want to track events and metrics in addition
-    # # to the Rails app middleware (ApplicationInsights::Rack::TrackRequest). More
-    # # info here:
-    #
-    # # https://github.com/microsoft/ApplicationInsights-Ruby
-    # # https://github.com/microsoft/ApplicationInsights-Home/wiki#getting-an-application-insights-instrumentation-key
-    #
-    # sender = ApplicationInsights::Channel::AsynchronousSender.new
-    # queue = ApplicationInsights::Channel::AsynchronousQueue.new(sender)
-    # channel = ApplicationInsights::Channel::TelemetryChannel.new(nil, queue)
-    #
-    # TELEMETRY_CLIENT = ApplicationInsights::TelemetryClient.new(app_insights_key, channel).tap do |tc|
-    #   # flush telemetry if we have 10 or more telemetry items in our queue
-    #   tc.channel.queue.max_queue_length = 10
-    #   # send telemetry to the service in batches of 5
-    #   tc.channel.sender.send_buffer_size = 5
-    #   # the background worker thread will be active for 5 seconds before it shuts down. if
-    #   # during this time items are picked up from the queue, the timer is reset.
-    #   tc.channel.sender.send_time = 5
-    #   # the background worker thread will poll the queue every 0.5 seconds for new items
-    #   tc.channel.sender.send_interval = 0.5
-    # end
-
-    # setup unhandled exception handler
-    ApplicationInsights::UnhandledException.collect(app_insights_key)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,11 @@ en-GB:
     errors_internal_server_error: Get help to retrain - Internal server error
     errors_postcode_search_error: Get help to retrain - Postcode search error
 
+  events:
+    check_your_skills_index_search: Check your skills - Job search
+    explore_occupations_index_search: Explore occupations - Job search
+    courses_index_search: Courses near me - Postcode search
+
   contact_us:
     title: Want to speak with an adviser?
     body: Call

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,7 @@ en-GB:
     errors_postcode_search_error: Get help to retrain - Postcode search error
 
   events:
+    pages_location_eligibility_search: Your location - Postcode search
     check_your_skills_index_search: Check your skills - Job search
     explore_occupations_index_search: Explore occupations - Job search
     courses_index_search: Courses near me - Postcode search


### PR DESCRIPTION
### Context
This uses asynchronous telemetry client channel so doesn't block main thread - takes a few seconds for events to show up in Azure Application Insights but works well. Refactored relevant controllers very slightly to make extracting the key search param a little neater / DRY.

### Changes proposed in this pull request

### Guidance to review
Easiest to test once deployed to a dev environment.
Search for job titles in check your skills and explore careers pages.
Search for postcode in courses page.
Ensure that custom events are recorded in Azure Application Insights
