### PR TITLE
GET-279 Use target image to improve docker caching

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,12 +137,24 @@ stages:
       - script: docker pull $(IMAGE_NAME):latest || true
         displayName: "Pull latest docker image to cache"
 
+      - script: docker pull $(IMAGE_NAME):assets-latest || true
+        displayName: "Pull assets latest docker image to cache"
+
+      - task: Docker@1
+        displayName: Build docker assets stage
+        inputs:
+          command: build
+          imageName: $(IMAGE_NAME):assets-latest
+          dockerFile: Dockerfile
+          arguments: '--cache-from $(IMAGE_NAME):assets-latest --target assets'
+
       - task: Docker@1
         displayName: Build docker image
         inputs:
           command: build
           imageName: $(IMAGE_NAME):$(Build.BuildNumber)
           dockerFile: Dockerfile
+          arguments: '--cache-from=$(IMAGE_NAME):assets-latest,$(IMAGE_NAME):latest'
 
       - task: Docker@2
         displayName: Push new image with current tag
@@ -150,6 +162,14 @@ stages:
           command: push
           repository: $(IMAGE_NAME)
           tags: $(Build.BuildNumber)
+
+      - task: Docker@2
+        displayName: Push new image with assets tag
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+        inputs:
+          command: push
+          repository: $(IMAGE_NAME)
+          tags: assets-latest
 
       - task: Docker@2
         displayName: Push tagged image (latest) if master


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-279

* Create new docker image for first stage of docker build called assets
* Use this image as a cache to build first target for assets
* Use two images as cache for building the full image to utilise caching correctly as we cannot retain local cache for host agents across builds. 

reference article: https://andrewlock.net/caching-docker-layers-on-serverless-build-hosts-with-multi-stage-builds---target,-and---cache-from/#summary

removes ~2 minutes from build on a cache hit