### PR TITLE
GET-332 Fix training hub link in job profiles

### DIFF
--- a/app/views/job_profiles/show.html.erb
+++ b/app/views/job_profiles/show.html.erb
@@ -23,7 +23,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <%= render 'relevant_sections' %>
-          <%= link_to('Find a training course', find_training_courses_path, class: 'govuk-button govuk-!-margin-top-6 govuk-!-margin-bottom-9') %>
+          <%= link_to('Find a training course', Flipflop.course_directory? ? training_hub_path : find_training_courses_path, class: 'govuk-button govuk-!-margin-top-6 govuk-!-margin-bottom-9') %>
         </div>
         <div class="govuk-grid-column-one-third govuk-!-padding-left-5 related-profiles-right-padding-0">
           <%= render 'related_profiles' %>

--- a/spec/features/explore_occupations_spec.rb
+++ b/spec/features/explore_occupations_spec.rb
@@ -15,6 +15,10 @@ RSpec.feature 'Explore Occupations', type: :feature do
     )
   end
 
+  background do
+    disable_feature! :course_directory
+  end
+
   scenario 'User explores their career through categories' do
     visit(explore_occupations_path)
     click_on('Apocalyptic services')
@@ -45,6 +49,15 @@ RSpec.feature 'Explore Occupations', type: :feature do
     click_on('Find a training course')
 
     expect(page).to have_text('Find and apply to a training course near you')
+  end
+
+  scenario 'User continues journey to training hub if course feature enabled' do
+    enable_feature! :course_directory
+
+    visit(job_profile_path(job_profile.slug))
+    click_on('Find a training course')
+
+    expect(page).to have_text('Find training that boosts your job options')
   end
 
   scenario 'paginates results of search' do


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-332

Feature flag training hub link in job profiles to link to new page
if course directory feature enabled