### PR TITLE
De-reference variable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
 pr: none
 
 variables:
-  IMAGE_NAME: '$(dockerHubUserName)/get-help-to-retrain'
+  IMAGE_NAME: dfedigital/get-help-to-retrain
   postgresUrl: postgres://test:test@localhost:5432/get-help-to-retrain
   BUNDLE_CACHE_FOLDER: $(Pipeline.Workspace)/vendor/bundle
 


### PR DESCRIPTION
This PR is an attempt to dereference a variable that moved between variable groups.
We don't really need it, and all other projects have the docker organization name hardcoded as part of the image, so there is also not much point in having the indirect reference.
This might help fix the build pipeline. 

