### PR TITLE
GET-231 Skills Builder

### DIFF
--- a/app/controllers/job_profiles_skills_controller.rb
+++ b/app/controllers/job_profiles_skills_controller.rb
@@ -1,19 +1,12 @@
 class JobProfilesSkillsController < ApplicationController
   def index
+    skills_builder.build
+
     if skills_valid?
-      redirect skills_path
+      redirect_to(skills_path(job_profile_id: skills_params[:job_profile_id]))
     else
-      @skills = job_profile.skills
-      @skills.errors.add(:postcode, 'Select at least one skill')
+      render 'job_profiles/skills/index'
     end
-  end
-
-  def current_job_skills
-
-  end
-
-  def your_skills
-    @skills = job_profile.skills
   end
 
   private
@@ -24,11 +17,19 @@ class JobProfilesSkillsController < ApplicationController
     )
   end
 
-  def skills_params
-    params.permit(:job_profile_id, skill_ids: [])
+  def skills_builder
+    @skills_builder ||= SkillsBuilder.new(
+      skills_params: skills_params[:skill_ids],
+      job_profile_skills: job_profile.skills,
+      user_session: session
+    )
   end
 
   def skills_valid?
-    skills_params[:skill_ids].present? && skills_params[:skill_ids].count > 1
+    skills_params[:skill_ids].present? && skills_builder.valid?
+  end
+
+  def skills_params
+    params.permit(:job_profile_id, skill_ids: [])
   end
 end

--- a/app/controllers/job_profiles_skills_controller.rb
+++ b/app/controllers/job_profiles_skills_controller.rb
@@ -1,0 +1,34 @@
+class JobProfilesSkillsController < ApplicationController
+  def index
+    if skills_valid?
+      redirect skills_path
+    else
+      @skills = job_profile.skills
+      @skills.errors.add(:postcode, 'Select at least one skill')
+    end
+  end
+
+  def current_job_skills
+
+  end
+
+  def your_skills
+    @skills = job_profile.skills
+  end
+
+  private
+
+  def job_profile
+    @job_profile ||= JobProfileDecorator.new(
+      JobProfile.find_by(slug: params[:job_profile_id])
+    )
+  end
+
+  def skills_params
+    params.permit(:job_profile_id, skill_ids: [])
+  end
+
+  def skills_valid?
+    skills_params[:skill_ids].present? && skills_params[:skill_ids].count > 1
+  end
+end

--- a/app/controllers/job_profiles_skills_controller.rb
+++ b/app/controllers/job_profiles_skills_controller.rb
@@ -1,11 +1,12 @@
 class JobProfilesSkillsController < ApplicationController
   def index
     skills_builder.build
-
     if skills_valid?
-      redirect_to(skills_path(job_profile_id: skills_params[:job_profile_id]))
+      redirect_to(
+        skills_path(job_profile_id: skills_params[:job_profile_id], search: skills_params[:search])
+      )
     else
-      render 'job_profiles/skills/index'
+      render('job_profiles/skills/index')
     end
   end
 
@@ -13,7 +14,7 @@ class JobProfilesSkillsController < ApplicationController
 
   def job_profile
     @job_profile ||= JobProfileDecorator.new(
-      JobProfile.find_by(slug: params[:job_profile_id])
+      JobProfile.find_by(slug: skills_params[:job_profile_id])
     )
   end
 
@@ -30,6 +31,6 @@ class JobProfilesSkillsController < ApplicationController
   end
 
   def skills_params
-    params.permit(:job_profile_id, skill_ids: [])
+    params.permit(:job_profile_id, :search, skill_ids: [])
   end
 end

--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -1,6 +1,12 @@
 class SkillsController < ApplicationController
   def index
-    @skills = job_profile.skills
+    if Flipflop.skills_builder?
+      job_profile
+      @skills = Skill.find(session[:skill_ids])
+      render 'index_v2'
+    else
+      @skills = job_profile.skills
+    end
   end
 
   private

--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -13,7 +13,11 @@ class SkillsController < ApplicationController
 
   def job_profile
     @job_profile ||= JobProfileDecorator.new(
-      JobProfile.find_by(slug: params[:job_profile_id])
+      JobProfile.find_by(slug: skills_params[:job_profile_id])
     )
+  end
+
+  def skills_params
+    params.permit(:job_profile_id)
   end
 end

--- a/app/models/skills_builder.rb
+++ b/app/models/skills_builder.rb
@@ -1,0 +1,36 @@
+class SkillsBuilder
+  include ActiveModel::Validations
+
+  attr_reader :skills_params, :job_profile_skills, :user_session
+  validate :skill_ids_presence
+
+  def initialize(skills_params:, job_profile_skills:, user_session:)
+    @skills_params = skills_params
+    @job_profile_skills = job_profile_skills
+    @user_session = user_session
+  end
+
+  def build
+    return unless skills_params.present?
+
+    user_session[:skill_ids] = formatted_skill_params
+  end
+
+  def skill_ids
+    user_session[:skill_ids] || job_profile_skills.pluck(:id)
+  end
+
+  private
+
+  def skill_ids_presence
+    errors.add(:skills, I18n.t('skills.invalid_skills_selected_error')) unless skills_selected?
+  end
+
+  def formatted_skill_params
+    @formatted_skill_params ||= skills_params.reject(&:empty?).map(&:to_i)
+  end
+
+  def skills_selected?
+    formatted_skill_params.any?
+  end
+end

--- a/app/views/job_profiles/skills/index.html.erb
+++ b/app/views/job_profiles/skills/index.html.erb
@@ -29,6 +29,7 @@
             <%= errors_tag @skills_builder, :skills %>
             <div class="govuk-checkboxes">
               <%= hidden_field_tag('skill_ids[]', nil, id: 'skill_ids') %>
+              <%= hidden_field_tag('search', params[:search], id: 'search') %>
               <% @skills_builder.job_profile_skills.each do |skill| %>
                 <div class="govuk-checkboxes__item">
                   <%= check_box_tag('skill_ids[]', skill.id, @skills_builder.skill_ids.include?(skill.id), id: dom_id(skill), class: 'govuk-checkboxes__input') %>

--- a/app/views/job_profiles/skills/index.html.erb
+++ b/app/views/job_profiles/skills/index.html.erb
@@ -1,0 +1,47 @@
+<% page_title :skills_current_job_skills %>
+<% content_for :breadcrumb do
+    generate_breadcrumbs(
+      t('breadcrumb.current_job_skills'),
+      [
+        [t('breadcrumb.task_list_home'), task_list_path],
+        [t('breadcrumb.check_your_skills'), check_your_skills_path],
+        [t('breadcrumb.search_results'), results_check_your_skills_path(search: params[:search])]
+      ]
+    )
+  end
+%>
+
+<div class="govuk-grid-row govuk-!-margin-top-7 govuk-body">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full govuk-!-padding-0">
+      <%= form_tag job_profile_skills_path, method: 'get' do %>
+        <%= form_group_tag @skills_builder, :skills do %>
+          <fieldset class="govuk-fieldset" aria-describedby="current-job-skills-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3">
+                <%= @job_profile.hero_copy %>
+              </h1>
+              <p class="govuk-body-l">We’ll use this list to suggest other types of job you can do.</p>
+              <span id="current-job-skills-hint" class="govuk-hint">
+                If you want to remove any of these skills, click the tick to remove it from the list.
+              </span>
+            </legend>
+            <%= errors_tag @skills_builder, :skills %>
+            <div class="govuk-checkboxes">
+              <%= hidden_field_tag('skill_ids[]', nil, id: 'skill_ids') %>
+              <% @skills_builder.job_profile_skills.each do |skill| %>
+                <div class="govuk-checkboxes__item">
+                  <%= check_box_tag('skill_ids[]', skill.id, @skills_builder.skill_ids.include?(skill.id), id: dom_id(skill), class: 'govuk-checkboxes__input') %>
+                  <%= label_tag(dom_id(skill), skill.name, class: 'govuk-label govuk-checkboxes__label') %>
+                </div>
+              <% end %>
+            </div>
+          </fieldset>
+        <% end %>
+        <%= button_tag('Select these skills', class: 'govuk-button', aria: { label: 'Select these skills button' }) %>
+      <% end %>
+    </div>
+  </div>
+
+  <%= render 'shared/contact_us' %>
+</div>

--- a/app/views/skills/index_v2.html.erb
+++ b/app/views/skills/index_v2.html.erb
@@ -6,7 +6,7 @@
         [t('breadcrumb.task_list_home'), task_list_path],
         [t('breadcrumb.check_your_skills'), check_your_skills_path],
         [t('breadcrumb.search_results'), results_check_your_skills_path(search: params[:search])],
-        [t('breadcrumb.current_job_skills'), job_profile_skills_path(job_profile_id: params[:job_profile_id])]
+        [t('breadcrumb.current_job_skills'), job_profile_skills_path(job_profile_id: params[:job_profile_id], search: params[:search])]
       ]
     )
   end
@@ -34,6 +34,7 @@
           <% end %>
         </tbody>
       </table>
+      <!-- TODO amend in skill matcher story -->
       <%= link_to('Find out what you can do with these skills', '#', class: 'govuk-button') %>
     </div>
   </div>

--- a/app/views/skills/index_v2.html.erb
+++ b/app/views/skills/index_v2.html.erb
@@ -1,0 +1,42 @@
+<% page_title :skills_index %>
+<% content_for :breadcrumb do
+    generate_breadcrumbs(
+      t('breadcrumb.your_skills'),
+      [
+        [t('breadcrumb.task_list_home'), task_list_path],
+        [t('breadcrumb.check_your_skills'), check_your_skills_path],
+        [t('breadcrumb.search_results'), results_check_your_skills_path(search: params[:search])],
+        [t('breadcrumb.current_job_skills'), job_profile_skills_path(job_profile_id: params[:job_profile_id])]
+      ]
+    )
+  end
+%>
+
+<div class="govuk-grid-row govuk-!-margin-top-7 govuk-body">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full govuk-!-padding-0">
+      <h1 class="govuk-heading-xl">Your skills</h1>
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= @job_profile.hero_copy %></h2>
+      <table class="govuk-table">
+        <caption class="govuk-table__caption small govuk-visually-hidden">Your skills</caption>
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header govuk-section-break__xl govuk-!-padding-0" scope="col">
+              <p class="govuk-body">You gained these skills from working as a <%= @job_profile.hero_copy %></p>
+            </th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @skills.each do |skill| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell govuk-!-padding-bottom-4 govuk-!-padding-top-4"><%= skill.name %></th>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <%= link_to('Find out what you can do with these skills', '#', class: 'govuk-button') %>
+    </div>
+  </div>
+
+  <%= render 'shared/contact_us' %>
+</div>

--- a/app/webpacker/styles/_skills-builder.scss
+++ b/app/webpacker/styles/_skills-builder.scss
@@ -1,0 +1,13 @@
+.govuk-section-break__xl {
+  border-bottom-width: 2px;
+  border-bottom-color: $govuk-text-colour;
+}
+
+.govuk-table__body {
+  tr:last-child {
+    td {
+      border-bottom-width: 2px;
+      border-bottom-color: $govuk-text-colour;
+    }
+  }
+}

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -5,3 +5,4 @@
 @import "pagination";
 @import "course";
 @import "user_feedback";
+@import "skills-builder";

--- a/config/features.rb
+++ b/config/features.rb
@@ -8,4 +8,5 @@ Flipflop.configure do
   feature :foo, description: 'Example feature flag', default: true
   feature :course_directory, description: 'Training courses feature'
   feature :location_eligibility, description: 'Location eligibility feature'
+  feature :skills_builder, description: 'Skills builder feature'
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en-GB:
     training_hub: Training hub
     location_eligibility: Your location
     location_ineligible: No courses in your area
+    current_job_skills: Current job skills
 
   page_titles:
     default: Get help to retrain
@@ -25,6 +26,7 @@ en-GB:
     check_your_skills_index: Get help to retrain - Check your skills
     check_your_skills_results: Get help to retrain - Check your skills results
     skills_index: Get help to retrain - Your skills
+    skills_current_job_skills: Get help to retrain - Current job skills
     explore_occupations_index: Get help to retrain - Explore occupations
     categories_show: Get help to retrain - Job category
     explore_occupations_results: Get help to retrain - Explore occupations results
@@ -83,7 +85,8 @@ en-GB:
   home:
     index:
       title: Get help to retrain
-
+  skills:
+    invalid_skills_selected_error: Select at least one skill
   pages:
     task_list:
       title: Get help to retrain

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,8 +32,12 @@ Rails.application.routes.draw do
   end
 
   resources :job_profiles, path: 'job-profiles', only: %i[show] do
-    resources :skills, only: %i[index]
+    resources :skills, only: %i[index] do
+      get :index, controller: 'job_profiles_skills', on: :collection, constraints: ->(_req) { Flipflop.skills_builder? }
+    end
   end
+
+  resources :skills, only: %i[index], constraints: ->(_req) { Flipflop.skills_builder? }
 
   resources :explore_occupations, path: 'explore-occupations', only: %i[index] do
     get :results, on: :collection

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -21,6 +21,7 @@ RSpec.feature 'Check your skills', type: :feature do
   end
 
   scenario 'User continues journey to explore their careers' do
+    disable_feature! :skills_builder
     visit(job_profile_skills_path(job_profile.slug))
     click_on('Explore jobs you could do')
 

--- a/spec/features/skills_builder_spec.rb
+++ b/spec/features/skills_builder_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.feature 'Build your skills', type: :feature do
+  background do
+    enable_feature! :skills_builder
+  end
+
+  let!(:job_profile) do
+    create(
+      :job_profile,
+      name: 'Hitman',
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics'),
+        create(:skill, name: 'License to kill'),
+        create(:skill, name: 'Baldness')
+      ]
+    )
+  end
+
+  scenario 'User sees a list of skills when checking their Job skills' do
+    visit(check_your_skills_path)
+    fill_in('search', with: 'Hitman')
+    find('.search-button').click
+    click_on('Hitman')
+
+    expect(page).to have_selector('div.govuk-checkboxes div.govuk-checkboxes__item', count: 3)
+  end
+
+  scenario 'User sees a list of skills all pre-checked' do
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+
+    expect(page).to have_selector('input[checked="checked"]', count: 3)
+  end
+
+  scenario 'User continues to see all skills selected' do
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    find('.govuk-button').click
+
+    expect(page).to have_selector('tbody tr', count: 3)
+  end
+
+  scenario 'User chooses which skills to select and continues to see those selected skills' do
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    uncheck('Baldness', allow_label_click: true)
+    find('.govuk-button').click
+
+    expect(page).to have_selector('tbody tr', count: 2)
+  end
+
+  scenario 'skill builder requires at least one skill selected' do
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    uncheck('Chameleon-like blend in tactics', allow_label_click: true)
+    uncheck('License to kill', allow_label_click: true)
+    uncheck('Baldness', allow_label_click: true)
+
+    find('.govuk-button').click
+
+    expect(page).to have_text(/Select at least one skill/)
+  end
+
+  context 'when feature disabled' do
+    background do
+      disable_feature! :skills_builder
+    end
+
+    scenario 'User is taken to static list of skills' do
+      visit(check_your_skills_path)
+      fill_in('search', with: 'Hitman')
+      find('.search-button').click
+      click_on('Hitman')
+
+      expect(page).not_to have_selector('div.govuk-checkboxes div.govuk-checkboxes__item')
+    end
+  end
+end

--- a/spec/features/skills_builder_spec.rb
+++ b/spec/features/skills_builder_spec.rb
@@ -58,6 +58,17 @@ RSpec.feature 'Build your skills', type: :feature do
     expect(page).to have_text(/Select at least one skill/)
   end
 
+  scenario 'breadcrumbs navigate back to search results from your skills' do
+    visit(check_your_skills_path)
+    fill_in('search', with: 'Hitman')
+    find('.search-button').click
+    click_on('Hitman')
+    find('.govuk-button').click
+    click_on('Search results')
+
+    expect(page).to have_text(/Hitman/)
+  end
+
   context 'when feature disabled' do
     background do
       disable_feature! :skills_builder

--- a/spec/models/skills_builder_spec.rb
+++ b/spec/models/skills_builder_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe SkillsBuilder do
+  describe '#build' do
+    it 'does not set user_session if no skills params available' do
+      builder = described_class.new(
+        skills_params: nil,
+        job_profile_skills: [create(:skill)],
+        user_session: {}
+      )
+      builder.build
+
+      expect(builder.user_session).to be_empty
+    end
+
+    it 'sets user_session to correct skills format if skills params available' do
+      builder = described_class.new(
+        skills_params: %w[1 2],
+        job_profile_skills: [create(:skill)],
+        user_session: {}
+      )
+      builder.build
+
+      expect(builder.user_session).to eq(skill_ids: [1, 2])
+    end
+
+    it 'ignores empty skill param ids when setting user_ession' do
+      builder = described_class.new(
+        skills_params: ['1', ''],
+        job_profile_skills: [create(:skill)],
+        user_session: {}
+      )
+      builder.build
+
+      expect(builder.user_session).to eq(skill_ids: [1])
+    end
+
+    it 'overrides existing user session with new skill param ids' do
+      builder = described_class.new(
+        skills_params: ['1', '', '5', '6'],
+        job_profile_skills: [create(:skill)],
+        user_session: { skill_ids: [3, 4] }
+      )
+      builder.build
+
+      expect(builder.user_session).to eq(skill_ids: [1, 5, 6])
+    end
+  end
+
+  describe '#skill_ids' do
+    it 'returns all job profile skill ids if no user_session empty' do
+      skill1 = create(:skill)
+      skill2 = create(:skill)
+
+      builder = described_class.new(
+        skills_params: nil,
+        job_profile_skills: [skill1, skill2],
+        user_session: {}
+      )
+
+      builder.build
+      expect(builder.skill_ids).to eq([skill1.id, skill2.id])
+    end
+
+    it 'returns skill ids if user_session populated' do
+      skill1 = create(:skill)
+      skill2 = create(:skill)
+
+      builder = described_class.new(
+        skills_params: nil,
+        job_profile_skills: [skill1, skill2],
+        user_session: { skill_ids: [3, 4] }
+      )
+
+      builder.build
+      expect(builder.skill_ids).to eq([3, 4])
+    end
+
+    it 'returns updated skill ids if skills_params populated' do
+      skill1 = create(:skill)
+      skill2 = create(:skill)
+
+      builder = described_class.new(
+        skills_params: ['1', '', '2'],
+        job_profile_skills: [skill1, skill2],
+        user_session: { skill_ids: [3, 4] }
+      )
+
+      builder.build
+      expect(builder.skill_ids).to eq([1, 2])
+    end
+  end
+
+  describe 'validation' do
+    it 'is invalid if no skills selected' do
+      builder = described_class.new(
+        skills_params: [''],
+        job_profile_skills: [create(:skill)],
+        user_session: {}
+      )
+
+      expect(builder).not_to be_valid
+    end
+
+    it 'is valid if skills selected' do
+      builder = described_class.new(
+        skills_params: ['1', '', '4'],
+        job_profile_skills: [create(:skill)],
+        user_session: {}
+      )
+
+      expect(builder).to be_valid
+    end
+  end
+end

--- a/spec/routing/skills_spec.rb
+++ b/spec/routing/skills_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'routes for Skills', type: :routing do
+  context 'when :skills_builder feature is ON' do
+    before do
+      enable_feature! :skills_builder
+    end
+
+    it 'successfully routes to job_profiles_skills#index' do
+      job_profile = create(:job_profile)
+      expect(get(job_profile_skills_path(job_profile.slug))).to route_to(controller: 'job_profiles_skills', action: 'index', job_profile_id: job_profile.slug)
+    end
+
+    it 'successfully routes to skills#index' do
+      expect(get(skills_path)).to route_to('skills#index')
+    end
+  end
+
+  context 'when :skills_builder feature is OFF' do
+    before do
+      disable_feature! :skills_builder
+    end
+
+    it 'successfully routes to job_profiles/skills#index' do
+      job_profile = create(:job_profile)
+      expect(get(job_profile_skills_path(job_profile.slug))).to route_to(controller: 'skills', action: 'index', job_profile_id: job_profile.slug)
+    end
+
+    it 'does not route to skills#index' do
+      expect(get(skills_path)).not_to be_routable
+    end
+  end
+end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-231

Add Skills Builder as a feature flagged service. Users get to this page from the check your skills results page, after clicking on any job. 
To allow this new behaviour a service object: skills builder takes in skill ids selected and adds them to the user session. The skills builder validates if any skills are selected and if not returns the appropriate validation message. The skills builder also returns the list of ids of selected by user to be used in the checkboxes themselves to maintain what the user selected/didn't select

deployed for testing: https://dev3.nrs-ghtr.org.uk