### PR TITLE
GET-363 Separate different job profiles in skill builder

### DIFF
--- a/app/controllers/job_profiles_skills_controller.rb
+++ b/app/controllers/job_profiles_skills_controller.rb
@@ -21,7 +21,7 @@ class JobProfilesSkillsController < ApplicationController
   def skills_builder
     @skills_builder ||= SkillsBuilder.new(
       skills_params: skills_params[:skill_ids],
-      job_profile_skills: job_profile.skills,
+      job_profile: job_profile,
       user_session: session
     )
   end

--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -2,7 +2,7 @@ class SkillsController < ApplicationController
   def index
     if Flipflop.skills_builder?
       job_profile
-      @skills = Skill.find(session[:skill_ids])
+      @skills = Skill.find(skill_ids)
       render 'index_v2'
     else
       @skills = job_profile.skills
@@ -15,6 +15,10 @@ class SkillsController < ApplicationController
     @job_profile ||= JobProfileDecorator.new(
       JobProfile.find_by(slug: skills_params[:job_profile_id])
     )
+  end
+
+  def skill_ids
+    session.fetch(:job_profile_skills, {})[job_profile.id.to_s] || []
   end
 
   def skills_params

--- a/app/models/skills_builder.rb
+++ b/app/models/skills_builder.rb
@@ -1,23 +1,26 @@
 class SkillsBuilder
   include ActiveModel::Validations
 
-  attr_reader :skills_params, :job_profile_skills, :user_session
+  attr_reader :skills_params, :job_profile, :user_session
   validate :skill_ids_presence
 
-  def initialize(skills_params:, job_profile_skills:, user_session:)
+  def initialize(skills_params:, job_profile:, user_session:)
     @skills_params = skills_params
-    @job_profile_skills = job_profile_skills
+    @job_profile = job_profile
     @user_session = user_session
+    @user_session[:job_profile_skills] = user_session[:job_profile_skills] || {}
   end
 
   def build
     return unless skills_params.present?
 
-    user_session[:skill_ids] = formatted_skill_params
+    user_session[:job_profile_skills][job_profile.id.to_s] = formatted_skill_params
   end
 
   def skill_ids
-    user_session[:skill_ids] || job_profile_skills.pluck(:id)
+    @skill_ids ||=
+      user_session[:job_profile_skills][job_profile.id.to_s] ||
+      job_profile.skills.pluck(:id)
   end
 
   private

--- a/app/views/job_profiles/skills/index.html.erb
+++ b/app/views/job_profiles/skills/index.html.erb
@@ -30,7 +30,7 @@
             <div class="govuk-checkboxes">
               <%= hidden_field_tag('skill_ids[]', nil, id: 'skill_ids') %>
               <%= hidden_field_tag('search', params[:search], id: 'search') %>
-              <% @skills_builder.job_profile_skills.each do |skill| %>
+              <% @skills_builder.job_profile.skills.each do |skill| %>
                 <div class="govuk-checkboxes__item">
                   <%= check_box_tag('skill_ids[]', skill.id, @skills_builder.skill_ids.include?(skill.id), id: dom_id(skill), class: 'govuk-checkboxes__input') %>
                   <%= label_tag(dom_id(skill), skill.name, class: 'govuk-label govuk-checkboxes__label') %>

--- a/spec/features/skills_builder_spec.rb
+++ b/spec/features/skills_builder_spec.rb
@@ -47,6 +47,30 @@ RSpec.feature 'Build your skills', type: :feature do
     expect(page).to have_selector('tbody tr', count: 2)
   end
 
+  scenario 'User selects skills but goes back to different job profile sees all skills selected' do
+    create(
+      :job_profile,
+      name: 'Assassin',
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics'),
+        create(:skill, name: 'Mastery of unarmed combat skill'),
+        create(:skill, name: 'License to kill')
+      ]
+    )
+
+    visit(check_your_skills_path)
+    fill_in('search', with: 'Hitman assassin')
+    find('.search-button').click
+    click_on('Hitman')
+    uncheck('Baldness', allow_label_click: true)
+    uncheck('License to kill', allow_label_click: true)
+    find('.govuk-button').click
+    click_on('Search results')
+    click_on('Assassin')
+
+    expect(page).to have_selector('input[checked="checked"]', count: 3)
+  end
+
   scenario 'skill builder requires at least one skill selected' do
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     uncheck('Chameleon-like blend in tactics', allow_label_click: true)

--- a/spec/features/task_list_spec.rb
+++ b/spec/features/task_list_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Tasks List', type: :feature do
   scenario 'User navigates to task list page' do
+    disable_feature! :location_eligibility
     visit(root_path)
     click_on('Start now')
 

--- a/spec/models/skills_builder_spec.rb
+++ b/spec/models/skills_builder_spec.rb
@@ -3,58 +3,104 @@ require 'rails_helper'
 RSpec.describe SkillsBuilder do
   describe '#build' do
     it 'does not set user_session if no skills params available' do
+      job_profile = create(:job_profile, skills: [create(:skill)])
       builder = described_class.new(
         skills_params: nil,
-        job_profile_skills: [create(:skill)],
+        job_profile: job_profile,
         user_session: {}
       )
-      builder.build
 
-      expect(builder.user_session).to be_empty
+      builder.build
+      expect(builder.user_session[:job_profile_skills]).to be_empty
     end
 
     it 'sets user_session to correct skills format if skills params available' do
+      job_profile = create(:job_profile, skills: [create(:skill)])
       builder = described_class.new(
         skills_params: %w[1 2],
-        job_profile_skills: [create(:skill)],
+        job_profile: job_profile,
         user_session: {}
       )
-      builder.build
 
-      expect(builder.user_session).to eq(skill_ids: [1, 2])
+      builder.build
+      expect(builder.user_session).to eq(job_profile_skills: { job_profile.id.to_s => [1, 2] })
     end
 
-    it 'ignores empty skill param ids when setting user_ession' do
+    it 'ignores empty skill param ids when setting user_session' do
+      job_profile = create(:job_profile, skills: [create(:skill)])
       builder = described_class.new(
         skills_params: ['1', ''],
-        job_profile_skills: [create(:skill)],
+        job_profile: job_profile,
         user_session: {}
       )
-      builder.build
 
-      expect(builder.user_session).to eq(skill_ids: [1])
+      builder.build
+      expect(builder.user_session).to eq(job_profile_skills: { job_profile.id.to_s => [1] })
     end
 
     it 'overrides existing user session with new skill param ids' do
+      job_profile = create(:job_profile, skills: [create(:skill)])
       builder = described_class.new(
         skills_params: ['1', '', '5', '6'],
-        job_profile_skills: [create(:skill)],
-        user_session: { skill_ids: [3, 4] }
+        job_profile: job_profile,
+        user_session: { job_profile_skills: { job_profile.id.to_s => [3, 4] } }
       )
-      builder.build
 
-      expect(builder.user_session).to eq(skill_ids: [1, 5, 6])
+      builder.build
+      expect(builder.user_session).to eq(job_profile_skills: { job_profile.id.to_s => [1, 5, 6] })
+    end
+
+    it 'handles existing user session with new skill param ids if another job profile present' do
+      job_profile1 = create(:job_profile, skills: [create(:skill)])
+      job_profile2 = create(:job_profile, skills: [create(:skill)])
+      builder = described_class.new(
+        skills_params: ['1', '', '5', '6'],
+        job_profile: job_profile2,
+        user_session: { job_profile_skills: { job_profile1.id.to_s => [3, 4] } }
+      )
+
+      builder.build
+      expect(builder.user_session).to eq(
+        job_profile_skills: {
+          job_profile1.id.to_s => [3, 4],
+          job_profile2.id.to_s => [1, 5, 6]
+        }
+      )
+    end
+
+    it 'updates existing user session with skill param ids if another job profile present' do
+      job_profile1 = create(:job_profile, skills: [create(:skill)])
+      job_profile2 = create(:job_profile, skills: [create(:skill)])
+      builder = described_class.new(
+        skills_params: ['1', '', '5', '6'],
+        job_profile: job_profile2,
+        user_session: {
+          job_profile_skills: {
+            job_profile1.id.to_s => [3, 4],
+            job_profile2.id.to_s => [3]
+          }
+        }
+      )
+
+      builder.build
+      expect(builder.user_session).to eq(
+        job_profile_skills: {
+          job_profile1.id.to_s => [3, 4],
+          job_profile2.id.to_s => [1, 5, 6]
+        }
+      )
     end
   end
 
   describe '#skill_ids' do
-    it 'returns all job profile skill ids if no user_session empty' do
+    it 'returns all job profile skill ids if no user_session' do
       skill1 = create(:skill)
       skill2 = create(:skill)
+      job_profile = create(:job_profile, skills: [skill1, skill2])
 
       builder = described_class.new(
         skills_params: nil,
-        job_profile_skills: [skill1, skill2],
+        job_profile: job_profile,
         user_session: {}
       )
 
@@ -65,37 +111,61 @@ RSpec.describe SkillsBuilder do
     it 'returns skill ids if user_session populated' do
       skill1 = create(:skill)
       skill2 = create(:skill)
-
+      job_profile = create(:job_profile, skills: [skill1, skill2])
       builder = described_class.new(
         skills_params: nil,
-        job_profile_skills: [skill1, skill2],
-        user_session: { skill_ids: [3, 4] }
+        job_profile: job_profile,
+        user_session: { job_profile_skills: { job_profile.id.to_s => [skill1.id] } }
       )
 
       builder.build
-      expect(builder.skill_ids).to eq([3, 4])
+      expect(builder.skill_ids).to eq([skill1.id])
     end
 
     it 'returns updated skill ids if skills_params populated' do
       skill1 = create(:skill)
       skill2 = create(:skill)
+      job_profile = create(:job_profile, skills: [skill1, skill2])
 
       builder = described_class.new(
         skills_params: ['1', '', '2'],
-        job_profile_skills: [skill1, skill2],
-        user_session: { skill_ids: [3, 4] }
+        job_profile: job_profile,
+        user_session: { job_profile_skills: { job_profile.id.to_s => [3, 4] } }
       )
 
       builder.build
       expect(builder.skill_ids).to eq([1, 2])
     end
+
+    it 'returns correct skill ids for given job profile if multiple job profiles saved' do
+      skill1 = create(:skill)
+      skill2 = create(:skill)
+      skill3 = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill1, skill2])
+      job_profile2 = create(:job_profile, skills: [skill1, skill3])
+
+      builder = described_class.new(
+        skills_params: [skill3.id.to_s, ''],
+        job_profile: job_profile2,
+        user_session: {
+          job_profile_skills: {
+            job_profile1.id.to_s => [skill1.id],
+            job_profile2.id.to_s => [skill1.id]
+          }
+        }
+      )
+
+      builder.build
+      expect(builder.skill_ids).to eq([skill3.id])
+    end
   end
 
   describe 'validation' do
     it 'is invalid if no skills selected' do
+      job_profile = create(:job_profile, skills: [create(:skill)])
       builder = described_class.new(
         skills_params: [''],
-        job_profile_skills: [create(:skill)],
+        job_profile: job_profile,
         user_session: {}
       )
 
@@ -103,9 +173,10 @@ RSpec.describe SkillsBuilder do
     end
 
     it 'is valid if skills selected' do
+      job_profile = create(:job_profile, skills: [create(:skill)])
       builder = described_class.new(
         skills_params: ['1', '', '4'],
-        job_profile_skills: [create(:skill)],
+        job_profile: job_profile,
         user_session: {}
       )
 


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-363

When a user navigates to a job profile and selects a list of skills, the scope of those skills are only to the job profile. If a user navigates back to the search results and picks a different job profile, they should see all skills ticked unless they have visited that page before. Moving towards a skills scoped to a job profile we make it easier to move to the skill builder v2 which will now only require FE changes only.

Note that because sessions change the format of hashes to JSON, all ids are changed to strings to make things consistent throughout

ready to test on https://dev2.nrs-ghtr.org.uk