### PR TITLE
Add the growth icon on the job profile details

### DIFF
--- a/app/decorators/job_profile_decorator.rb
+++ b/app/decorators/job_profile_decorator.rb
@@ -1,5 +1,6 @@
 # TODO: Most of the xpath expressions within this class will be migrated to JobProfileScraper over time
 # which should remove the need to disable rubocop rules here.
+# rubocop:disable Metrics/ClassLength
 class JobProfileDecorator < SimpleDelegator
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::NumberHelper
@@ -63,25 +64,27 @@ class JobProfileDecorator < SimpleDelegator
     @doc.to_html.gsub(%r{<a.*?>(.+?)</a>}, '\1').concat(separator_line)
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def growth_icon
     return '' unless growth
 
     return 'arrow-falling-icon' if growth <= -5
-    return 'arrow-stable-icon' if (growth > -5 && growth <= 5)
-    return 'arrow-growing-icon' if (growth > 5 && growth <= 50)
+    return 'arrow-stable-icon' if growth > -5 && growth <= 5
+    return 'arrow-growing-icon' if growth > 5 && growth <= 50
 
     'arrow-growing-strongly-icon'
   end
 
   def growth_type
     return unless growth
-    
+
     return 'Falling' if growth <= -5
-    return 'Stable' if (growth > -5 && growth <= 5)
-    return 'Growing' if (growth > 5 && growth <= 50)
+    return 'Stable' if growth > -5 && growth <= 5
+    return 'Growing' if growth > 5 && growth <= 50
 
     'Growing strongly'
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private
 
@@ -141,3 +144,4 @@ class JobProfileDecorator < SimpleDelegator
     content_tag :hr, nil, class: 'govuk-section-break govuk-section-break--m govuk-section-break--visible'
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/decorators/job_profile_decorator.rb
+++ b/app/decorators/job_profile_decorator.rb
@@ -63,6 +63,26 @@ class JobProfileDecorator < SimpleDelegator
     @doc.to_html.gsub(%r{<a.*?>(.+?)</a>}, '\1').concat(separator_line)
   end
 
+  def growth_icon
+    return '' unless growth
+
+    return 'arrow-falling-icon' if growth <= -5
+    return 'arrow-stable-icon' if (growth > -5 && growth <= 5)
+    return 'arrow-growing-icon' if (growth > 5 && growth <= 50)
+
+    'arrow-growing-strongly-icon'
+  end
+
+  def growth_type
+    return unless growth
+    
+    return 'Falling' if growth <= -5
+    return 'Stable' if (growth > -5 && growth <= 5)
+    return 'Growing' if (growth > 5 && growth <= 50)
+
+    'Growing strongly'
+  end
+
   private
 
   def html_body

--- a/app/views/job_profiles/_highlights.html.erb
+++ b/app/views/job_profiles/_highlights.html.erb
@@ -1,3 +1,4 @@
+<hr class="govuk-section-break--m govuk-section-break--visible govuk-!-margin-top-7">
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <div class="govuk-grid-row">
@@ -59,3 +60,4 @@
     </div>
   <% end %>
 </div>
+<hr class="govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-7">

--- a/app/views/job_profiles/_highlights.html.erb
+++ b/app/views/job_profiles/_highlights.html.erb
@@ -7,7 +7,7 @@
       </div>
       <div class="govuk-grid-column-three-quarters">
         <h4 class="govuk-heading-s govuk-!-margin-top-5">Average Salary</h4>
-        <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-3">
+        <hr class="govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-3 responsive-section-break">
         <ul class="govuk-list">
           <li>
             <%= @job_profile.salary_range %>
@@ -24,7 +24,7 @@
       </div>
       <div class="govuk-grid-column-three-quarters">
         <h4 class="govuk-heading-s govuk-!-margin-top-5">Typical hours</h4>
-        <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-3">
+        <hr class="govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-3 responsive-section-break">
         <p class="govuk-body"><span id="hours"><%= @job_profile.working_hours %></span> a week</p>
       </div>
     </div>
@@ -39,7 +39,7 @@
       </div>
       <div class="govuk-grid-column-three-quarters">
         <h4 class="govuk-heading-s govuk-!-margin-top-5">You could work</h4>
-        <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-3">
+        <hr class="govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-3 responsive-section-break">
         <p id="lifestyle" class="govuk-body"><%= @job_profile.working_hours_patterns %></p>
       </div>
     </div>
@@ -53,11 +53,11 @@
         </div>
         <div class="govuk-grid-column-three-quarters">
           <h4 class="govuk-heading-s govuk-!-margin-top-5">Recent job growth</h4>
-          <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-3">
+          <hr class="govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-3 responsive-section-break">
           <p id="lifestyle" class="govuk-body"><%= @job_profile.growth_type %></p>
         </div>
       </div>
     </div>
   <% end %>
 </div>
-<hr class="govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-7">
+<hr class="govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-7 govuk-!-margin-top-7">

--- a/app/views/job_profiles/_highlights.html.erb
+++ b/app/views/job_profiles/_highlights.html.erb
@@ -1,42 +1,61 @@
-<div class="govuk-grid-column-one-third">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-quarter govuk-!-margin-top-9 govuk-!-margin-bottom-6">
-      <div class="profile-highlights salary-icon"></div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-quarter govuk-!-margin-top-7 govuk-!-margin-bottom-6">
+        <div class="profile-highlights salary-icon"></div>
+      </div>
+      <div class="govuk-grid-column-three-quarters">
+        <h4 class="govuk-heading-s govuk-!-margin-top-5">Average Salary</h4>
+        <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-3">
+        <ul class="govuk-list">
+          <li>
+            <%= @job_profile.salary_range %>
+          </li>
+        </ul>
+      </div>
     </div>
-    <div class="govuk-grid-column-three-quarters">
-      <h4 class="govuk-heading-s govuk-!-margin-top-5">Average Salary</h4>
-      <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-3">
-      <ul class="govuk-list">
-        <li>
-          <%= @job_profile.salary_range %>
-        </li>
-      </ul>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-quarter govuk-!-margin-top-7 govuk-!-margin-bottom-6">
+        <div class="profile-highlights time-icon"></div>
+      </div>
+      <div class="govuk-grid-column-three-quarters">
+        <h4 class="govuk-heading-s govuk-!-margin-top-5">Typical hours</h4>
+        <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-3">
+        <p class="govuk-body"><span id="hours"><%= @job_profile.working_hours %></span> a week</p>
+      </div>
     </div>
   </div>
 </div>
 
-<div class="govuk-grid-column-one-third">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-quarter govuk-!-margin-top-9 govuk-!-margin-bottom-6">
-      <div class="profile-highlights calendar-icon"></div>
-    </div>
-    <div class="govuk-grid-column-three-quarters">
-      <h4 class="govuk-heading-s govuk-!-margin-top-5">Typical hours</h4>
-      <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-3">
-      <p class="govuk-body"><span id="hours"><%= @job_profile.working_hours %></span> a week</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-quarter govuk-!-margin-top-7 govuk-!-margin-bottom-6">
+        <div class="profile-highlights calendar-icon"></div>
+      </div>
+      <div class="govuk-grid-column-three-quarters">
+        <h4 class="govuk-heading-s govuk-!-margin-top-5">You could work</h4>
+        <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-3">
+        <p id="lifestyle" class="govuk-body"><%= @job_profile.working_hours_patterns %></p>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="govuk-grid-column-one-third">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-quarter govuk-!-margin-top-9 govuk-!-margin-bottom-6">
-      <div class="profile-highlights time-icon"></div>
+  <% if @job_profile.growth %>
+    <div class="govuk-grid-column-one-half">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-quarter govuk-!-margin-top-7 govuk-!-margin-bottom-6">
+          <div class="profile-highlights <%= @job_profile.growth_icon %>"></div>
+        </div>
+        <div class="govuk-grid-column-three-quarters">
+          <h4 class="govuk-heading-s govuk-!-margin-top-5">Recent job growth</h4>
+          <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-3">
+          <p id="lifestyle" class="govuk-body"><%= @job_profile.growth_type %></p>
+        </div>
+      </div>
     </div>
-    <div class="govuk-grid-column-three-quarters">
-      <h4 class="govuk-heading-s govuk-!-margin-top-5">You could work</h4>
-      <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-3">
-      <p id="lifestyle" class="govuk-body"><%= @job_profile.working_hours_patterns %></p>
-    </div>
-  </div>
+  <% end %>
 </div>

--- a/app/views/job_profiles/show.html.erb
+++ b/app/views/job_profiles/show.html.erb
@@ -21,12 +21,19 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <%= render 'relevant_sections' %>
-          <%= link_to('Find a training course', Flipflop.course_directory? ? training_hub_path : find_training_courses_path, class: 'govuk-button govuk-!-margin-top-6 govuk-!-margin-bottom-9') %>
-        </div>
-        <div class="govuk-grid-column-one-third govuk-!-padding-left-5 related-profiles-right-padding-0">
-          <%= render 'related_profiles' %>
+          <%= link_to('Back to top', '#', class: 'govuk-link') %>
         </div>
       </div>
+    </div>
+  </div>
+  <%= render 'shared/boost_job_prospects' %>
+  <div class="govuk-grid-column-one-third">
+    <div class="govuk-related-items govuk-!-padding-bottom-1 top-border__container">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-0"><%= t('what_you_can_do_next.title') %></h2>
+      <p class="govuk-body"><%= t('what_you_can_do_next.sub_title') %></p>
+      <p class="govuk-body">
+        <%= link_to t('what_you_can_do_next.cta_copy'), next_steps_path, class: 'govuk-button govuk-button-full govuk-!-margin-bottom-1' %>
+      </p>
     </div>
   </div>
   <%= render 'shared/contact_us' %>

--- a/app/views/job_profiles/show.html.erb
+++ b/app/views/job_profiles/show.html.erb
@@ -16,9 +16,7 @@
     <div class="govuk-grid-column-full govuk-!-padding-0">
       <%= render 'brief' %>
     </div>
-    <div class="govuk-grid-column-full extended-container govuk-!-padding-0  govuk-!-margin-bottom-6">
-      <%= render 'highlights' %>
-    </div>
+    <%= render 'highlights' %>
     <div class="govuk-grid-column-full govuk-!-padding-0 extended-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/app/views/shared/_boost_job_prospects.html.erb
+++ b/app/views/shared/_boost_job_prospects.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-grid-column-one-third">
+  <div class="govuk-related-items govuk-!-padding-bottom-1 top-border__container">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= t('boost_job_prospects.title') %></h2>
+    <p class="govuk-body-m govuk-!-margin-bottom-2"><%= t('boost_job_prospects.sub_title') %></p>
+    <p class="govuk-body">
+      <%= link_to t('boost_job_prospects.cta_copy'), training_hub_path, class: 'govuk-button govuk-button-full govuk-!-margin-bottom-1' %>
+    </p>
+  </div>
+</div>

--- a/app/webpacker/images/arrow_falling.svg
+++ b/app/webpacker/images/arrow_falling.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="40px" height="45px" viewBox="0 0 40 45" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 51.3 (57544) - http://www.bohemiancoding.com/sketch -->
+    <title>arrow_falling</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="arrow_falling" transform="translate(-3.000000, -5.000000)">
+            <polygon id="Shape" points="0 0 45 0 45 54 0 54"></polygon>
+            <g id="Group" transform="translate(23.000000, 27.500000) rotate(180.000000) translate(-23.000000, -27.500000) translate(3.000000, 5.000000)" fill="#000000" fill-rule="nonzero">
+                <polygon id="Triangle" points="20 0 40 22 0 22"></polygon>
+                <rect id="Rectangle" x="12" y="13" width="16" height="32"></rect>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/app/webpacker/images/arrow_growing.svg
+++ b/app/webpacker/images/arrow_growing.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="38px" height="39px" viewBox="0 0 38 39" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 51.3 (57544) - http://www.bohemiancoding.com/sketch -->
+    <title>arrow_growing</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="arrow_growing" transform="translate(-9.000000, -14.000000)">
+            <g id="Group" transform="translate(31.000000, 30.500000) rotate(45.000000) translate(-31.000000, -30.500000) translate(11.000000, 8.000000)" fill="#000000" fill-rule="nonzero">
+                <polygon id="Triangle" points="20 0 40 22 0 22"></polygon>
+                <rect id="Rectangle" x="12" y="13" width="16" height="32"></rect>
+            </g>
+            <polygon id="Shape" points="6 3 51 3 51 57 6 57"></polygon>
+        </g>
+    </g>
+</svg>

--- a/app/webpacker/images/arrow_growing_strongly.svg
+++ b/app/webpacker/images/arrow_growing_strongly.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="40px" height="45px" viewBox="0 0 40 45" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 51.3 (57544) - http://www.bohemiancoding.com/sketch -->
+    <title>growing_strongly</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="growing_strongly" transform="translate(-3.000000, -5.000000)">
+            <polygon id="Shape" points="0 0 45 0 45 54 0 54"></polygon>
+            <polygon id="Triangle" fill="#000000" points="23 5 43 27 3 27"></polygon>
+            <rect id="Rectangle" fill="#000000" x="15" y="18" width="16" height="32"></rect>
+        </g>
+    </g>
+</svg>

--- a/app/webpacker/images/arrow_stable.svg
+++ b/app/webpacker/images/arrow_stable.svg
@@ -1,0 +1,1 @@
+<svg height="41" viewBox="0 0 46 41" width="46" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" transform="translate(0 -7)"><g fill="#000" fill-rule="nonzero" transform="matrix(0 1 -1 0 45.5 7.5)"><path d="m20 0 20 22h-40z"/><path d="m12 13h16v32h-16z"/></g><path d="m0 0h45v54h-45z"/></g></svg>

--- a/app/webpacker/styles/_job-profile.scss
+++ b/app/webpacker/styles/_job-profile.scss
@@ -82,43 +82,72 @@
   height: 55px;
 }
 
+%responsive-icon {
+  @include govuk-media-query($from: mobile, $until: tablet) {
+    float: left;
+    margin-right: 20px;
+    height: 62px;
+  }
+}
+
+.responsive-section-break {
+  @include govuk-media-query($from: mobile, $until: tablet) {
+    width: 40%;
+    margin-left: 0px;
+  }
+}
+
 .salary-icon {
+  @extend %responsive-icon;
+
   background: url('../images/pound.svg');
   background-position: center;
   background-repeat: no-repeat;
 }
 
 .calendar-icon {
+  @extend %responsive-icon;
+
   background: url('../images/cal.svg');
   background-position: center;
   background-repeat: no-repeat;
 }
 
 .time-icon {
+  @extend %responsive-icon;
+
   background: url('../images/time.svg');
   background-position: center;
   background-repeat: no-repeat;
 }
 
 .arrow-falling-icon {
+  @extend %responsive-icon;
+
   background: url('../images/arrow_falling.svg');
   background-position: center;
   background-repeat: no-repeat;
 }
 
 .arrow-growing-icon {
+  @extend %responsive-icon;
+
   background: url('../images/arrow_growing.svg');
   background-position: center;
   background-repeat: no-repeat;
 }
 
 .arrow-growing-strongly-icon {
+  @extend %responsive-icon;
+
   background: url('../images/arrow_growing_strongly.svg');
   background-position: center;
   background-repeat: no-repeat;
 }
 
 .arrow-stable-icon {
+  @extend %responsive-icon;
+
   background: url('../images/arrow_stable.svg');
   background-position: center;
   background-repeat: no-repeat;

--- a/app/webpacker/styles/_job-profile.scss
+++ b/app/webpacker/styles/_job-profile.scss
@@ -93,7 +93,7 @@
 .responsive-section-break {
   @include govuk-media-query($from: mobile, $until: desktop) {
     width: 40%;
-    margin-left: 0px;
+    margin-left: 0;
   }
 }
 

--- a/app/webpacker/styles/_job-profile.scss
+++ b/app/webpacker/styles/_job-profile.scss
@@ -7,6 +7,10 @@
   }
 }
 
+.govuk-button-full {
+  width: 100%;
+}
+
 .search-button,
 %search-button {
   cursor: pointer;

--- a/app/webpacker/styles/_job-profile.scss
+++ b/app/webpacker/styles/_job-profile.scss
@@ -83,7 +83,7 @@
 }
 
 %responsive-icon {
-  @include govuk-media-query($from: mobile, $until: tablet) {
+  @include govuk-media-query($from: mobile, $until: desktop) {
     float: left;
     margin-right: 20px;
     height: 62px;
@@ -91,7 +91,7 @@
 }
 
 .responsive-section-break {
-  @include govuk-media-query($from: mobile, $until: tablet) {
+  @include govuk-media-query($from: mobile, $until: desktop) {
     width: 40%;
     margin-left: 0px;
   }

--- a/app/webpacker/styles/_job-profile.scss
+++ b/app/webpacker/styles/_job-profile.scss
@@ -96,6 +96,30 @@
   background-repeat: no-repeat;
 }
 
+.arrow-falling-icon {
+  background: url('../images/arrow_falling.svg');
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.arrow-growing-icon {
+  background: url('../images/arrow_growing.svg');
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.arrow-growing-strongly-icon {
+  background: url('../images/arrow_growing_strongly.svg');
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.arrow-stable-icon {
+  background: url('../images/arrow_stable.svg');
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
 .extended-container {
   @include govuk-media-query($from: tablet) {
     width: 150% !important;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,7 +104,12 @@ en-GB:
       title: No courses are available in your area yet
   what_you_can_do_next:
     title: Further help to find work
-    body: Other ways to change jobs
+    sub_title: Support to move into a new role.
+    cta_copy: Other ways to change jobs
+  boost_job_prospects:
+    title: Boost your job prospects
+    sub_title: Access free and flexible training that improves your job options.
+    cta_copy: Find a training course
   help_improve_this_service:
     title: Help improve this service
     body: Take a quick survey and tell us about your experience

--- a/spec/decorators/job_profile_decorator_spec.rb
+++ b/spec/decorators/job_profile_decorator_spec.rb
@@ -57,14 +57,13 @@ RSpec.describe JobProfileDecorator do
     end
 
     context 'when the job profile has no growth score' do
-      let(:model) { build_stubbed :job_profile, growth: nil}
+      let(:model) { build_stubbed :job_profile, growth: nil }
 
       it 'returns an empty css class' do
         expect(job_profile.growth_icon).to eq ''
       end
     end
   end
-
 
   describe '#growth_type' do
     context 'when the job is falling' do

--- a/spec/decorators/job_profile_decorator_spec.rb
+++ b/spec/decorators/job_profile_decorator_spec.rb
@@ -23,6 +23,91 @@ RSpec.describe JobProfileDecorator do
     end
   end
 
+  describe '#growth_icon' do
+    context 'when the job is falling' do
+      let(:model) { build(:job_profile, :falling) }
+
+      it 'returns a falling arrow css class' do
+        expect(job_profile.growth_icon).to eq 'arrow-falling-icon'
+      end
+    end
+
+    context 'when the job is stable' do
+      let(:model) { build(:job_profile, :stable) }
+
+      it 'returns a stable arrow css class' do
+        expect(job_profile.growth_icon).to eq 'arrow-stable-icon'
+      end
+    end
+
+    context 'when the job is growing' do
+      let(:model) { build(:job_profile, :growing) }
+
+      it 'returns a growing arrow css class' do
+        expect(job_profile.growth_icon).to eq 'arrow-growing-icon'
+      end
+    end
+
+    context 'when the job is growing strongly' do
+      let(:model) { build(:job_profile, :growing_strongly) }
+
+      it 'returns a growing strongly arrow css class' do
+        expect(job_profile.growth_icon).to eq 'arrow-growing-strongly-icon'
+      end
+    end
+
+    context 'when the job profile has no growth score' do
+      let(:model) { build_stubbed :job_profile, growth: nil}
+
+      it 'returns an empty css class' do
+        expect(job_profile.growth_icon).to eq ''
+      end
+    end
+  end
+
+
+  describe '#growth_type' do
+    context 'when the job is falling' do
+      let(:model) { build(:job_profile, :falling) }
+
+      it 'returns the type falling' do
+        expect(job_profile.growth_type).to eq 'Falling'
+      end
+    end
+
+    context 'when the job is stable' do
+      let(:model) { build(:job_profile, :stable) }
+
+      it 'returns the type stable' do
+        expect(job_profile.growth_type).to eq 'Stable'
+      end
+    end
+
+    context 'when the job is growing' do
+      let(:model) { build(:job_profile, :growing) }
+
+      it 'returns the type growing' do
+        expect(job_profile.growth_type).to eq 'Growing'
+      end
+    end
+
+    context 'when the job is growing strongly' do
+      let(:model) { build(:job_profile, :growing_strongly) }
+
+      it 'returns the type growing strongly' do
+        expect(job_profile.growth_type).to eq 'Growing strongly'
+      end
+    end
+
+    context 'when the job is missing the growth score' do
+      let(:model) { build(:job_profile, growth: nil) }
+
+      it 'returns nil' do
+        expect(job_profile.growth_type).to be nil
+      end
+    end
+  end
+
   describe '#working_hours' do
     let(:html_body) do
       '<div id="WorkingHours" class="column-30 job-profile-heroblock">

--- a/spec/factories/job_profiles.rb
+++ b/spec/factories/job_profiles.rb
@@ -12,6 +12,22 @@ FactoryBot.define do
       recommended { true }
     end
 
+    trait :falling do
+      growth { -7.45 }
+    end
+
+    trait :stable do
+      growth { 4.56 }
+    end
+
+    trait :growing do
+      growth { 9.89 }
+    end
+
+    trait :growing_strongly do
+      growth { 51.22 }
+    end
+
     trait :with_html_content do
       template = Rails.root.join('spec', 'fixtures', 'files', 'job_profile_content.html.erb').read
 

--- a/spec/features/explore_occupations_spec.rb
+++ b/spec/features/explore_occupations_spec.rb
@@ -44,14 +44,7 @@ RSpec.feature 'Explore Occupations', type: :feature do
     expect(page).to have_text('0 results')
   end
 
-  scenario 'User continues journey to finding a training course' do
-    visit(job_profile_path(job_profile.slug))
-    click_on('Find a training course')
-
-    expect(page).to have_text('Find and apply to a training course near you')
-  end
-
-  scenario 'User continues journey to training hub if course feature enabled' do
+  scenario 'User continues journey to training hub' do
     enable_feature! :course_directory
 
     visit(job_profile_path(job_profile.slug))


### PR DESCRIPTION
### Context

We've got 4 different growth icons marking the growth prospects
depending on the growth metric as follows:

n ≤ -5 - falling
-5 < n ≤ 5 - stable
5 < n ≤ 50 - growing
n > 50 - growing strongly

Also redesign the highlights section on the same page.

### Screenshots

<img width="1005" alt="Screen Shot 2019-08-13 at 13 56 17" src="https://user-images.githubusercontent.com/1955084/62943237-e89e1700-bdd1-11e9-8bea-ff06fbf6d668.png">

![Screen Shot 2019-08-13 at 15 48 17](https://user-images.githubusercontent.com/1955084/62951259-8c42f380-bde1-11e9-951f-ac486a3b437d.png)

![Screen Shot 2019-08-13 at 16 45 51](https://user-images.githubusercontent.com/1955084/62956368-bc42c480-bdea-11e9-9eb6-5fa2345cb3c4.png)

### JIRA

https://dfedigital.atlassian.net/browse/GET-317