### PR TITLE
Update the build name on first stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,8 @@ stages:
       - script: |
           gateway_ip=$(docker network inspect bridge --format='{{range .IPAM.Config}}{{.Gateway}}{{end}}')
           echo "##vso[task.setvariable variable=GatewayIP;]$gateway_ip"
+          git_sha=$(git rev-parse --short HEAD)
+          echo "##vso[build.updatebuildnumber]$git_sha"
         displayName: 'Set Task Variables'
 
       - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,10 +125,6 @@ stages:
       vmImage: 'ubuntu-16.04'
 
     steps:
-      - script: |
-          git_sha=$(git rev-parse --short HEAD)
-        displayName: 'Set Image Tags'
-
       - task: Docker@1
         displayName: Docker Hub login
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,7 +127,6 @@ stages:
     steps:
       - script: |
           git_sha=$(git rev-parse --short HEAD)
-          echo "##vso[build.updatebuildnumber]$git_sha"
         displayName: 'Set Image Tags'
 
       - task: Docker@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -196,8 +196,8 @@ stages:
   condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/master'))
 
   jobs:
-    - job: CI
-      displayName: Deploy to CI
+    - job: QA
+      displayName: Deploy to QA
       pool:
         vmImage: 'vs2017-win2016'
 


### PR DESCRIPTION
Update the build name on first stage.
The pipeline name is not being updated on first stage, so it keeps the internal ID until stage 'build' 

