### PR TITLE
GET-232 skill matcher

### DIFF
--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -1,8 +1,9 @@
 class SkillsController < ApplicationController
   def index
     if Flipflop.skills_builder?
-      job_profile
+      session[:current_job_id] = job_profile.id
       @skills = Skill.find(skill_ids)
+
       render 'index_v2'
     else
       @skills = job_profile.skills

--- a/app/controllers/skills_matcher_controller.rb
+++ b/app/controllers/skills_matcher_controller.rb
@@ -1,6 +1,6 @@
 class SkillsMatcherController < ApplicationController
   def index
-    @results = skills_matcher.match.page(params[:page])
+    @results = Kaminari.paginate_array(skills_matcher.match).page(params[:page]).per(10)
     @scores = skills_matcher.job_profile_scores
     @job_profiles = @results.map { |job_profile|
       JobProfileDecorator.new(job_profile)

--- a/app/controllers/skills_matcher_controller.rb
+++ b/app/controllers/skills_matcher_controller.rb
@@ -1,0 +1,8 @@
+class SkillsMatcherController < ApplicationController
+  def index
+    @results = JobProfile.all.includes(:categories).page(params[:page])
+    @job_profiles = @results.map { |job_profile|
+      JobProfileDecorator.new(job_profile)
+    }
+  end
+end

--- a/app/controllers/skills_matcher_controller.rb
+++ b/app/controllers/skills_matcher_controller.rb
@@ -1,8 +1,15 @@
 class SkillsMatcherController < ApplicationController
   def index
-    @results = JobProfile.all.includes(:categories).page(params[:page])
+    @results = skills_matcher.match.page(params[:page])
+    @scores = skills_matcher.job_profile_scores
     @job_profiles = @results.map { |job_profile|
       JobProfileDecorator.new(job_profile)
     }
+  end
+
+  private
+
+  def skills_matcher
+    @skills_matcher ||= SkillsMatcher.new(user_session: session)
   end
 end

--- a/app/controllers/skills_matcher_controller.rb
+++ b/app/controllers/skills_matcher_controller.rb
@@ -1,6 +1,6 @@
 class SkillsMatcherController < ApplicationController
   def index
-    @results = Kaminari.paginate_array(skills_matcher.match).page(params[:page]).per(10)
+    @results = Kaminari.paginate_array(skills_matcher.match).page(params[:page])
     @scores = skills_matcher.job_profile_scores
     @job_profiles = @results.map { |job_profile|
       JobProfileDecorator.new(job_profile)

--- a/app/decorators/job_profile_decorator.rb
+++ b/app/decorators/job_profile_decorator.rb
@@ -89,13 +89,13 @@ class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLengt
     return unless score
 
     if score <= 25
-      'low'
+      'Low'
     elsif score > 25 && score <= 50
-      'reasonable'
+      'Reasonable'
     elsif score > 50 && score <= 75
-      'good'
+      'Good'
     elsif score > 75
-      'excellent'
+      'Excellent'
     end
   end
 

--- a/app/decorators/job_profile_decorator.rb
+++ b/app/decorators/job_profile_decorator.rb
@@ -85,6 +85,20 @@ class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLengt
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 
+  def skills_match(score) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    return unless score
+
+    if score <= 25
+      'low'
+    elsif score > 25 && score <= 50
+      'reasonable'
+    elsif score > 50 && score <= 75
+      'good'
+    elsif score > 75
+      'excellent'
+    end
+  end
+
   private
 
   def html_body

--- a/app/decorators/job_profile_decorator.rb
+++ b/app/decorators/job_profile_decorator.rb
@@ -1,7 +1,6 @@
 # TODO: Most of the xpath expressions within this class will be migrated to JobProfileScraper over time
 # which should remove the need to disable rubocop rules here.
-# rubocop:disable Metrics/ClassLength
-class JobProfileDecorator < SimpleDelegator
+class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLength
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::NumberHelper
 
@@ -144,4 +143,3 @@ class JobProfileDecorator < SimpleDelegator
     content_tag :hr, nil, class: 'govuk-section-break govuk-section-break--m govuk-section-break--visible'
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/models/skills_matcher.rb
+++ b/app/models/skills_matcher.rb
@@ -13,8 +13,9 @@ class SkillsMatcher
   end
 
   def job_profile_scores
+    user_skills_ids_count = user_skill_ids.count
     @job_profile_scores ||= build_query.each_with_object({}) do |job_profile, hash|
-      hash[job_profile.id] = job_profile.skills_matched.to_f / user_skill_ids.count * 100
+      hash[job_profile.id] = job_profile.skills_matched.to_f / user_skills_ids_count * 100
     end
   end
 
@@ -22,7 +23,7 @@ class SkillsMatcher
 
   def job_profile_skills_subquery
     JobProfileSkill
-      .select('job_profile_id, COUNT(job_profile_id) AS skills_matched')
+      .select(:job_profile_id, 'COUNT(job_profile_id) AS skills_matched')
       .where(skill_id: user_skill_ids)
       .group(:job_profile_id)
       .to_sql
@@ -30,12 +31,12 @@ class SkillsMatcher
 
   def job_profiles_subquery
     JobProfile
-      .select('skills_matched, array_agg(id order by name ASC) as alphabetically_ordered_ids')
-      .from("(#{job_profile_skills_subquery}) as ranked_job_profiles")
-      .joins('LEFT OUTER JOIN "job_profiles" ON "job_profiles"."id" = "ranked_job_profiles"."job_profile_id"')
+      .select(:skills_matched, 'array_agg(id order by name ASC) as alphabetically_ordered_ids')
+      .from(Arel.sql("(#{job_profile_skills_subquery}) as ranked_job_profiles"))
+      .joins('LEFT JOIN job_profiles ON job_profiles.id = ranked_job_profiles.job_profile_id')
       .where.not(id: user_job_profile_ids)
       .group(:skills_matched)
-      .order('skills_matched desc')
+      .order(skills_matched: :desc)
       .to_sql
   end
 
@@ -45,11 +46,13 @@ class SkillsMatcher
         .select(
           :skills_matched, :id, :name, :description, :alternative_titles, :salary_min, :salary_max, :slug, :growth
         )
-        .from(
-          "(#{job_profiles_subquery}) as ordered_query, unnest(alphabetically_ordered_ids) WITH ORDINALITY ordered_id"
-        )
-        .joins('LEFT JOIN "job_profiles" ON "job_profiles"."id" = "ordered_id"')
+        .from(Arel.sql(job_profile_ids_unnest_query))
+        .joins('LEFT JOIN job_profiles ON job_profiles.id = ordered_id')
     end
+  end
+
+  def job_profile_ids_unnest_query
+    "(#{job_profiles_subquery}) as ordered_query, unnest(alphabetically_ordered_ids) WITH ORDINALITY ordered_id"
   end
 
   def user_skill_ids

--- a/app/models/skills_matcher.rb
+++ b/app/models/skills_matcher.rb
@@ -1,9 +1,8 @@
 class SkillsMatcher
   attr_reader :user_session, :job_profile_id
 
-  def initialize(user_session:, job_profile_id: nil)
+  def initialize(user_session:)
     @user_session = user_session
-    @job_profile_id = job_profile_id
   end
 
   def match
@@ -56,14 +55,18 @@ class SkillsMatcher
   end
 
   def user_skill_ids
-    return user_session[:job_profile_skills][job_profile_id] if job_profile_id.present?
+    return user_session[:job_profile_skills][current_job_id.to_s] if current_job_id.present?
 
     user_session[:job_profile_skills].values.flatten.uniq
   end
 
   def user_job_profile_ids
-    return [job_profile_id.to_i] if job_profile_id.present?
+    return [current_job_id] if current_job_id.present?
 
     user_session[:job_profile_skills].keys.flatten.map(&:to_i)
+  end
+
+  def current_job_id
+    user_session[:current_job_id]
   end
 end

--- a/app/models/skills_matcher.rb
+++ b/app/models/skills_matcher.rb
@@ -1,0 +1,66 @@
+class SkillsMatcher
+  attr_reader :user_session, :job_profile_id
+
+  def initialize(user_session:, job_profile_id: nil)
+    @user_session = user_session
+    @job_profile_id = job_profile_id
+  end
+
+  def match
+    return JobProfile.none unless user_session[:job_profile_skills].present?
+
+    build_query
+  end
+
+  def job_profile_scores
+    @job_profile_scores ||= build_query.each_with_object({}) do |job_profile, hash|
+      hash[job_profile.id] = job_profile.skills_matched.to_f / user_skill_ids.count * 100
+    end
+  end
+
+  private
+
+  def job_profile_skills_subquery
+    JobProfileSkill
+      .select('job_profile_id, COUNT(job_profile_id) AS skills_matched')
+      .where(skill_id: user_skill_ids)
+      .group(:job_profile_id)
+      .to_sql
+  end
+
+  def job_profiles_subquery
+    JobProfile
+      .select('skills_matched, array_agg(id order by name ASC) as alphabetically_ordered_ids')
+      .from("(#{job_profile_skills_subquery}) as ranked_job_profiles")
+      .joins('LEFT OUTER JOIN "job_profiles" ON "job_profiles"."id" = "ranked_job_profiles"."job_profile_id"')
+      .where.not(id: user_job_profile_ids)
+      .group(:skills_matched)
+      .order('skills_matched desc')
+      .to_sql
+  end
+
+  def build_query
+    @build_query ||= begin
+      JobProfile
+        .select(
+          :skills_matched, :id, :name, :description, :alternative_titles, :salary_min, :salary_max, :slug, :growth
+        )
+        .from(
+          "(#{job_profiles_subquery}) as ordered_query, unnest(alphabetically_ordered_ids) WITH ORDINALITY ordered_id"
+        )
+        .joins('LEFT JOIN "job_profiles" ON "job_profiles"."id" = "ordered_id"')
+    end
+  end
+
+  def user_skill_ids
+    return user_session[:job_profile_skills][job_profile_id] if job_profile_id.present?
+
+    user_session[:job_profile_skills].values.flatten.uniq
+  end
+
+  def user_job_profile_ids
+    return [job_profile_id.to_i] if job_profile_id.present?
+
+    user_session[:job_profile_skills].keys.flatten.map(&:to_i)
+  end
+end

--- a/app/views/job_profiles/show.html.erb
+++ b/app/views/job_profiles/show.html.erb
@@ -1,13 +1,23 @@
 <% page_title :job_profiles_show %>
 <% content_for :breadcrumb do
-    generate_breadcrumbs(
-      t('breadcrumb.job_profile'),
-      [
-        [t('breadcrumb.task_list_home'), task_list_path],
-        [t('breadcrumb.explore_occupations'), explore_occupations_path],
-        job_profile_breadcrumbs_for(params)
-      ]
-    )
+    if Flipflop.skills_builder?
+      generate_breadcrumbs(
+        t('breadcrumb.job_profile'),
+        [
+          [t('breadcrumb.task_list_home'), task_list_path],
+          [t('breadcrumb.job_matches'), skills_matcher_index_path],
+        ]
+      )
+    else
+      generate_breadcrumbs(
+        t('breadcrumb.job_profile'),
+        [
+          [t('breadcrumb.task_list_home'), task_list_path],
+          [t('breadcrumb.explore_occupations'), explore_occupations_path],
+          job_profile_breadcrumbs_for(params)
+        ]
+      )
+    end
   end
 %>
 

--- a/app/views/pages/task_list.html.erb
+++ b/app/views/pages/task_list.html.erb
@@ -38,7 +38,7 @@
         <ul class="app-task-list__items">
           <li class="app-task-list__item">
             <div class="app-task-list__task-name">
-              <%= link_to explore_occupations_path, class: 'govuk-link' do %>
+              <%= link_to Flipflop.skills_builder? ? skills_matcher_index_path : explore_occupations_path, class: 'govuk-link' do %>
                 Search for the types of jobs you could retrain to do <span class="app-step-nav__context">5 to 20 minutes</span>
               <% end %>
               <p class="govuk-body govuk-!-margin-bottom-0">These are not live jobs you can apply to – they're the types of jobs you'll be able to do with your existing skills or once you do some training.</p>

--- a/app/views/skills/index_v2.html.erb
+++ b/app/views/skills/index_v2.html.erb
@@ -34,7 +34,7 @@
           <% end %>
         </tbody>
       </table>
-      <%= link_to('Find out what you can do with these skills', skills_matcher_index_path(job_profile_id: @job_profile.id), class: 'govuk-button') %>
+      <%= link_to('Find out what you can do with these skills', skills_matcher_index_path, class: 'govuk-button') %>
     </div>
   </div>
 

--- a/app/views/skills/index_v2.html.erb
+++ b/app/views/skills/index_v2.html.erb
@@ -34,8 +34,7 @@
           <% end %>
         </tbody>
       </table>
-      <!-- TODO amend in skill matcher story -->
-      <%= link_to('Find out what you can do with these skills', '#', class: 'govuk-button') %>
+      <%= link_to('Find out what you can do with these skills', skills_matcher_index_path(job_profile_id: @job_profile.id), class: 'govuk-button') %>
     </div>
   </div>
 

--- a/app/views/skills_matcher/_job_matches.html.erb
+++ b/app/views/skills_matcher/_job_matches.html.erb
@@ -11,7 +11,7 @@
       <p class="govuk-body-s govuk-!-margin-bottom-1">Salary: <span class="strong"><%= job_profile.salary_range %></span></p>
       <p class="govuk-body-s govuk-!-margin-bottom-1">Skills match: <span class="strong"><%= job_profile.skills_match(@scores[job_profile.id]) %></span></p>
       <% if job_profile.growth.present? %>
-        <p class="govuk-body-s govuk-!-margin-bottom-1">Recent job growth: <span class="strong"><%= job_profile.recent_job_growth %></span></p>
+        <p class="govuk-body-s govuk-!-margin-bottom-1">Recent job growth: <span class="strong"><%= job_profile.growth_type %></span></p>
       <% end %>
     </li>
   <% end %>

--- a/app/views/skills_matcher/_job_matches.html.erb
+++ b/app/views/skills_matcher/_job_matches.html.erb
@@ -1,0 +1,18 @@
+<ul class="govuk-list">
+  <% job_profiles.each do |job_profile| %>
+    <li class="govuk-!-padding-bottom-1">
+      <h3 class="govuk-!-margin-bottom-0">
+         <%= link_to job_profile.name, job_profile_path(job_profile.slug, search: params[:search]), class: 'govuk-link no-text-decoration' %>
+      </h3>
+      <% if job_profile.alternative_titles.present? %>
+        <p class="govuk-body-s govuk-!-margin-bottom-2 muted-text"><%= job_profile.alternative_titles %></p>
+      <% end %>
+      <p class="govuk-!-margin-0 govuk-!-margin-bottom-3"><%= job_profile.description %></p>
+      <p class="govuk-body-s govuk-!-margin-bottom-1">Salary: <span class="strong"><%= job_profile.salary_range %></span></p>
+      <p class="govuk-body-s govuk-!-margin-bottom-1">Skills match: <span class="strong"><%= job_profile.salary_range %></span></p>
+      <% if job_profile.growth %>
+        <p class="govuk-body-s govuk-!-margin-bottom-1">Recent job growth: <span class="strong"><%= job_profile.recent_job_growth %></span></p>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/skills_matcher/_job_matches.html.erb
+++ b/app/views/skills_matcher/_job_matches.html.erb
@@ -9,8 +9,8 @@
       <% end %>
       <p class="govuk-!-margin-0 govuk-!-margin-bottom-3"><%= job_profile.description %></p>
       <p class="govuk-body-s govuk-!-margin-bottom-1">Salary: <span class="strong"><%= job_profile.salary_range %></span></p>
-      <p class="govuk-body-s govuk-!-margin-bottom-1">Skills match: <span class="strong"><%= job_profile.salary_range %></span></p>
-      <% if job_profile.growth %>
+      <p class="govuk-body-s govuk-!-margin-bottom-1">Skills match: <span class="strong"><%= job_profile.skills_match(@scores[job_profile.id]) %></span></p>
+      <% if job_profile.growth.present? %>
         <p class="govuk-body-s govuk-!-margin-bottom-1">Recent job growth: <span class="strong"><%= job_profile.recent_job_growth %></span></p>
       <% end %>
     </li>

--- a/app/views/skills_matcher/index.html.erb
+++ b/app/views/skills_matcher/index.html.erb
@@ -1,0 +1,23 @@
+<% page_title :skills_matcher_index %>
+<% content_for :breadcrumb do
+    generate_breadcrumbs(
+      t('breadcrumb.job_matches'),
+      [
+        [t('breadcrumb.task_list_home'), task_list_path]
+      ]
+    )
+  end
+%>
+
+<div class="govuk-grid-row govuk-!-margin-top-7">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
+    <p class="govuk-body">You may already have many of the skills to do these types of job. Click into each job title to understand what additional training you might need.</p>
+    <p class="govuk-body">You’ll see information about whether job numbers have been growing or falling in recent years. If job numbers are growing it may mean you’re more likely to find work doing this job and it’s more likely to be secure.</p>
+    <%= render "job_matches", job_profiles: @job_profiles %>
+    <div class="govuk-grid-column-full govuk-!-padding-top-6 govuk-!-margin-bottom-4 govuk-!-margin-top-6 pagination__section">
+      <%= paginate @results %>
+    </div>
+  </div>
+  <%= render "shared/contact_us" %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en-GB:
     task_list_home: 'Home: Get help to retrain'
     check_your_skills: Check your existing skills
     explore_occupations: Explore occupations
+    job_matches: Your job matches
     find_training_courses: Find training
     next_steps: Next steps
     job_category: Job category
@@ -27,6 +28,7 @@ en-GB:
     check_your_skills_results: Get help to retrain - Check your skills results
     skills_index: Get help to retrain - Your skills
     skills_current_job_skills: Get help to retrain - Current job skills
+    skills_matcher_index: Get help to retrain - Your job matches
     explore_occupations_index: Get help to retrain - Explore occupations
     categories_show: Get help to retrain - Job category
     explore_occupations_results: Get help to retrain - Explore occupations results
@@ -52,7 +54,7 @@ en-GB:
 
   contact_us:
     title: Speak to an adviser
-    sub_title: Get advice on finding work and training. 
+    sub_title: Get advice on finding work and training.
     by_phone: By phone
     body: Call
     telephone: 0800 051 0459
@@ -78,6 +80,9 @@ en-GB:
       title: Your current job
       placeholder: Enter your current job title
       body: Click the job title that best matches what you do now.
+  skills_matcher:
+    index:
+      title: Types of jobs that match your skills
   categories:
     show:
       other_categories: Other job categories

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :skills_matcher, path: 'job-matches', only: %i[index], constraints: ->(_req) { Flipflop.skills_builder? }
   resources :skills, only: %i[index], constraints: ->(_req) { Flipflop.skills_builder? }
 
   resources :explore_occupations, path: 'explore-occupations', only: %i[index] do

--- a/spec/decorators/job_profile_decorator_spec.rb
+++ b/spec/decorators/job_profile_decorator_spec.rb
@@ -249,35 +249,27 @@ RSpec.describe JobProfileDecorator do
     end
   end
 
-  describe '#recent_job_growth' do
-    it 'returns nothing if job growth is not populated' do
-      model = build(:job_profile, growth: nil)
-      job_profile = described_class.new(model)
-      expect(job_profile.recent_job_growth).to be_nil
+  describe '#skills_match' do
+    subject(:job_profile) { described_class.new(build(:job_profile)) }
+
+    it 'returns nothing if no score given' do
+      expect(job_profile.skills_match(nil)).to be_nil
     end
 
-    it 'returns failing if job growth is less than 5' do
-      model = build(:job_profile, growth: -7.12)
-      job_profile = described_class.new(model)
-      expect(job_profile.recent_job_growth).to eq('falling')
+    it 'returns Low if score is less than 25' do
+      expect(job_profile.skills_match(23.333)).to eq('Low')
     end
 
-    it 'returns stable if job growth is between -5 and 5' do
-      model = build(:job_profile, growth: 0.01)
-      job_profile = described_class.new(model)
-      expect(job_profile.recent_job_growth).to eq('stable')
+    it 'returns Reasonable if score is between 25 and 50' do
+      expect(job_profile.skills_match(45.55)).to eq('Reasonable')
     end
 
-    it 'returns growing if job growth is between 5 and 50' do
-      model = build(:job_profile, growth: 10.1)
-      job_profile = described_class.new(model)
-      expect(job_profile.recent_job_growth).to eq('growing')
+    it 'returns Good if score is between 50 and 75' do
+      expect(job_profile.skills_match(66.667)).to eq('Good')
     end
 
-    it 'returns growing if job growth is more than 50' do
-      model = build(:job_profile, growth: 100.102)
-      job_profile = described_class.new(model)
-      expect(job_profile.recent_job_growth).to eq('growing strongly')
+    it 'returns Excellent if score is more than 75' do
+      expect(job_profile.skills_match(88.8)).to eq('Excellent')
     end
   end
 end

--- a/spec/decorators/job_profile_decorator_spec.rb
+++ b/spec/decorators/job_profile_decorator_spec.rb
@@ -248,4 +248,36 @@ RSpec.describe JobProfileDecorator do
       end
     end
   end
+
+  describe '#recent_job_growth' do
+    it 'returns nothing if job growth is not populated' do
+      model = build(:job_profile, growth: nil)
+      job_profile = described_class.new(model)
+      expect(job_profile.recent_job_growth).to be_nil
+    end
+
+    it 'returns failing if job growth is less than 5' do
+      model = build(:job_profile, growth: -7.12)
+      job_profile = described_class.new(model)
+      expect(job_profile.recent_job_growth).to eq('falling')
+    end
+
+    it 'returns stable if job growth is between -5 and 5' do
+      model = build(:job_profile, growth: 0.01)
+      job_profile = described_class.new(model)
+      expect(job_profile.recent_job_growth).to eq('stable')
+    end
+
+    it 'returns growing if job growth is between 5 and 50' do
+      model = build(:job_profile, growth: 10.1)
+      job_profile = described_class.new(model)
+      expect(job_profile.recent_job_growth).to eq('growing')
+    end
+
+    it 'returns growing if job growth is more than 50' do
+      model = build(:job_profile, growth: 100.102)
+      job_profile = described_class.new(model)
+      expect(job_profile.recent_job_growth).to eq('growing strongly')
+    end
+  end
 end

--- a/spec/features/skills_matcher_feature.rb
+++ b/spec/features/skills_matcher_feature.rb
@@ -1,48 +1,94 @@
 require 'rails_helper'
 
 RSpec.feature 'Skills matcher', type: :feature do
-  let!(:job_profile) do
+  let!(:skill1) { create(:skill, name: 'Chameleon-like blend in tactics') }
+  let!(:skill2) { create(:skill, name: 'License to kill') }
+  let!(:skill3) { create(:skill, name: 'Baldness') }
+
+  let!(:job_profile1) do
     create(
       :job_profile,
       :with_html_content,
-      name: 'Zombie Killer',
-      categories: [
-        create(:category, name: 'Apocalyptic services')
-      ],
+      name: 'Hitman',
       skills: [
-        create(:skill, name: 'the ability to work well with the deceased')
+        skill1,
+        skill2,
+        skill3
       ]
     )
   end
 
   background do
     enable_feature! :skills_builder
+    create(:job_profile, :with_html_content, name: 'Assasin', skills: [skill1, skill2])
   end
 
   scenario 'User explores their occupations through skills matcher results' do
+    visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
     visit(skills_matcher_index_path)
-    click_on('Zombie Killer')
+    click_on('Assasin')
 
-    expect(page).to have_text('the ability to work well with the deceased')
+    expect(page).to have_text('Chameleon-like blend in tactics')
   end
 
-  scenario 'User continues journey to finding a training course' do
-    visit(job_profile_path(job_profile.slug))
-    click_on('Find a training course')
+  scenario 'returns other profiles than one selected for skills' do
+    visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+    visit(skills_matcher_index_path)
 
-    expect(page).to have_text('Find and apply to a training course near you')
+    expect(page).not_to have_text('Hitman')
+  end
+
+  scenario 'does not return profiles if skills not present' do
+    create(:job_profile, name: 'Hacker', skills: [skill2])
+    visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
+    uncheck('License to kill', allow_label_click: true)
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+    visit(skills_matcher_index_path)
+
+    expect(page).not_to have_text('Hacker')
+  end
+
+  scenario 'arranges profiles according to descending matching score' do
+    create(:job_profile, name: 'Hacker', skills: [skill1, skill2, skill3])
+    visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+    visit(skills_matcher_index_path)
+
+    expect(page.all('ul.govuk-list li a').collect(&:text)).to eq(%w[Hacker Assasin])
+  end
+
+  scenario 'arranges profiles alphabetically if they share a score' do
+    create(:job_profile, name: 'Hacker', skills: [skill2])
+    create(:job_profile, name: 'Admin', skills: [skill1, skill2])
+    visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+    visit(skills_matcher_index_path)
+
+    expect(page.all('ul.govuk-list li a').collect(&:text)).to eq(%w[Admin Assasin Hacker])
   end
 
   scenario 'paginates results of search' do
-    create_list(:job_profile, 12, name: 'Hacker')
+    create_list(:job_profile, 12, name: 'Hacker', skills: [skill1])
+    visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
     visit(skills_matcher_index_path)
 
     expect(page).to have_selector('ul.govuk-list li', count: 10)
   end
 
   scenario 'allows user to paginate through results' do
-    create_list(:job_profile, 11, name: 'Hacker')
-    visit(skills_matcher_index_path)
+    create_list(:job_profile, 11, name: 'Hacker', skills: [skill1])
+    visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
     click_on('Next')
 
     expect(page).to have_selector('ul.govuk-list li', count: 2)

--- a/spec/features/skills_matcher_feature.rb
+++ b/spec/features/skills_matcher_feature.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.feature 'Skills matcher', type: :feature do
+  let!(:job_profile) do
+    create(
+      :job_profile,
+      :with_html_content,
+      name: 'Zombie Killer',
+      categories: [
+        create(:category, name: 'Apocalyptic services')
+      ],
+      skills: [
+        create(:skill, name: 'the ability to work well with the deceased')
+      ]
+    )
+  end
+
+  background do
+    enable_feature! :skills_builder
+  end
+
+  scenario 'User explores their occupations through skills matcher results' do
+    visit(skills_matcher_index_path)
+    click_on('Zombie Killer')
+
+    expect(page).to have_text('the ability to work well with the deceased')
+  end
+
+  scenario 'User continues journey to finding a training course' do
+    visit(job_profile_path(job_profile.slug))
+    click_on('Find a training course')
+
+    expect(page).to have_text('Find and apply to a training course near you')
+  end
+
+  scenario 'paginates results of search' do
+    create_list(:job_profile, 12, name: 'Hacker')
+    visit(skills_matcher_index_path)
+
+    expect(page).to have_selector('ul.govuk-list li', count: 10)
+  end
+
+  scenario 'allows user to paginate through results' do
+    create_list(:job_profile, 11, name: 'Hacker')
+    visit(skills_matcher_index_path)
+    click_on('Next')
+
+    expect(page).to have_selector('ul.govuk-list li', count: 2)
+  end
+end

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Skills matcher', type: :feature do
   let!(:skill2) { create(:skill, name: 'License to kill') }
   let!(:skill3) { create(:skill, name: 'Baldness') }
 
-  let!(:job_profile1) do
+  let!(:current_job_profile) do
     create(
       :job_profile,
       :with_html_content,
@@ -18,77 +18,81 @@ RSpec.feature 'Skills matcher', type: :feature do
     )
   end
 
+  def visit_skills_for_current_job_profile
+    visit(job_profile_skills_path(job_profile_id: current_job_profile.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+  end
+
   background do
     enable_feature! :skills_builder
     create(:job_profile, :with_html_content, name: 'Assasin', skills: [skill1, skill2])
   end
 
   scenario 'User explores their occupations through skills matcher results' do
-    visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
-    find('.govuk-button').click
-    click_on('Find out what you can do with these skills')
-    visit(skills_matcher_index_path)
+    visit_skills_for_current_job_profile
     click_on('Assasin')
 
     expect(page).to have_text('Chameleon-like blend in tactics')
   end
 
   scenario 'returns other profiles than one selected for skills' do
-    visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
+    visit_skills_for_current_job_profile
+
+    expect(page.all('ul.govuk-list li a').collect(&:text)).to eq(['Assasin'])
+  end
+
+  scenario 'if user changes their current job profile skills, it should be reflected in profile results' do
+    alternative_job_profile = create(:job_profile, name: 'Hacker', skills: [skill2])
+
+    visit(job_profile_skills_path(job_profile_id: current_job_profile.slug))
+    find('.govuk-button').click
+    visit(job_profile_skills_path(job_profile_id: alternative_job_profile.slug))
     find('.govuk-button').click
     click_on('Find out what you can do with these skills')
-    visit(skills_matcher_index_path)
 
-    expect(page).not_to have_text('Hitman')
+    expect(page.all('ul.govuk-list li a').collect(&:text)).to eq(['Assasin', current_job_profile.name])
   end
 
   scenario 'does not return profiles if skills not present' do
     create(:job_profile, name: 'Hacker', skills: [skill2])
-    visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
-    uncheck('License to kill', allow_label_click: true)
+    visit(job_profile_skills_path(job_profile_id: current_job_profile.slug))
+    uncheck(skill2.name, allow_label_click: true)
     find('.govuk-button').click
     click_on('Find out what you can do with these skills')
-    visit(skills_matcher_index_path)
 
     expect(page).not_to have_text('Hacker')
   end
 
   scenario 'arranges profiles according to descending matching score' do
     create(:job_profile, name: 'Hacker', skills: [skill1, skill2, skill3])
-    visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
-    find('.govuk-button').click
-    click_on('Find out what you can do with these skills')
-    visit(skills_matcher_index_path)
+    visit_skills_for_current_job_profile
 
-    expect(page.all('ul.govuk-list li a').collect(&:text)).to eq(%w[Hacker Assasin])
+    expect(page.all('ul.govuk-list li a,p:contains("Skills match")').collect(&:text)).to eq(
+      ['Hacker', 'Skills match: Excellent', 'Assasin', 'Skills match: Good']
+    )
   end
 
   scenario 'arranges profiles alphabetically if they share a score' do
     create(:job_profile, name: 'Hacker', skills: [skill2])
     create(:job_profile, name: 'Admin', skills: [skill1, skill2])
-    visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
-    find('.govuk-button').click
-    click_on('Find out what you can do with these skills')
-    visit(skills_matcher_index_path)
+    visit_skills_for_current_job_profile
 
-    expect(page.all('ul.govuk-list li a').collect(&:text)).to eq(%w[Admin Assasin Hacker])
+    expect(page.all('ul.govuk-list li a,p:contains("Skills match")').collect(&:text)).to eq(
+      ['Admin', 'Skills match: Good', 'Assasin', 'Skills match: Good', 'Hacker', 'Skills match: Reasonable']
+    )
   end
 
   scenario 'paginates results of search' do
     create_list(:job_profile, 12, name: 'Hacker', skills: [skill1])
-    visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
-    find('.govuk-button').click
-    click_on('Find out what you can do with these skills')
-    visit(skills_matcher_index_path)
+    visit_skills_for_current_job_profile
 
     expect(page).to have_selector('ul.govuk-list li', count: 10)
   end
 
   scenario 'allows user to paginate through results' do
     create_list(:job_profile, 11, name: 'Hacker', skills: [skill1])
-    visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
-    find('.govuk-button').click
-    click_on('Find out what you can do with these skills')
+    visit_skills_for_current_job_profile
     click_on('Next')
 
     expect(page).to have_selector('ul.govuk-list li', count: 2)

--- a/spec/features/task_list_spec.rb
+++ b/spec/features/task_list_spec.rb
@@ -17,10 +17,29 @@ RSpec.feature 'Tasks List', type: :feature do
   end
 
   scenario 'User explores their occupation' do
+    disable_feature! :skills_builder
     visit(task_list_path)
     click_on('Search for the types of jobs you could retrain to do')
 
     expect(page).to have_text('Explore occupations')
+  end
+
+  scenario 'User navigates to skills matcher results page' do
+    enable_feature! :skills_builder
+    job_profile = create(
+      :job_profile,
+      name: 'Assassin',
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics')
+      ]
+    )
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    find('.govuk-button').click
+    visit(task_list_path)
+    click_on('Search for the types of jobs you could retrain to do')
+
+    expect(page).to have_text('Types of jobs that match your skills')
   end
 
   scenario 'User finds a training course' do

--- a/spec/models/skills_matcher_spec.rb
+++ b/spec/models/skills_matcher_spec.rb
@@ -8,26 +8,10 @@ RSpec.describe SkillsMatcher do
         user_session: {}
       )
 
-      matcher.match
       expect(matcher.match).to be_empty
     end
 
-    it 'returns a job matching skills selected ignoring job profiles in the session' do
-      skill = create(:skill)
-      job_profile1 = create(:job_profile, skills: [skill])
-      job_profile2 = create(:job_profile, skills: [skill])
-      matcher = described_class.new(
-        user_session: {
-          job_profile_skills: {
-            job_profile1.id.to_s => [skill.id]
-          }
-        }
-      )
-
-      expect(matcher.match).to contain_exactly(job_profile2)
-    end
-
-    it 'returns multiple jobs matching skill selected' do
+    it 'returns multiple jobs matching skill selected ignoring job profiles in the session' do
       skill = create(:skill)
       job_profile1 = create(:job_profile, skills: [skill])
       job_profile2 = create(:job_profile, skills: [skill])
@@ -43,7 +27,7 @@ RSpec.describe SkillsMatcher do
       expect(matcher.match).to contain_exactly(job_profile2, job_profile3)
     end
 
-    it 'returns multiple jobs matching different skills selected' do
+    it 'returns multiple jobs matching different skills within profiles selected' do
       skill1 = create(:skill)
       skill2 = create(:skill)
       skill3 = create(:skill)
@@ -62,7 +46,7 @@ RSpec.describe SkillsMatcher do
       expect(matcher.match).to contain_exactly(job_profile2, job_profile3)
     end
 
-    it 'returns multiple jobs matching multiple job skills selected' do
+    it 'returns multiple jobs matching different skills across profiles selected' do
       skill1 = create(:skill)
       skill2 = create(:skill)
       skill3 = create(:skill)
@@ -134,8 +118,7 @@ RSpec.describe SkillsMatcher do
       job_profile2 = create(:job_profile, name: 'Researcher', skills: [skill2])
       job_profile3 = create(:job_profile, name: 'Beekeeper', skills: [skill1, skill2, skill3])
       job_profile4 = create(:job_profile, name: 'Admin', skills: [skill1, skill2, skill3])
-      job_profile5 = create(:job_profile, skills: [skill1, skill3])
-      job_profile6 = create(:job_profile, name: 'Boat builder', skills: [skill3])
+      job_profile5 = create(:job_profile, name: 'Boat builder', skills: [skill3])
       matcher = described_class.new(
         user_session: {
           job_profile_skills: {
@@ -149,7 +132,6 @@ RSpec.describe SkillsMatcher do
           job_profile4,
           job_profile3,
           job_profile5,
-          job_profile6,
           job_profile2
         ]
       )

--- a/spec/models/skills_matcher_spec.rb
+++ b/spec/models/skills_matcher_spec.rb
@@ -1,0 +1,262 @@
+require 'rails_helper'
+
+RSpec.describe SkillsMatcher do
+  describe '#match' do
+    it 'returns no jobs if no session skills selected' do
+      create(:job_profile, skills: [create(:skill)])
+      matcher = described_class.new(
+        user_session: {}
+      )
+
+      matcher.match
+      expect(matcher.match).to be_empty
+    end
+
+    it 'returns a job matching skills selected ignoring job profiles in the session' do
+      skill = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill])
+      job_profile2 = create(:job_profile, skills: [skill])
+      matcher = described_class.new(
+        user_session: {
+          job_profile_skills: {
+            job_profile1.id.to_s => [skill.id]
+          }
+        }
+      )
+
+      expect(matcher.match).to contain_exactly(job_profile2)
+    end
+
+    it 'returns multiple jobs matching skill selected' do
+      skill = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill])
+      job_profile2 = create(:job_profile, skills: [skill])
+      job_profile3 = create(:job_profile, skills: [skill])
+      matcher = described_class.new(
+        user_session: {
+          job_profile_skills: {
+            job_profile1.id.to_s => [skill.id]
+          }
+        }
+      )
+
+      expect(matcher.match).to contain_exactly(job_profile2, job_profile3)
+    end
+
+    it 'returns multiple jobs matching different skills selected' do
+      skill1 = create(:skill)
+      skill2 = create(:skill)
+      skill3 = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill1, skill3])
+      create(:job_profile, skills: [skill2])
+      job_profile2 = create(:job_profile, skills: [skill2, skill3])
+      job_profile3 = create(:job_profile, skills: [skill1, skill3])
+      matcher = described_class.new(
+        user_session: {
+          job_profile_skills: {
+            job_profile1.id.to_s => [skill1.id, skill3.id]
+          }
+        }
+      )
+
+      expect(matcher.match).to contain_exactly(job_profile2, job_profile3)
+    end
+
+    it 'returns multiple jobs matching multiple job skills selected' do
+      skill1 = create(:skill)
+      skill2 = create(:skill)
+      skill3 = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill1])
+      create(:job_profile, skills: [skill2])
+      job_profile2 = create(:job_profile, skills: [skill3])
+      job_profile3 = create(:job_profile, skills: [skill3])
+      job_profile4 = create(:job_profile, skills: [skill1])
+      matcher = described_class.new(
+        user_session: {
+          job_profile_skills: {
+            job_profile1.id.to_s => [skill1.id],
+            job_profile2.id.to_s => [skill3.id]
+          }
+        }
+      )
+
+      expect(matcher.match).to contain_exactly(job_profile3, job_profile4)
+    end
+
+    it 'orders jobs by number of skills matched' do
+      skill1 = create(:skill)
+      skill2 = create(:skill)
+      skill3 = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill1, skill3])
+      job_profile2 = create(:job_profile, skills: [skill2])
+      job_profile3 = create(:job_profile, skills: [skill1, skill2, skill3])
+      job_profile4 = create(:job_profile, skills: [skill1, skill2, skill3])
+      job_profile5 = create(:job_profile, skills: [skill1, skill3])
+      matcher = described_class.new(
+        user_session: {
+          job_profile_skills: {
+            job_profile3.id.to_s => [skill1.id, skill2.id],
+            job_profile1.id.to_s => [skill1.id, skill3.id]
+          }
+        }
+      )
+
+      expect(matcher.match).to eq([job_profile4, job_profile5, job_profile2])
+    end
+
+    it 'scopes job profiles to user session job profile if job profile id supplied' do
+      skill1 = create(:skill)
+      skill2 = create(:skill)
+      skill3 = create(:skill)
+      skill4 = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill1, skill3])
+      create(:job_profile, skills: [skill2])
+      job_profile2 = create(:job_profile, skills: [skill1, skill2, skill3, skill4])
+      job_profile3 = create(:job_profile, skills: [skill1, skill3])
+      matcher = described_class.new(
+        job_profile_id: job_profile1.id.to_s,
+        user_session: {
+          job_profile_skills: {
+            job_profile2.id.to_s => [skill1.id, skill2.id],
+            job_profile1.id.to_s => [skill1.id, skill3.id, skill4.id]
+          }
+        }
+      )
+
+      expect(matcher.match).to eq([job_profile2, job_profile3])
+    end
+
+    it 'arranges job profiles in alphabetical order as well as matching skills order' do
+      skill1 = create(:skill)
+      skill2 = create(:skill)
+      skill3 = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill1, skill2, skill3])
+      job_profile2 = create(:job_profile, name: 'Researcher', skills: [skill2])
+      job_profile3 = create(:job_profile, name: 'Beekeeper', skills: [skill1, skill2, skill3])
+      job_profile4 = create(:job_profile, name: 'Admin', skills: [skill1, skill2, skill3])
+      job_profile5 = create(:job_profile, skills: [skill1, skill3])
+      job_profile6 = create(:job_profile, name: 'Boat builder', skills: [skill3])
+      matcher = described_class.new(
+        user_session: {
+          job_profile_skills: {
+            job_profile1.id.to_s => [skill1.id, skill2.id, skill3.id]
+          }
+        }
+      )
+
+      expect(matcher.match).to eq(
+        [
+          job_profile4,
+          job_profile3,
+          job_profile5,
+          job_profile6,
+          job_profile2
+        ]
+      )
+    end
+
+    xit 'ignores unrecommended jobs' do
+      skill = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill])
+      create(:job_profile, skills: [skill], recommended: false)
+      job_profile2 = create(:job_profile, skills: [skill])
+      matcher = described_class.new(
+        user_session: {
+          job_profile_skills: {
+            job_profile1.id.to_s => [skill.id]
+          }
+        }
+      )
+
+      expect(matcher.match).to contain_exactly(job_profile2)
+    end
+  end
+
+  describe '#job_profile_scores' do
+    it 'returns job profiles mapped to a percentage of skills match to total user skills' do
+      skill = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill])
+      job_profile2 = create(:job_profile, skills: [skill])
+      job_profile3 = create(:job_profile, skills: [skill])
+
+      matcher = described_class.new(
+        user_session: {
+          job_profile_skills: {
+            job_profile1.id.to_s => [skill.id]
+          }
+        }
+      )
+
+      expect(matcher.job_profile_scores).to eq(
+        job_profile2.id => 100.0,
+        job_profile3.id => 100.0
+      )
+    end
+
+    it 'returns job profiles matched to multiple skills with the correct percentage score' do
+      skill1 = create(:skill)
+      skill2 = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill1, skill2])
+      job_profile2 = create(:job_profile, skills: [skill1])
+      job_profile3 = create(:job_profile, skills: [skill1, skill2])
+      matcher = described_class.new(
+        user_session: {
+          job_profile_skills: {
+            job_profile1.id.to_s => [skill1.id, skill2.id]
+          }
+        }
+      )
+
+      expect(matcher.job_profile_scores).to eq(
+        job_profile2.id => 50.0,
+        job_profile3.id => 100.0
+      )
+    end
+
+    it 'returns job profiles matched to multiple skills across multiple jobs profiles with the correct score' do
+      skill1 = create(:skill)
+      skill2 = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill1, skill2])
+      job_profile2 = create(:job_profile, skills: [skill1])
+      job_profile3 = create(:job_profile, skills: [skill1, skill2])
+      job_profile4 = create(:job_profile, skills: [skill2])
+      matcher = described_class.new(
+        user_session: {
+          job_profile_skills: {
+            job_profile1.id.to_s => [skill2.id],
+            job_profile2.id.to_s => [skill1.id]
+          }
+        }
+      )
+
+      expect(matcher.job_profile_scores).to eq(
+        job_profile4.id => 50.0,
+        job_profile3.id => 100.0
+      )
+    end
+
+    it 'returns job profiles matched to multiple skills across multiple jobs profiles scoped to profile' do
+      skill1 = create(:skill)
+      skill2 = create(:skill)
+      skill3 = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill1, skill2])
+      job_profile2 = create(:job_profile, skills: [skill1])
+      job_profile3 = create(:job_profile, skills: [skill1, skill2])
+      create(:job_profile, skills: [skill2])
+      matcher = described_class.new(
+        job_profile_id: job_profile2.id.to_s,
+        user_session: {
+          job_profile_skills: {
+            job_profile1.id.to_s => [skill2.id],
+            job_profile2.id.to_s => [skill1.id, skill3.id]
+          }
+        }
+      )
+
+      expect(matcher.job_profile_scores).to eq(
+        job_profile1.id => 50.0,
+        job_profile3.id => 50.0
+      )
+    end
+  end
+end

--- a/spec/models/skills_matcher_spec.rb
+++ b/spec/models/skills_matcher_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe SkillsMatcher do
       expect(matcher.match).to eq([job_profile4, job_profile5, job_profile2])
     end
 
-    it 'scopes job profiles to user session job profile if job profile id supplied' do
+    it 'scopes job profiles to user session job profile if job profile current id exists' do
       skill1 = create(:skill)
       skill2 = create(:skill)
       skill3 = create(:skill)
@@ -114,8 +114,8 @@ RSpec.describe SkillsMatcher do
       job_profile2 = create(:job_profile, skills: [skill1, skill2, skill3, skill4])
       job_profile3 = create(:job_profile, skills: [skill1, skill3])
       matcher = described_class.new(
-        job_profile_id: job_profile1.id.to_s,
         user_session: {
+          current_job_id: job_profile1.id,
           job_profile_skills: {
             job_profile2.id.to_s => [skill1.id, skill2.id],
             job_profile1.id.to_s => [skill1.id, skill3.id, skill4.id]
@@ -244,8 +244,8 @@ RSpec.describe SkillsMatcher do
       job_profile3 = create(:job_profile, skills: [skill1, skill2])
       create(:job_profile, skills: [skill2])
       matcher = described_class.new(
-        job_profile_id: job_profile2.id.to_s,
         user_session: {
+          current_job_id: job_profile2.id,
           job_profile_skills: {
             job_profile1.id.to_s => [skill2.id],
             job_profile2.id.to_s => [skill1.id, skill3.id]

--- a/spec/routing/skills_matcher_spec.rb
+++ b/spec/routing/skills_matcher_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'routes for Skills Matcher', type: :routing do
+  context 'when :skills_builder feature is ON' do
+    before do
+      enable_feature! :skills_builder
+    end
+
+    it 'successfully routes to skills_matcher#index' do
+      expect(get(skills_matcher_index_path)).to route_to(controller: 'skills_matcher', action: 'index')
+    end
+  end
+
+  context 'when :skills_builder feature is OFF' do
+    before do
+      disable_feature! :skills_builder
+    end
+
+    it 'does not route to skills_matcher#index' do
+      expect(get(skills_matcher_index_path)).not_to be_routable
+    end
+  end
+end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-232

Add skill matcher, which accepts a session with a set of skills, and optionally a job profile id to scope to for version 1.

If there is no job profile id, the skills matcher finds all job profile ids matching those skills, and groups them by skills matched count of job profiles as a subquery.

Then by grouping on the count of skills matched we get all job profile ids that have the same
score, and order them in ascending order of name, as well as on frequency. Finally we select
the records scoped to the fields needed and expand the ids of the ordered group maintaining
ordinality.

For the score we create a new hash from the ids and calculate the score mapped to a job profile id.
The scoring system chosen counts the skills matched in the job profile / the total count of skills selected %