### PR TITLE
Fix broken UX journey caused page redesign

### DIFF
--- a/app/views/check_your_skills/results.html.erb
+++ b/app/views/check_your_skills/results.html.erb
@@ -13,14 +13,16 @@
 <div class="govuk-grid-row govuk-!-padding-top-7">
   <div class="govuk-grid-column-two-thirds" >
     <% if @job_profiles.blank? %>
-      <p class="govuk-body-m"><%= render '/shared/search/no_results' %></p>
+      <%= render '/shared/search/no_results' %>
     <% else %>
+      <h3 class="govuk-heading-xl govuk-!-margin-bottom-7"><%= t('.title') %></h3>
+      <%= render "shared/search/results_form", search_path: results_check_your_skills_path, scope: 'check_your_skills.results' %>
       <p class="govuk-body-l govuk-!-margin-bottom-2"><%= t('.body') %></p>
       <%= render "results_list", job_profiles: @job_profiles %>
+      <div class="govuk-grid-column-full govuk-!-padding-top-6 govuk-!-margin-bottom-4 govuk-!-margin-top-6 pagination__section">
+        <%= paginate @job_profiles %>
+      </div>
     <% end %>
-    <div class="govuk-grid-column-full govuk-!-padding-top-6 govuk-!-margin-bottom-4 govuk-!-margin-top-6">
-      <%= paginate @job_profiles %>
-    </div>
   </div>
   <%= render "shared/contact_us" %>
 </div>

--- a/app/views/check_your_skills/results.html.erb
+++ b/app/views/check_your_skills/results.html.erb
@@ -12,8 +12,6 @@
 
 <div class="govuk-grid-row govuk-!-padding-top-7">
   <div class="govuk-grid-column-two-thirds" >
-    <h3 class="govuk-heading-l"><%= t('.title') %></h3>
-    <%= render "shared/search/results_form", search_path: results_check_your_skills_path, scope: 'check_your_skills.results' %>
     <% if @job_profiles.blank? %>
       <p class="govuk-body-m"><%= render '/shared/search/no_results' %></p>
     <% else %>
@@ -21,7 +19,7 @@
       <p class="govuk-inset-text govuk-!-margin-bottom-2"><%= t('.body') %></p>
       <%= render "results_list", job_profiles: @job_profiles %>
     <% end %>
-    <div class="govuk-grid-column-full govuk-!-padding-top-6 govuk-!-margin-bottom-4 govuk-!-margin-top-6 pagination__section">
+    <div class="govuk-grid-column-full govuk-!-padding-top-6 govuk-!-margin-bottom-4 govuk-!-margin-top-6">
       <%= paginate @job_profiles %>
     </div>
   </div>

--- a/app/views/shared/search/_no_results.html.erb
+++ b/app/views/shared/search/_no_results.html.erb
@@ -1,3 +1,7 @@
 <h3 class="govuk-heading-xl">No results found</h3>
-<p class="govuk-body">We couldn’t find any results for this job title. Is there any other name for the job you do?</p>
-<p class="govuk-body"><%= link_to 'Search again', check_your_skills_path %></p>
+<%= render "shared/search/results_form", search_path: results_check_your_skills_path, scope: 'check_your_skills.results' %>
+<p class="govuk-body">You could try:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>checking your spelling</li>
+  <li>using a different name for the job you do</li>
+</ul>

--- a/app/views/shared/search/_no_results.html.erb
+++ b/app/views/shared/search/_no_results.html.erb
@@ -1,8 +1,3 @@
-<p class="govuk-body-m">0 results</p>
-<h2 class="govuk-heading-s">Try again using a different job title.</h2>
-<p class="govuk-body">You could try:</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>double checking your spelling</li>
-  <li>using fewer words</li>
-  <li>searching for something less specific</li>
-</ul>
+<h3 class="govuk-heading-xl">No results found</h3>
+<p class="govuk-body">We couldn’t find any results for this job title. Is there any other name for the job you do?</p>
+<p class="govuk-body"><%= link_to 'Search again', check_your_skills_path %></p>

--- a/app/views/shared/search/_results_form.html.erb
+++ b/app/views/shared/search/_results_form.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-column-full govuk-!-padding-0">
   <%= form_tag search_path, method: 'get', id: 'job-profile-search' do %>
-    <div class="govuk-form-group">
+    <div class="govuk-form-group govuk-!-margin-bottom-0">
       <%= text_field(nil, :search, value: params[:search], class: 'search-input govuk-input govuk-!-width-one-half', placeholder: t('placeholder', scope: scope), required: true, aria: { label: 'Search' }) %>
       <%= button_tag('Search', class: 'search-button govuk-button', aria: { label: 'Search button' }) %>
     </div>

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Check your skills', type: :feature do
 
     click_on('Search again')
 
-    expect(current_path).to eql(check_your_skills_path)
+    expect(page).to have_current_path(check_your_skills_path)
   end
 
   scenario 'paginates results of search' do

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -36,16 +36,6 @@ RSpec.feature 'Check your skills', type: :feature do
     expect(page).to have_text('No results found')
   end
 
-  scenario 'User can return to the search form when no results are found' do
-    visit(check_your_skills_path)
-    fill_in('search', with: 'Embalmer')
-    find('.search-button').click
-
-    click_on('Search again')
-
-    expect(page).to have_current_path(check_your_skills_path)
-  end
-
   scenario 'paginates results of search' do
     create_list(:job_profile, 12, name: 'Hacker')
     visit(check_your_skills_path)
@@ -83,5 +73,14 @@ RSpec.feature 'Check your skills', type: :feature do
     find('.search-button').click
 
     expect(page).to have_current_path(check_your_skills_path)
+  end
+
+  scenario 'cannot send results search form with no input', :js do
+    create(:job_profile, name: 'Hacker')
+    visit(results_check_your_skills_path(search: 'Hacker'))
+    fill_in('search', with: '')
+    find('.search-button').click
+
+    expect(page).to have_text('Hacker')
   end
 end

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -33,7 +33,17 @@ RSpec.feature 'Check your skills', type: :feature do
     fill_in('search', with: 'Embalmer')
     find('.search-button').click
 
-    expect(page).to have_text('0 results')
+    expect(page).to have_text('No results found')
+  end
+
+  scenario 'User can return to the search form when no results are found' do
+    visit(check_your_skills_path)
+    fill_in('search', with: 'Embalmer')
+    find('.search-button').click
+
+    click_on('Search again')
+
+    expect(current_path).to eql(check_your_skills_path)
   end
 
   scenario 'paginates results of search' do
@@ -73,14 +83,5 @@ RSpec.feature 'Check your skills', type: :feature do
     find('.search-button').click
 
     expect(page).to have_current_path(check_your_skills_path)
-  end
-
-  scenario 'cannot send results search form with no input', :js do
-    create(:job_profile, name: 'Hacker')
-    visit(results_check_your_skills_path(search: 'Hacker'))
-    fill_in('search', with: '')
-    find('.search-button-results').click
-
-    expect(page).to have_text('1 results found')
   end
 end

--- a/spec/features/explore_occupations_spec.rb
+++ b/spec/features/explore_occupations_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Explore Occupations', type: :feature do
     fill_in('search', with: 'Embalmer')
     find('.search-button').click
 
-    expect(page).to have_text('0 results')
+    expect(page).to have_text('No results found')
   end
 
   scenario 'User continues journey to finding a training course' do


### PR DESCRIPTION
The Skills page has been redesigned and the search form
was removed from the results page causing an issue when
the searched skill has no results, as the user has no way to
search again.

## Screenshots

![Screen Shot 2019-08-14 at 15 07 23](https://user-images.githubusercontent.com/1955084/63027488-f96b8d00-bea4-11e9-8e60-96c4c1b2797a.png)


https://dfedigital.atlassian.net/browse/GET-365

