### PR TITLE
Add rake task to correctly set recommended flag for all job profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ If job profiles have been previously scraped and `content` is populated, it's po
   bundle exec rails data_import:refresh_job_profiles
 ```
 
+### Recommended job profiles
+The service is intended for users without degrees, so should not recommend future job roles that require a degree level qualification. Job profiles include a `recommended` attribute for this purpose, that is respected by the skills matcher when computing matches.
+
+The list of job profiles that require a degree has been manually curated by reviewing each of the current job roles scraped from NCS site. A rake task allows setting the recommended attribute correctly for known job profiles. Any new job profiles that are discovered during subsequent scraping will be excluded by default, but can manually be recommended via the admin interface.
+
+Once job profiles have been scraped from NCS, run the relevant rake task (a one off exercise):
+
+```bash
+  bundle exec rails data_import:update_recommended_job_profiles
+```
+
 ### Additional job profile data
 Growth information and SOC codes for job profiles are imported via an Excel spreadsheet and used to update specific attributes of existing job profiles (i.e. these must have been previously imported by running the scraping tasks). Copy the relevant spreadsheet locally and then run rake task:
 

--- a/app/models/job_profile.rb
+++ b/app/models/job_profile.rb
@@ -10,6 +10,9 @@ class JobProfile < ApplicationRecord
                           foreign_key: :job_profile_id,
                           association_foreign_key: :related_job_profile_id
 
+  scope :recommended, -> { where(recommended: true) }
+  scope :excluded, -> { where(recommended: false) }
+
   def self.find_by_name(name)
     where('lower(name) = ?', name.downcase).first
   end

--- a/app/models/skills_matcher.rb
+++ b/app/models/skills_matcher.rb
@@ -30,6 +30,7 @@ class SkillsMatcher
 
   def job_profiles_subquery
     JobProfile
+      .recommended
       .select(:skills_matched, 'array_agg(id order by name ASC) as alphabetically_ordered_ids')
       .from(Arel.sql("(#{job_profile_skills_subquery}) as ranked_job_profiles"))
       .joins('LEFT JOIN job_profiles ON job_profiles.id = ranked_job_profiles.job_profile_id')

--- a/lib/tasks/data_import/update_recommended_job_profiles.rake
+++ b/lib/tasks/data_import/update_recommended_job_profiles.rake
@@ -1,0 +1,74 @@
+# rubocop:disable Metrics/BlockLength, Metrics/LineLength
+namespace :data_import do
+  # bin/rails data_import:update_recommended_job_profiles
+  desc 'Sets correct recommended value for all job profiles'
+  task update_recommended_job_profiles: :environment do
+    print 'Updating recommended flag for all job profiles'
+    if JobProfile.any?
+      non_recommended_jobs = JobProfile.where(slug: %w[
+                                                astronaut
+                                                naturopath
+                                                psychiatrist
+                                                vet
+                                                art-therapist
+                                                sport-and-exercise-psychologist
+                                                geoscientist
+                                                naval-architect
+                                                botanist
+                                                dentist
+                                                data-analyst-statistician
+                                                audiologist
+                                                archaeologist
+                                                dance-movement-psychotherapist
+                                                ornithologist
+                                                forensic-psychologist
+                                                psychologist
+                                                play-therapist
+                                                consumer-scientist
+                                                astronomer
+                                                nutritionist
+                                                chiropractor
+                                                research-and-development-manager
+                                                cognitive-behavioural-therapist
+                                                environmental-consultant
+                                                medical-herbalist
+                                                music-therapist
+                                                paediatrician
+                                                nutritional-therapist
+                                                zoologist
+                                                palaeontologist
+                                                dental-hygienist
+                                                ecologist
+                                                surgeon
+                                                pharmacologist
+                                                dispensing-optician
+                                                dramatherapist
+                                                materials-engineer
+                                                gp
+                                                anaesthetist
+                                                critical-care-technologist
+                                                orthoptist
+                                                pathologist
+                                                geneticist
+                                                oceanographer
+                                                sports-scientist
+                                                pharmacist
+                                                speech-and-language-therapist
+                                                climate-scientist
+                                                archivist
+                                                ergonomist
+                                                clinical-psychologist
+                                                hospital-doctor
+                                                oil-and-gas-operations-manager
+                                              ])
+
+      JobProfile.update_all(recommended: true)
+      non_recommended_jobs.update_all(recommended: false)
+
+      print "#{JobProfile.count} job profiles, #{JobProfile.recommended.count} recommended, #{JobProfile.excluded.count} excluded"
+    else
+      print 'No job profiles setup - please import sitemap first'
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength, Metrics/LineLength

--- a/spec/factories/job_profiles.rb
+++ b/spec/factories/job_profiles.rb
@@ -3,13 +3,14 @@ FactoryBot.define do
     name { Faker::Job.title }
     description { Faker::Company.catch_phrase }
     content { Faker::Lorem.paragraphs.join }
+    recommended { true }
 
     sequence :slug do |n|
       "#{name.parameterize.underscore}_#{n}"
     end
 
-    trait :recommended do
-      recommended { true }
+    trait :excluded do
+      recommended { false }
     end
 
     trait :falling do

--- a/spec/models/job_profile_spec.rb
+++ b/spec/models/job_profile_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe JobProfile do
   let(:category) { build_stubbed(:category) }
   let(:skill) { build_stubbed(:skill) }
-  let(:recommended_job) { build_stubbed(:job_profile, :recommended) }
-  let(:discouraged_job) { build_stubbed(:job_profile) }
+  let(:recommended_job) { build_stubbed(:job_profile) }
+  let(:discouraged_job) { build_stubbed(:job_profile, :excluded) }
 
   describe '#recommended' do
     it 'is true for recommended job profiles' do

--- a/spec/models/skills_matcher_spec.rb
+++ b/spec/models/skills_matcher_spec.rb
@@ -137,10 +137,10 @@ RSpec.describe SkillsMatcher do
       )
     end
 
-    xit 'ignores unrecommended jobs' do
+    it 'ignores unrecommended jobs' do
       skill = create(:skill)
       job_profile1 = create(:job_profile, skills: [skill])
-      create(:job_profile, skills: [skill], recommended: false)
+      create(:job_profile, :excluded, skills: [skill])
       job_profile2 = create(:job_profile, skills: [skill])
       matcher = described_class.new(
         user_session: {

--- a/spec/tasks/update_recommended_job_profiles_spec.rb
+++ b/spec/tasks/update_recommended_job_profiles_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+require 'support/tasks'
+
+RSpec.describe 'data_import:update_recommended_job_profiles' do
+  let!(:astronaut) { create :job_profile, slug: 'astronaut' }
+  let!(:mad_titan) { create :job_profile, slug: 'mad-titan' }
+
+  it 'excludes specific named jobs' do
+    task.execute
+    expect(astronaut.reload).to be_excluded
+  end
+
+  it 'recommends all other jobs' do
+    task.execute
+    expect(mad_titan.reload).to be_recommended
+  end
+end

--- a/spec/tasks/update_recommended_job_profiles_spec.rb
+++ b/spec/tasks/update_recommended_job_profiles_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'data_import:update_recommended_job_profiles' do
 
   it 'excludes specific named jobs' do
     task.execute
-    expect(astronaut.reload).to be_excluded
+    expect(astronaut.reload).not_to be_recommended
   end
 
   it 'recommends all other jobs' do


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-226

### Changes proposed in this pull request
Other than 54 job profiles that have been identified, all other job profiles are recommended. The 54 identified are excluded as they require a degree level qualification. Excluded jobs will still be included in the search results for "Check your skills" and skills builder so no code changes have been made there. Explore careers is about to be retired in favour of skill matcher so no changes have been made there either.

Excluded jobs don't appear in the skill matcher results, but remain elsewhere.

### Guidance to review
Run the rake task locally as described in the README - this will set `recommended` to true for all job profiles except the ones listed in the spreadsheet linked to this Jira task: https://dfedigital.atlassian.net/browse/GET-304

This can be checked by taking a look at http://localhost:3000/admin/job_profiles