### PR TITLE
HOTFIX: Minor indentation + copy fixes

### DIFF
--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -2,7 +2,7 @@
   <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-heading-l title"><%= course.title %></h2>
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0 muted-text"><%= course.provider %></h3>
   <p class="govuk-body govuk-!-margin-bottom-0">Distance: <b><%= course.distance.round(1) %> miles</b></p>
-   <p class="govuk-body govuk-!-margin-bottom-1">Cost: <b>Free</p>
+  <p class="govuk-body govuk-!-margin-bottom-1">Cost: <b>Free</b></p>
   <p class="govuk-body-s"><%= course.full_address %></p>
   <p class="govuk-body-s">Tel:<%= link_to(course.phone_number, "tel:#{course.phone_number}", class: 'govuk-!-padding-left-1 govuk-link' ) %></p>
   <%= link_to 'Visit website', course.url, class: 'govuk-!-margin-bottom-6 govuk-button', target: '_blank', data: { tracked_event: "Courses - Clicked course link: #{course.url}" } %>

--- a/app/views/pages/next_steps.html.erb
+++ b/app/views/pages/next_steps.html.erb
@@ -24,7 +24,7 @@
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
     <h3 class="govuk-heading-m govuk-!-margin-bottom-1">Find an apprenticeship</h3>
-    <p class="govuk-body">Use the <%= link_to 'National Apprenticeship Service', 'https://www.gov.uk/apprenticeships-guide', class: 'govuk-link' %> to find and learn more about apprenticeships, offering opportunities to train on-the-job.</p>
+    <p class="govuk-body">Use the <%= link_to 'National Apprenticeship Service', 'https://www.gov.uk/apprenticeships-guide', class: 'govuk-link' %> to find apprenticeships in your local area, offering opportunities to train on-the-job.</p>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
     <h3 class="govuk-heading-m govuk-!-margin-bottom-4">On offer near you</h3>

--- a/app/views/pages/training_hub.html.erb
+++ b/app/views/pages/training_hub.html.erb
@@ -13,7 +13,7 @@
   <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-7">
     <h1 class="govuk-heading-xl">Find training that boosts your job options</h1>
     <p class="govuk-body-l">You could get a better job by adding to the skills you already have. Complete a short course in maths or English and you could find you have a wider range of job options. Many courses are free and offer flexible times to fit round your life.</p>
-    <p class="govuk-body-l">This is a new scheme - a wider range of courses will be added in future.</p>
+    <p class="govuk-body-m">This is a new scheme - a wider range of courses will be added in future.</p>
     <h2 class="govuk-heading-m">What’s on offer?</h2>
     <%= render 'shared/training_hub/maths' %>
     <%= render 'shared/training_hub/english' %>

--- a/app/views/shared/_what_you_can_do_next.html.erb
+++ b/app/views/shared/_what_you_can_do_next.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-related-items govuk-!-padding-bottom-4 top-border__container">
     <h2 class="govuk-heading-m"><%= t('what_you_can_do_next.title') %></h2>
     <p class="govuk-body-m">
-      <%= link_to t('what_you_can_do_next.body'), next_steps_path, class: 'govuk-link' %>
+      <%= link_to t('what_you_can_do_next.cta_copy'), next_steps_path, class: 'govuk-link' %>
     </p>
   </div>
 </div>


### PR DESCRIPTION
Following fixes:

1. second paragraph should have small text: https://qa.nrs-ghtr.org.uk/training-hub
https://get-help-to-retrain-prototype.herokuapp.com/main/release2_e2e_v3/training_hub
2. Fix indentation in: https://github.com/DFE-Digital/get-help-to-retrain/pull/130/files#diff-235f0713347955c73fe1258944294858R4 and close tag in: Cost: Free
3. Further help to find work on https://qa.nrs-ghtr.org.uk/courses/maths has body instead of text
4. Copy in find an apprenticeship is different on https://get-help-to-retrain-prototype.herokuapp.com/main/release2_e2e_v3/next_steps than https://qa.nrs-ghtr.org.uk/next-steps
