### PR TITLE
GET-364 Redirect back to task list path if no job profile and skills selected

### DIFF
--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -1,6 +1,8 @@
 class SkillsController < ApplicationController
   def index
     if Flipflop.skills_builder?
+      return redirect_to task_list_path unless job_profile_and_skills_present
+
       session[:current_job_id] = job_profile.id
       @skills = Skill.find(skill_ids)
 
@@ -24,5 +26,9 @@ class SkillsController < ApplicationController
 
   def skills_params
     params.permit(:job_profile_id)
+  end
+
+  def job_profile_and_skills_present
+    job_profile.present? && skill_ids.present?
   end
 end

--- a/spec/features/skills_builder_spec.rb
+++ b/spec/features/skills_builder_spec.rb
@@ -93,6 +93,18 @@ RSpec.feature 'Build your skills', type: :feature do
     expect(page).to have_text(/Hitman/)
   end
 
+  scenario 'redirected to task list path if no job profile selected' do
+    visit(skills_path)
+
+    expect(page).to have_current_path(task_list_path)
+  end
+
+  scenario 'redirected to task list path if job profile selected but no skills selected' do
+    visit(skills_path(job_profile_id: job_profile.slug))
+
+    expect(page).to have_current_path(task_list_path)
+  end
+
   context 'when feature disabled' do
     background do
       disable_feature! :skills_builder


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-357

This is to guard against users deep linking to skills selected without
parameters for job profile or skills selected in session

