### PR TITLE
GET-319 Add error page when postcodes.io api is down on course search page

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -9,6 +9,8 @@ class CoursesController < ApplicationController
       topic: courses_params[:topic_id]
     )
     @courses = @search.find_courses.map { |c| CourseDecorator.new(c) }
+  rescue CourseGeospatialSearch::GeocoderAPIError
+    redirect_to course_postcode_search_error_path
   end
 
   private

--- a/app/views/errors/course_postcode_search_error.html.erb
+++ b/app/views/errors/course_postcode_search_error.html.erb
@@ -1,0 +1,12 @@
+<% page_title :errors_postcode_search_error %>
+
+<main role="main" class="govuk-main-wrapper" id="main-content">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Sorry, there is a problem with this service</h1>
+      <p class="govuk-body">Postcode search isn't working right now.</p>
+      <p class="govuk-body-m">You can still use this service to <%= link_to 'check your existing skills', check_your_skills_path, class: 'govuk-link' %> and get further <%= link_to 'help to find work', next_steps_path, class: 'govuk-link' %>.</p>
+      <%= link_to 'Continue', task_list_path, class: 'govuk-button' %>
+    </div>
+  </div>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     get 'maths-course-overview', to: 'pages#maths_overview'
     get 'english-course-overview', to: 'pages#english_overview'
     get 'training-hub', to: 'pages#training_hub'
+    get 'course-postcode-search-error', to: 'errors#course_postcode_search_error'
   end
 
   constraints(->(_req) { Flipflop.location_eligibility? }) do

--- a/spec/features/find_training_courses_spec.rb
+++ b/spec/features/find_training_courses_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature 'Find training courses', type: :feature do
     expect(page).to have_text(/Enter a real postcode/)
   end
 
-  xscenario 'User gets relevant messaging if their address coordinates could not be retrieved' do
+  scenario 'User gets relevant messaging if their address coordinates could not be retrieved' do
     allow(Geocoder).to receive(:coordinates).and_raise(Geocoder::ServiceUnavailable)
     create(:course, topic: 'maths')
 
@@ -99,7 +99,7 @@ RSpec.feature 'Find training courses', type: :feature do
     fill_in('postcode', with: 'NW6 8ET')
     find('.search-button-results').click
 
-    expect(page).to have_text(/We cannot verify your postcode/)
+    expect(page).to have_text(/Sorry, there is a problem with this service/)
   end
 
   scenario 'search form required field available when no js running' do


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-319

When Postcodes.io API is down, show error page on course searching through
postcode
