### PR TITLE
Foundation for user completion journey

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,10 @@
 class ApplicationController < ActionController::Base
+  def user_session
+    @user_session ||= ::UserSession.new(session)
+  end
+
+  helper_method :user_session
+
   private
 
   def track_event(event_key, properties = {})

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  # TO DO: This needs to be removed as it's never being hit
+  # TODO: This needs to be removed as it's never being hit
   def show
     render template: "pages/#{params[:page]}"
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,15 @@
 class PagesController < ApplicationController
+  # TO DO: This needs to be removed as it's never being hit
   def show
     render template: "pages/#{params[:page]}"
+  end
+
+  def training_hub
+    user_session.track_page('training_hub')
+  end
+
+  def next_steps
+    user_session.track_page('next_steps')
   end
 
   def location_eligibility

--- a/app/controllers/skills_matcher_controller.rb
+++ b/app/controllers/skills_matcher_controller.rb
@@ -1,10 +1,12 @@
 class SkillsMatcherController < ApplicationController
   def index
+    return redirect_to task_list_path unless user_session.job_profile_skills?
+
+    user_session.track_page('skills_matcher_index')
+
     @results = Kaminari.paginate_array(skills_matcher.match).page(params[:page])
     @scores = skills_matcher.job_profile_scores
-    @job_profiles = @results.map { |job_profile|
-      JobProfileDecorator.new(job_profile)
-    }
+    @job_profiles = @results.map { |job_profile| JobProfileDecorator.new(job_profile) }
   end
 
   private

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -1,0 +1,20 @@
+class UserSession
+  attr_reader :session
+
+  def initialize(session)
+    @session = session
+    @session[:visited_pages] ||= []
+  end
+
+  def track_page(page_key)
+    session[:visited_pages] << page_key unless session[:visited_pages].include?(page_key)
+  end
+
+  def page_visited?(page_key)
+    session[:visited_pages].include?(page_key)
+  end
+
+  def job_profile_skills?
+    session.fetch(:job_profile_skills, {}).keys.present?
+  end
+end

--- a/app/views/pages/next_steps.html.erb
+++ b/app/views/pages/next_steps.html.erb
@@ -32,7 +32,7 @@
     <p class="govuk-body">A local scheme is coming soon.</p>
 
     <p class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-1">Liverpool</p>
-    <p class="govuk-body">Use the <%= link_to 'Be More', 'https://be-more.info' %> service to find apprenticeships in the Liverpool area.</p>
+    <p class="govuk-body">Use the <%= link_to 'Be More', 'https://be-more.info', class:'govuk-link' %> service to find apprenticeships in the Liverpool area.</p>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     
   </div>

--- a/app/views/pages/task_list.html.erb
+++ b/app/views/pages/task_list.html.erb
@@ -17,77 +17,19 @@
     </p>
     <ol class="app-task-list">
       <li>
-        <h2 class="app-task-list__section">
-          <span class="app-task-list__section-number">1. </span> Check what you are good at
-        </h2>
-        <ul class="app-task-list__items">
-          <li class="app-task-list__item">
-            <div class="app-task-list__task-name">
-              <%= link_to check_your_skills_path, class: 'govuk-link' do %>
-                Check your existing skills <span class="app-step-nav__context">5 minutes</span>
-              <% end %>
-              <p class="govuk-body govuk-!-margin-bottom-0">You'll be surprised at what you already know.</p>
-            </div>
-          </li>
-        </ul>
+        <%= render 'pages/task_list_items/item_1' %>
       </li>
       <li>
-        <h2 class="app-task-list__section">
-          <span class="app-task-list__section-number">2. </span> Explore the types of jobs you could do
-        </h2>
-        <ul class="app-task-list__items">
-          <li class="app-task-list__item">
-            <div class="app-task-list__task-name">
-              <%= link_to Flipflop.skills_builder? ? skills_matcher_index_path : explore_occupations_path, class: 'govuk-link' do %>
-                Search for the types of jobs you could retrain to do <span class="app-step-nav__context">5 to 20 minutes</span>
-              <% end %>
-              <p class="govuk-body govuk-!-margin-bottom-0">These are not live jobs you can apply to – they're the types of jobs you'll be able to do with your existing skills or once you do some training.</p>
-            </div>
-          </li>
-        </ul>
+        <%= render 'pages/task_list_items/item_2' %>
       </li>
       <li>
-        <h2 class="app-task-list__section">
-          <span class="app-task-list__section-number">3. </span> Find training that's right for you
-        </h2>
-        <ul class="app-task-list__items">
-          <li class="app-task-list__item">
-            <div class="app-task-list__task-name">
-              <%= link_to Flipflop.course_directory? ? training_hub_path : find_training_courses_path, class: 'govuk-link' do %>
-                Find a training course <span class="app-step-nav__context">10 to 20 minutes</span>
-              <% end %>
-              <p class="govuk-body govuk-!-margin-bottom-0">Training can help you access a broader range of jobs and stay in secure work.</p>
-            </div>
-          </li>
-        </ul>
+        <%= render 'pages/task_list_items/item_3' %>
       </li>
       <li>
-        <h2 class="app-task-list__section">
-          <span class="app-task-list__section-number">4. </span> Find out what you can do next
-        </h2>
-        <ul class="app-task-list__items">
-          <li class="app-task-list__item">
-            <div class="app-task-list__task-name">
-              <%= link_to 'Get more support to help you on your new career path', next_steps_path, class: 'govuk-link' %>
-              <p class="govuk-body govuk-!-margin-bottom-0">For example, advice on how to find and apply for jobs.</p>
-            </div>
-          </li>
-        </ul>
+        <%= render 'pages/task_list_items/item_4' %>
       </li>
       <li>
-        <h2 class="app-task-list__section">
-          <span class="app-task-list__section-number">5. </span> Help improve this service
-        </h2>
-        <ul class="app-task-list__items">
-          <li class="app-task-list__item">
-            <div class="app-task-list__task-name">
-              <%= link_to 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link', data: { tracked_event: 'TaskList - User Exit Survey Link' }, target: '_blank' do %>
-                Take a quick survey and tell us about your experience <span class="app-step-nav__context">3 to 5 minutes</span>
-              <% end %>
-              <p class="govuk-body govuk-!-margin-bottom-0">This is a new service – your feedback will help us improve it.</p>
-            </div>
-          </li>
-        </ul>
+        <%= render 'pages/task_list_items/item_5' %>
       </li>
     </ol>
   </div>

--- a/app/views/pages/task_list_items/_body.html.erb
+++ b/app/views/pages/task_list_items/_body.html.erb
@@ -1,0 +1,18 @@
+<% if enabled %>
+  <%= link_to path, class: 'govuk-link' do %>
+    <%= cta %>
+    <% if local_assigns[:time_to_complete].present? %>
+      <span class="app-step-nav__context"><%= time_to_complete %></span>
+    <% end %>
+  <% end %>
+<% else %>
+  <div class="govuk-grid-row govuk-body">
+    <div class="govuk-grid-column-full">
+      <span id='section-<%= span_id %>-blocked' class="govuk-tag app-task-list__task-not-active">Can’t start yet</span>
+      <%= cta %>
+      <% if local_assigns[:time_to_complete].present? %>
+        <span class="app-step-nav__context"><%= time_to_complete %></span>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/pages/task_list_items/_item_1.html.erb
+++ b/app/views/pages/task_list_items/_item_1.html.erb
@@ -1,0 +1,13 @@
+<h2 class="app-task-list__section">
+  <span class="app-task-list__section-number">1. </span> Check what you are good at
+</h2>
+<ul class="app-task-list__items">
+  <li class="app-task-list__item">
+    <div class="app-task-list__task-name">
+      <%= link_to check_your_skills_path, class: 'govuk-link' do %>
+        Check your existing skills <span class="app-step-nav__context">5 minutes</span>
+      <% end %>
+      <p class="govuk-body govuk-!-margin-bottom-0">You'll be surprised at what you already know.</p>
+    </div>
+  </li>
+</ul>

--- a/app/views/pages/task_list_items/_item_2.html.erb
+++ b/app/views/pages/task_list_items/_item_2.html.erb
@@ -1,0 +1,11 @@
+<h2 class="app-task-list__section">
+  <span class="app-task-list__section-number">2. </span> <%= t('pages.job_matches.title') %>
+</h2>
+<ul class="app-task-list__items">
+  <li class="app-task-list__item">
+    <div class="app-task-list__task-name">
+      <%= render 'pages/task_list_items/body', enabled: user_session.page_visited?('skills_matcher_index'), path: skills_matcher_index_path, cta: t('pages.job_matches.cta'), time_to_complete: t('pages.job_matches.time'), span_id: '2' %>
+      <p class="govuk-body govuk-!-margin-bottom-0"><%= t('pages.job_matches.description') %></p>
+    </div>
+  </li>
+</ul>

--- a/app/views/pages/task_list_items/_item_3.html.erb
+++ b/app/views/pages/task_list_items/_item_3.html.erb
@@ -1,0 +1,11 @@
+<h2 class="app-task-list__section">
+  <span class="app-task-list__section-number">3. </span> Find training that's right for you
+</h2>
+<ul class="app-task-list__items">
+  <li class="app-task-list__item">
+    <div class="app-task-list__task-name">
+      <%= render 'pages/task_list_items/body', enabled: user_session.page_visited?('training_hub') || user_session.page_visited?('next_steps'), path: training_hub_path, cta: t('pages.find_training_courses.cta'), time_to_complete: t('pages.find_training_courses.time'), span_id: '3' %>
+      <p class="govuk-body govuk-!-margin-bottom-0"><%= t('pages.find_training_courses.description') %></p>
+    </div>
+  </li>
+</ul>

--- a/app/views/pages/task_list_items/_item_4.html.erb
+++ b/app/views/pages/task_list_items/_item_4.html.erb
@@ -1,0 +1,11 @@
+<h2 class="app-task-list__section">
+  <span class="app-task-list__section-number">4. </span> Further help to find work
+</h2>
+<ul class="app-task-list__items">
+  <li class="app-task-list__item">
+    <div class="app-task-list__task-name">
+      <%= render 'pages/task_list_items/body', enabled: user_session.page_visited?('training_hub') || user_session.page_visited?('next_steps'), path: next_steps_path, cta: t('pages.next_steps.cta'), time_to_complete: nil, span_id: '4' %>
+      <p class="govuk-body govuk-!-margin-bottom-0"><%= t('pages.next_steps.description') %></p>
+    </div>
+  </li>
+</ul>

--- a/app/views/pages/task_list_items/_item_5.html.erb
+++ b/app/views/pages/task_list_items/_item_5.html.erb
@@ -1,0 +1,24 @@
+<h2 class="app-task-list__section">
+  <span class="app-task-list__section-number">5. </span> Help improve this service
+</h2>
+<ul class="app-task-list__items">
+  <li class="app-task-list__item">
+    <div class="app-task-list__task-name">
+      <% if user_session.page_visited?('training_hub') || user_session.page_visited?('next_steps') %>
+        <%= link_to 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link', data: { tracked_event: 'TaskList - User Exit Survey Link' }, target: '_blank' do %>
+          <%= t('help_improve_this_service.cta') %>
+        <% end %>
+        <span class="app-step-nav__context"><%= t('help_improve_this_service.time') %></span>
+      <% else %>
+        <div class="govuk-grid-row govuk-body">
+          <div class="govuk-grid-column-full">
+            <span id='section-5-blocked' class="govuk-tag app-task-list__task-not-active">Can’t start yet</span>
+            <%= t('help_improve_this_service.cta') %>
+            <span class="app-step-nav__context"><%= t('help_improve_this_service.time') %></span>
+          </div>
+        </div>
+      <% end %>
+      <p class="govuk-body govuk-!-margin-bottom-0"><%= t('help_improve_this_service.description') %></p>
+    </div>
+  </li>
+</ul>

--- a/app/webpacker/styles/_task-list.scss
+++ b/app/webpacker/styles/_task-list.scss
@@ -51,23 +51,15 @@
 
   @include govuk-media-query($from: 450px) {
     float: left;
-    width: 75%;
+    width: 100%;
   }
 }
 
-.app-task-list__task-completed {
-  margin-top: govuk-spacing(2);
-  margin-bottom: govuk-spacing(1);
-
-  @include govuk-media-query($from: 450px) {
-    float: right;
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-
-  &--hidden {
-    display: none;
-  }
+.app-task-list__task-not-active {
+  color: govuk-colour("white");
+  background-color: govuk-colour("grey-1");
+  margin-left: 5%;
+  float: right;
 }
 
 .app-step-nav__context {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,9 +96,19 @@ en-GB:
     task_list:
       title: Get help to retrain
     find_training_courses:
-      title: Find and apply to a training course near you
+      title: Find training that's right for you
+      cta: Find a training course
+      description: Training can help you access a broader range of jobs and stay in secure work.
+      time: 10 to 20 minutes
     next_steps:
       title: Further help to find work
+      cta: Find other ways to change jobs
+      description: Connecting you to further advice, ideas and help.
+    job_matches:
+      title: Explore the types of jobs you could do
+      cta: See types of jobs that match your skills
+      description: You already have many of the skills to do these types of jobs. Find out what additional training you might need.
+      time: 5 to 20 minutes
     maths_overview:
       title: Benefits of doing a maths course
     english_overview:
@@ -118,6 +128,9 @@ en-GB:
   help_improve_this_service:
     title: Help improve this service
     body: Take a quick survey and tell us about your experience
+    cta: Take a quick survey
+    description: Tell us about your experience using Get help to retrain.
+    time: 3 to 5 minutes
   courses:
     invalid_postcode_error: Enter a valid postcode.
     nonexisting_postcode_error: Enter a real postcode.

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -36,6 +36,20 @@ RSpec.feature 'Skills matcher', type: :feature do
     expect(page).to have_text('Chameleon-like blend in tactics')
   end
 
+  scenario 'Page gets tracked on the session' do
+    visit_skills_for_current_job_profile
+
+    current_session = Capybara.current_session.driver.request.session
+
+    expect(current_session[:visited_pages]).to eq(['skills_matcher_index'])
+  end
+
+  scenario 'Redirect to tasks-list page when session is missing the job_profile_skills key' do
+    visit '/job-matches'
+
+    expect(page).to have_current_path(task_list_path)
+  end
+
   scenario 'returns other profiles than one selected for skills' do
     visit_skills_for_current_job_profile
 

--- a/spec/features/task_list_spec.rb
+++ b/spec/features/task_list_spec.rb
@@ -9,19 +9,29 @@ RSpec.feature 'Tasks List', type: :feature do
     expect(page).to have_text('Here\'s what you need to do to retrain for another job.')
   end
 
+  scenario 'With a clean new session the user will see sections 2,3,4,5 locked' do
+    disable_feature! :location_eligibility
+    visit(task_list_path)
+
+    (2..5).each do |section_no|
+      expect(page).to have_css("span#section-#{section_no}-blocked")
+    end
+  end
+
+  scenario 'With a clean new session the user will not be able to click sections 2,3,4,5' do
+    disable_feature! :location_eligibility
+    visit(task_list_path)
+
+    ['See types of jobs that match your skills', 'Find a training course', 'Find other ways to change jobs', 'Take a quick survey'].each do |link|
+      expect(page).to have_no_link(link)
+    end
+  end
+
   scenario 'User checks their existing skills' do
     visit(task_list_path)
     click_on('Check your existing skills')
 
     expect(page).to have_text('Check your existing skills')
-  end
-
-  scenario 'User explores their occupation' do
-    disable_feature! :skills_builder
-    visit(task_list_path)
-    click_on('Search for the types of jobs you could retrain to do')
-
-    expect(page).to have_text('Explore occupations')
   end
 
   scenario 'User navigates to skills matcher results page' do
@@ -32,26 +42,109 @@ RSpec.feature 'Tasks List', type: :feature do
 
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+
     visit(task_list_path)
-    click_on('Search for the types of jobs you could retrain to do')
+
+    click_on('See types of jobs that match your skills')
 
     expect(page).to have_text('Types of jobs that match your skills')
   end
 
-  scenario 'User finds a training course' do
-    disable_feature! :course_directory
+  scenario 'User unlocks the training course section by clicking Other ways to change jobs from job profile page' do
+    enable_feature! :course_directory, :skills_builder
+
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      name: 'Assassin',
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics')
+      ]
+    )
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+    visit(job_profile_path(job_profile.slug))
+    click_on('Other ways to change jobs')
 
     visit(task_list_path)
     click_on('Find a training course')
 
-    expect(page).to have_text('Find and apply to a training course near you')
+    expect(page).to have_text('Find training that boosts your job options')
   end
 
-  scenario 'User finds ouy next steps' do
-    visit(task_list_path)
-    click_on('Get more support to help you on your new career path')
+  scenario 'User unlocks the training course section by clicking Find a training course from job profile page' do
+    enable_feature! :course_directory, :skills_builder
 
-    expect(page).to have_text('Get advice and help in your search for a new role.')
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      name: 'Assassin',
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics')
+      ]
+    )
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+    visit("job-profiles/#{job_profile.slug}")
+    click_on('Find a training course')
+
+    visit(task_list_path)
+    click_on('Find a training course')
+
+    expect(page).to have_text('Find training that boosts your job options')
+  end
+
+  scenario 'User unlocks next steps section by clicking Find a training course from job profile page' do
+    enable_feature! :course_directory, :skills_builder
+
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      name: 'Assassin',
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics')
+      ]
+    )
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+    visit("job-profiles/#{job_profile.slug}")
+    click_on('Find a training course')
+
+    visit(task_list_path)
+    click_on('Find other ways to change jobs')
+
+    expect(page).to have_text('Further help to find work')
+  end
+
+  scenario 'User unlocks next steps section by clicking Other ways to change jobs from job profile page' do
+    enable_feature! :course_directory, :skills_builder
+
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      name: 'Assassin',
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics')
+      ]
+    )
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+    visit("job-profiles/#{job_profile.slug}")
+    click_on('Other ways to change jobs')
+
+    visit(task_list_path)
+    click_on('Find other ways to change jobs')
+
+    expect(page).to have_text('Further help to find work')
   end
 
   scenario 'Smart survey link is present on the top banner' do
@@ -67,10 +160,27 @@ RSpec.feature 'Tasks List', type: :feature do
     )
   end
 
-  scenario 'Smart survey link is present under Help improve this service section' do
+  scenario 'User unlocks survey section by clicking Find a training course from job profile page' do
+    enable_feature! :course_directory, :skills_builder
+
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      name: 'Assassin',
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics')
+      ]
+    )
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+    visit("job-profiles/#{job_profile.slug}")
+    click_on('Find a training course')
+
     visit(task_list_path)
 
-    link = find_link('Take a quick survey and tell us about your experience ')
+    link = find_link('Take a quick survey')
 
     expect([link[:href], link[:target]]).to eq(
       [
@@ -80,11 +190,107 @@ RSpec.feature 'Tasks List', type: :feature do
     )
   end
 
-  scenario 'User navigates to task list page when course directory feature is enabled' do
-    enable_feature! :course_directory
+  scenario 'User unlocks survey section by clicking Other ways to change jobs from job profile page' do
+    enable_feature! :course_directory, :skills_builder
+
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      name: 'Assassin',
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics')
+      ]
+    )
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+    visit("job-profiles/#{job_profile.slug}")
+    click_on('Other ways to change jobs')
 
     visit(task_list_path)
 
-    expect(page).to have_selector(:css, 'a[href="/training-hub"]')
+    link = find_link('Take a quick survey')
+
+    expect([link[:href], link[:target]]).to eq(
+      [
+        'https://www.smartsurvey.co.uk/s/get-help-to-retrain/',
+        '_blank'
+      ]
+    )
+  end
+
+  scenario 'User unlocks skill matcher section when clicking on Find out what you can do with these skills from /jobs-match' do
+    enable_feature! :course_directory, :skills_builder
+
+    skill = create(:skill)
+
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      name: 'Assassin',
+      skills: [skill]
+    )
+
+    create(
+      :job_profile,
+      skills: [skill]
+    )
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+
+    visit(task_list_path)
+
+    click_on('See types of jobs that match your skills')
+
+    expect(page).to have_text('Types of jobs that match your skills')
+  end
+
+  scenario 'Unlocking skill matcher section does not unlock sections 3,4,5' do
+    enable_feature! :course_directory, :skills_builder
+
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      name: 'Assassin',
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics')
+      ]
+    )
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+
+    visit(task_list_path)
+
+    (3..5).each do |section_no|
+      expect(page).to have_css("span#section-#{section_no}-blocked")
+    end
+  end
+
+  scenario 'Unlocking skill matcher section does not allow clicking sections 3,4,5' do
+    enable_feature! :course_directory, :skills_builder
+
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      name: 'Assassin',
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics')
+      ]
+    )
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    find('.govuk-button').click
+    click_on('Find out what you can do with these skills')
+
+    visit(task_list_path)
+
+    ['Find a training course', 'Find other ways to change jobs', 'Take a quick survey'].each do |link|
+      expect(page).to have_no_link(link)
+    end
   end
 end

--- a/spec/models/user_sessions_spec.rb
+++ b/spec/models/user_sessions_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe UserSession do
+  subject(:user_session) { described_class.new(session) }
+
+  let(:session) { HashWithIndifferentAccess.new }
+
+  describe '#track_page' do
+    it 'does store the tracked page in the session under visited_pages key' do
+      user_session.track_page('some_page')
+
+      expect(session[:visited_pages]).to contain_exactly('some_page')
+    end
+
+    it 'does store duplicates in the session' do
+      2.times do
+        user_session.track_page('some_page')
+      end
+
+      expect(session[:visited_pages]).to contain_exactly('some_page')
+    end
+  end
+
+  describe '#page_visited?' do
+    it 'returns true if the page has alreaady been persisted on the session' do
+      user_session.track_page('some_page')
+
+      expect(user_session.page_visited?('some_page')).to be true
+    end
+
+    it 'returns false if the page is not yet persisted on the session' do
+      expect(user_session.page_visited?('some_page')).to be false
+    end
+  end
+
+  describe '#job_profile_skills?' do
+    it 'returns true if the session already contains job profile skills' do
+      session[:job_profile_skills] = { '1' => [2, 3] }
+
+      expect(user_session.job_profile_skills?).to be true
+    end
+
+    it 'returns false if the session does not contain job profile skills' do
+      expect(user_session.job_profile_skills?).to be false
+    end
+  end
+end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -16,4 +16,22 @@ RSpec.describe 'Pages', type: :request do
       expect(session[:postcode]).to be nil
     end
   end
+
+  describe 'GET #next_steps' do
+    it 'presists next steps page on the session' do
+      get next_steps_path
+
+      expect(session[:visited_pages]).to eq(['next_steps'])
+    end
+  end
+
+  describe 'GET #training_hub' do
+    it 'presists next steps page on the session' do
+      enable_feature! :course_directory
+
+      get training_hub_path
+
+      expect(session[:visited_pages]).to eq(['training_hub'])
+    end
+  end
 end


### PR DESCRIPTION
### Context

We want to have user unlock the sections on our platform
once they've went to a certain flow as follows:

'CAN’T START YET' status shown on tasklist page
on all tasks except section 1.

‘CAN’T START YET’ removed from section two once user
has clicked on ‘Find out what you can do with
these skills’ CTA on selected skills page.

‘CAN’T START YET’ removed from sections 3,4,5  after user has
clicked on ‘Find a training course’ or ‘Other ways to change jobs’
CTAs on the job descriptions page.

The state of user progress is stored on the session.

###  Screenshots

![Screen Shot 2019-08-16 at 15 24 57](https://user-images.githubusercontent.com/1955084/63174469-e9d17d00-c039-11e9-8f48-753161788724.png)
![Screen Shot 2019-08-16 at 15 25 34](https://user-images.githubusercontent.com/1955084/63174470-e9d17d00-c039-11e9-8917-191902bc4596.png)
![Screen Shot 2019-08-16 at 15 25 49](https://user-images.githubusercontent.com/1955084/63174471-ea6a1380-c039-11e9-9bad-77b6faa9c26b.png)
![Screen Shot 2019-08-16 at 15 35 38](https://user-images.githubusercontent.com/1955084/63175126-41241d00-c03b-11e9-95df-a1ce2ec6c670.png)

### JIRA

https://dfedigital.atlassian.net/browse/GET-291
