### PR TITLE
Removed copy which suggests all courses are free

### DIFF
--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -2,7 +2,6 @@
   <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-heading-l title"><%= course.title %></h2>
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0 muted-text"><%= course.provider %></h3>
   <p class="govuk-body govuk-!-margin-bottom-0">Distance: <b><%= course.distance.round(1) %> miles</b></p>
-  <p class="govuk-body govuk-!-margin-bottom-1">Cost: <b>Free</b></p>
   <p class="govuk-body-s"><%= course.full_address %></p>
   <p class="govuk-body-s">Tel:<%= link_to(course.phone_number, "tel:#{course.phone_number}", class: 'govuk-!-padding-left-1 govuk-link' ) %></p>
   <%= link_to 'Visit website', course.url, class: 'govuk-!-margin-bottom-6 govuk-button', target: '_blank', data: { tracked_event: "Courses - Clicked course link: #{course.url}" } %>

--- a/app/views/shared/training_hub/_maths.html.erb
+++ b/app/views/shared/training_hub/_maths.html.erb
@@ -1,5 +1,5 @@
 <h2 class="govuk-heading-m govuk-!-margin-bottom-1 title">Maths</h2>
-<p class="govuk-body-m govuk-!-margin-bottom-1">Employers tell us they are looking for people who can show they have some maths skills. Completing a short maths course can really boost your job prospects in many different types of work. </p>
+<p class="govuk-body-m govuk-!-margin-bottom-1">Employers tell us they are looking for people who can show they have some maths skills. Completing a free maths course can really boost your job prospects in many different types of work. </p>
 <%= link_to('More information on maths courses', maths_course_overview_path, class: 'govuk-body-m govuk-link') %>
 <br>
 <%= link_to('Find a maths course', courses_path('maths'), class: 'govuk-button govuk-!-margin-top-5 govuk-button govuk-!-margin-bottom-2') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,7 +112,7 @@ en-GB:
     cta_copy: Other ways to change jobs
   boost_job_prospects:
     title: Boost your job prospects
-    sub_title: Access free and flexible training that improves your job options.
+    sub_title: Access flexible training that improves your job options.
     cta_copy: Find a training course
   help_improve_this_service:
     title: Help improve this service


### PR DESCRIPTION
### Context
Only some courses are free; revised wording as per ticket but left the copy on training hub page as is. The wording on there is softer and doesn't imply all courses are free. No tests broke as a result, so no corresponding spec changes.

### Guidance to review
* Check that individual courses don't show "Cost: Free" in the course list pages
* Check that side bar on job details page doesn't include "free"
