### PR TITLE
Add custom event tracking for selected skills in skills builder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,8 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 Style/Documentation:
   Enabled: false
+Metrics/AbcSize:
+  Max: 20
 Metrics/LineLength:
   Max: 120
 Style/GuardClause:

--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -6,6 +6,8 @@ class SkillsController < ApplicationController
       session[:current_job_id] = job_profile.id
       @skills = Skill.find(skill_ids)
 
+      track_event(:skills_index_selected, job_profile.slug => skill_ids)
+
       render 'index_v2'
     else
       @skills = job_profile.skills

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en-GB:
     check_your_skills_index_search: Check your skills - Job search
     explore_occupations_index_search: Explore occupations - Job search
     courses_index_search: Courses near me - Postcode search
+    skills_index_selected: Current job skills - Skills selected
 
   contact_us:
     title: Speak to an adviser


### PR DESCRIPTION
### Context
Keep track of which skills are selected in skills matcher.

https://dfedigital.atlassian.net/browse/GET-309

### Changes proposed in this pull request
This uses Job slug for custom dimension key, with an array of skill id's as the value. This was tried with skill names but the text ends up extremely long and unreadable within AAI (we don't have any other skill attributes!). Skill id's can be correlated with skills by exporting the skills from active admin.

### Guidance to review
Tracking implementation needs a wholescale refactor to support testing; for now (due to time constraints) this does not have coverage but will be addressed soon.

Jira ticket suggests an original approach of making one tracking call for each skill; after further consideration this does not feel like a scalable approach, particularly when we move to skills builder v2 which allows upto 5 jobs per user. The ticket also mentions listing skills that were not selected; again this would involve an extra query per job profile to get the full set of skill id's - instead we can infer this information by linking an export of skills/job profiles to the selected skill ids.

This can be tested by deploying to a dev environment and then querying `customEvents` with Application Insights logs e.g. https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-dev/providers/Microsoft.Insights/components/s108d01-dev-as/logs

<img width="991" alt="Screenshot 2019-08-19 at 10 06 09" src="https://user-images.githubusercontent.com/280472/63253044-01db1380-c269-11e9-8150-b819dff98475.png">

