### PR TITLE
Revert powershell command because retry is not available

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -237,9 +237,6 @@ stages:
             resourceGroupName: s108t01-qa
             Slot: staging
 
-        - powershell:  Invoke-WebRequest -RetryIntervalSec 10 -MaximumRetryCount 5 -Uri "https://s108t01-qa-as-staging.azurewebsites.net"
-          ignoreLASTEXITCODE: true
-
         - task: AzureAppServiceManage@0
           displayName: 'Swap Slots: QA'
           inputs:


### PR DESCRIPTION
Revert powershell command because retry is not available on PowerShell 5.1.
We need some sort of retry.
