### PR TITLE
GET-407 Force locale and collation settings to english GB

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,8 @@ resources:
       POSTGRES_DB: 'get-help-to-retrain'
       POSTGRES_USER: 'test'
       POSTGRES_PASSWORD: 'test'
+      LANG: en_GB.UTF-8
+      LC_ALL: en_GB.UTF-8
   - container: 'selenium'
     image: 'selenium/standalone-chrome:3'
     ports:


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-407

Failures in tests are happening sporadically on sorting order, specifically alphabetically in CI. I could not replicate this locally with docker, but setting the encoding/collation explicitly as a test for now to see if this will mitigate the issue for the future, as we are not sure what is forcing the collation to change on specific vms.