### PR TITLE
GET-307 Change pagination to read from array rather than perform a db query

### DIFF
--- a/app/controllers/check_your_skills_controller.rb
+++ b/app/controllers/check_your_skills_controller.rb
@@ -12,7 +12,7 @@ class CheckYourSkillsController < ApplicationController
     track_event(:check_your_skills_index_search, search: search) if search.present?
 
     @job_profile_search = JobProfileSearch.new(term: search, profile_ids_to_exclude: profile_ids_to_exclude)
-    @job_profiles = @job_profile_search.search.page(params[:page])
+    @job_profiles = Kaminari.paginate_array(@job_profile_search.search).page(params[:page])
   end
 
   private


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-307

Use kaminari pagination via array rather than db query with offsets and ordering, as that is creating surprising behaviour in text search and messes with the ordering of the query itself and introduces duplicates.

This has no implications on performance either.

Ready to test on: https://dev1.nrs-ghtr.org.uk/task-list


