### PR TITLE
GET-383 user session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   def user_session
-    @user_session ||= ::UserSession.new(session)
+    @user_session ||= UserSession.new(session)
   end
 
   helper_method :user_session

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -14,7 +14,7 @@ class CoursesController < ApplicationController
   private
 
   def postcode
-    @postcode ||= courses_params[:postcode] || session[:postcode]
+    @postcode ||= courses_params[:postcode] || user_session.postcode
   end
 
   def courses_params

--- a/app/controllers/job_profiles_skills_controller.rb
+++ b/app/controllers/job_profiles_skills_controller.rb
@@ -21,7 +21,7 @@ class JobProfilesSkillsController < ApplicationController
     @skills_builder ||= SkillsBuilder.new(
       skills_params: skills_params[:skill_ids],
       job_profile: job_profile,
-      user_session: session
+      user_session: user_session
     )
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,7 +11,7 @@ class PagesController < ApplicationController
     track_event(:pages_location_eligibility_search, search: postcode) if postcode.present?
     @search = CourseGeospatialSearch.new(postcode: postcode)
     if postcode && @search.valid?
-      user_session.store_at(key: :postcode, value: postcode)
+      user_session.postcode = postcode
 
       location_eligibility_through_courses
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,7 +11,7 @@ class PagesController < ApplicationController
     track_event(:pages_location_eligibility_search, search: postcode) if postcode.present?
     @search = CourseGeospatialSearch.new(postcode: postcode)
     if postcode && @search.valid?
-      session[:postcode] = postcode
+      user_session.store_at(key: :postcode, value: postcode)
 
       location_eligibility_through_courses
     end

--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -16,7 +16,7 @@ class SkillsController < ApplicationController
   def show_skills_builder
     return redirect_to task_list_path unless job_profile_and_skills_present
 
-    user_session.store_at(key: :current_job_id, value: job_profile.id)
+    user_session.current_job_id = job_profile.id
     @skills = Skill.find(skill_ids_for_job_profile)
     track_event(:skills_index_selected, job_profile.slug => skill_ids_for_job_profile)
   end

--- a/app/models/skills_builder.rb
+++ b/app/models/skills_builder.rb
@@ -8,18 +8,17 @@ class SkillsBuilder
     @skills_params = skills_params
     @job_profile = job_profile
     @user_session = user_session
-    @user_session[:job_profile_skills] = user_session[:job_profile_skills] || {}
   end
 
   def build
     return unless skills_params.present?
 
-    user_session[:job_profile_skills][job_profile.id.to_s] = formatted_skill_params
+    user_session.set_skills_ids_for_profile(job_profile.id, formatted_skill_params)
   end
 
   def skill_ids
     @skill_ids ||=
-      user_session[:job_profile_skills][job_profile.id.to_s] ||
+      user_session.job_profile_skills[job_profile.id.to_s] ||
       job_profile.skills.pluck(:id)
   end
 

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -2,9 +2,16 @@ class UserSession
   attr_reader :session
 
   def initialize(session)
+    session.destroy unless session[:version] == expected_version
+
     @session = session
     @session[:visited_pages] ||= []
     @session[:job_profile_skills] ||= {}
+    @session[:version] ||= expected_version
+  end
+
+  def version
+    session[:version]
   end
 
   def postcode
@@ -71,5 +78,9 @@ class UserSession
 
   def current_job_id
     session[:current_job_id]
+  end
+
+  def expected_version
+    Flipflop.skills_builder_v2? ? 2 : 1
   end
 end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -6,6 +6,10 @@ class UserSession
     @session[:visited_pages] ||= []
   end
 
+  def postcode
+    session[:postcode]
+  end
+
   def track_page(page_key)
     session[:visited_pages] << page_key unless session[:visited_pages].include?(page_key)
   end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -2,9 +2,9 @@ class UserSession
   attr_reader :session
 
   def initialize(session)
-    session.destroy unless session[:version] == expected_version
-
     @session = session
+    @session.destroy unless version == expected_version
+
     @session[:visited_pages] ||= []
     @session[:job_profile_skills] ||= {}
     @session[:version] ||= expected_version
@@ -18,12 +18,20 @@ class UserSession
     session[:postcode]
   end
 
-  def job_profile_skills
-    session[:job_profile_skills]
+  def postcode=(value)
+    session[:postcode] = value
   end
 
-  def store_at(key:, value:)
-    session[key] = value
+  def current_job_id
+    session[:current_job_id]
+  end
+
+  def current_job_id=(value)
+    session[:current_job_id] = value
+  end
+
+  def job_profile_skills
+    session[:job_profile_skills]
   end
 
   def set_skills_ids_for_profile(job_profile_id, skill_ids)
@@ -31,7 +39,7 @@ class UserSession
   end
 
   def track_page(page_key)
-    session[:visited_pages] << page_key unless session[:visited_pages].include?(page_key)
+    session[:visited_pages] << page_key unless page_visited?(page_key)
   end
 
   def current_job?
@@ -75,10 +83,6 @@ class UserSession
   end
 
   private
-
-  def current_job_id
-    session[:current_job_id]
-  end
 
   def expected_version
     Flipflop.skills_builder_v2? ? 2 : 1

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -4,18 +4,31 @@ class UserSession
   def initialize(session)
     @session = session
     @session[:visited_pages] ||= []
+    @session[:job_profile_skills] ||= {}
   end
 
   def postcode
     session[:postcode]
   end
 
-  def track_page(page_key)
-    session[:visited_pages] << page_key unless session[:visited_pages].include?(page_key)
+  def job_profile_skills
+    session[:job_profile_skills]
   end
 
   def store_at(key:, value:)
     session[key] = value
+  end
+
+  def set_skills_ids_for_profile(job_profile_id, skill_ids)
+    job_profile_skills[job_profile_id.to_s] = skill_ids
+  end
+
+  def track_page(page_key)
+    session[:visited_pages] << page_key unless session[:visited_pages].include?(page_key)
+  end
+
+  def current_job?
+    session[:current_job_id].present?
   end
 
   def page_visited?(page_key)
@@ -24,6 +37,18 @@ class UserSession
 
   def job_profile_skills?
     job_profile_skills.keys.present?
+  end
+
+  def job_profiles_cap_reached?
+    job_profile_skills
+      .reject { |_k, v| v.size.zero? }
+      .keys
+      .size > 4
+  end
+
+  def unblock_all_sections?
+    page_visited?('skills_matcher_index') &&
+      (page_visited?('training_hub') || page_visited?('next_steps'))
   end
 
   def skill_ids
@@ -42,29 +67,9 @@ class UserSession
     job_profile_skills[id.to_s] || []
   end
 
-  def current_job?
-    session[:current_job_id].present?
-  end
+  private
 
   def current_job_id
     session[:current_job_id]
-  end
-
-  def job_profiles_cap_reached?
-    job_profile_skills
-      .reject { |_k, v| v.size.zero? }
-      .keys
-      .size > 4
-  end
-
-  def unblock_all_sections?
-    page_visited?('skills_matcher_index') &&
-      (page_visited?('training_hub') || page_visited?('next_steps'))
-  end
-
-  private
-
-  def job_profile_skills
-    session.fetch(:job_profile_skills, {})
   end
 end

--- a/spec/models/skills_builder_spec.rb
+++ b/spec/models/skills_builder_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 RSpec.describe SkillsBuilder do
   describe '#build' do
     it 'does not set user_session if no skills params available' do
+      session = create_fake_session({})
       job_profile = create(:job_profile, skills: [create(:skill)])
       builder = described_class.new(
         skills_params: nil,
         job_profile: job_profile,
-        user_session: UserSession.new({})
+        user_session: UserSession.new(session)
       )
 
       builder.build
@@ -15,11 +16,12 @@ RSpec.describe SkillsBuilder do
     end
 
     it 'sets user_session to correct skills format if skills params available' do
+      session = create_fake_session({})
       job_profile = create(:job_profile, skills: [create(:skill)])
       builder = described_class.new(
         skills_params: %w[1 2],
         job_profile: job_profile,
-        user_session: UserSession.new({})
+        user_session: UserSession.new(session)
       )
 
       builder.build
@@ -27,11 +29,12 @@ RSpec.describe SkillsBuilder do
     end
 
     it 'ignores empty skill param ids when setting user_session' do
+      session = create_fake_session({})
       job_profile = create(:job_profile, skills: [create(:skill)])
       builder = described_class.new(
         skills_params: ['1', ''],
         job_profile: job_profile,
-        user_session: UserSession.new({})
+        user_session: UserSession.new(session)
       )
 
       builder.build
@@ -40,12 +43,11 @@ RSpec.describe SkillsBuilder do
 
     it 'overrides existing user session with new skill param ids' do
       job_profile = create(:job_profile, skills: [create(:skill)])
+      session = create_fake_session(job_profile_skills: { job_profile.id.to_s => [3, 4] })
       builder = described_class.new(
         skills_params: ['1', '', '5', '6'],
         job_profile: job_profile,
-        user_session: UserSession.new(
-          job_profile_skills: { job_profile.id.to_s => [3, 4] }
-        )
+        user_session: UserSession.new(session)
       )
 
       builder.build
@@ -55,12 +57,11 @@ RSpec.describe SkillsBuilder do
     it 'handles existing user session with new skill param ids if another job profile present' do
       job_profile1 = create(:job_profile, skills: [create(:skill)])
       job_profile2 = create(:job_profile, skills: [create(:skill)])
+      session = create_fake_session(job_profile_skills: { job_profile1.id.to_s => [3, 4] })
       builder = described_class.new(
         skills_params: ['1', '', '5', '6'],
         job_profile: job_profile2,
-        user_session: UserSession.new(
-          job_profile_skills: { job_profile1.id.to_s => [3, 4] }
-        )
+        user_session: UserSession.new(session)
       )
 
       builder.build
@@ -73,15 +74,16 @@ RSpec.describe SkillsBuilder do
     it 'updates existing user session with skill param ids if another job profile present' do
       job_profile1 = create(:job_profile, skills: [create(:skill)])
       job_profile2 = create(:job_profile, skills: [create(:skill)])
+      session = create_fake_session(
+        job_profile_skills: {
+          job_profile1.id.to_s => [3, 4],
+          job_profile2.id.to_s => [3]
+        }
+      )
       builder = described_class.new(
         skills_params: ['1', '', '5', '6'],
         job_profile: job_profile2,
-        user_session: UserSession.new(
-          job_profile_skills: {
-            job_profile1.id.to_s => [3, 4],
-            job_profile2.id.to_s => [3]
-          }
-        )
+        user_session: UserSession.new(session)
       )
 
       builder.build
@@ -94,6 +96,7 @@ RSpec.describe SkillsBuilder do
 
   describe '#skill_ids' do
     it 'returns all job profile skill ids if no user_session' do
+      session = create_fake_session({})
       skill1 = create(:skill)
       skill2 = create(:skill)
       job_profile = create(:job_profile, skills: [skill1, skill2])
@@ -101,7 +104,7 @@ RSpec.describe SkillsBuilder do
       builder = described_class.new(
         skills_params: nil,
         job_profile: job_profile,
-        user_session: UserSession.new({})
+        user_session: UserSession.new(session)
       )
 
       builder.build
@@ -112,12 +115,13 @@ RSpec.describe SkillsBuilder do
       skill1 = create(:skill)
       skill2 = create(:skill)
       job_profile = create(:job_profile, skills: [skill1, skill2])
+      session = create_fake_session(
+        job_profile_skills: { job_profile.id.to_s => [skill1.id] }
+      )
       builder = described_class.new(
         skills_params: nil,
         job_profile: job_profile,
-        user_session: UserSession.new(
-          job_profile_skills: { job_profile.id.to_s => [skill1.id] }
-        )
+        user_session: UserSession.new(session)
       )
 
       builder.build
@@ -128,13 +132,14 @@ RSpec.describe SkillsBuilder do
       skill1 = create(:skill)
       skill2 = create(:skill)
       job_profile = create(:job_profile, skills: [skill1, skill2])
+      session = create_fake_session(
+        job_profile_skills: { job_profile.id.to_s => [3, 4] }
+      )
 
       builder = described_class.new(
         skills_params: ['1', '', '2'],
         job_profile: job_profile,
-        user_session: UserSession.new(
-          job_profile_skills: { job_profile.id.to_s => [3, 4] }
-        )
+        user_session: UserSession.new(session)
       )
 
       builder.build
@@ -147,16 +152,17 @@ RSpec.describe SkillsBuilder do
       skill3 = create(:skill)
       job_profile1 = create(:job_profile, skills: [skill1, skill2])
       job_profile2 = create(:job_profile, skills: [skill1, skill3])
+      session = create_fake_session(
+        job_profile_skills: {
+          job_profile1.id.to_s => [skill1.id],
+          job_profile2.id.to_s => [skill1.id]
+        }
+      )
 
       builder = described_class.new(
         skills_params: [skill3.id.to_s, ''],
         job_profile: job_profile2,
-        user_session: UserSession.new(
-          job_profile_skills: {
-            job_profile1.id.to_s => [skill1.id],
-            job_profile2.id.to_s => [skill1.id]
-          }
-        )
+        user_session: UserSession.new(session)
       )
 
       builder.build
@@ -166,22 +172,24 @@ RSpec.describe SkillsBuilder do
 
   describe 'validation' do
     it 'is invalid if no skills selected' do
+      session = create_fake_session({})
       job_profile = create(:job_profile, skills: [create(:skill)])
       builder = described_class.new(
         skills_params: [''],
         job_profile: job_profile,
-        user_session: UserSession.new({})
+        user_session: UserSession.new(session)
       )
 
       expect(builder).not_to be_valid
     end
 
     it 'is valid if skills selected' do
+      session = create_fake_session({})
       job_profile = create(:job_profile, skills: [create(:skill)])
       builder = described_class.new(
         skills_params: ['1', '', '4'],
         job_profile: job_profile,
-        user_session: UserSession.new({})
+        user_session: UserSession.new(session)
       )
 
       expect(builder).to be_valid

--- a/spec/models/skills_builder_spec.rb
+++ b/spec/models/skills_builder_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe SkillsBuilder do
       builder = described_class.new(
         skills_params: nil,
         job_profile: job_profile,
-        user_session: {}
+        user_session: UserSession.new({})
       )
 
       builder.build
-      expect(builder.user_session[:job_profile_skills]).to be_empty
+      expect(builder.user_session.job_profile_skills).to be_empty
     end
 
     it 'sets user_session to correct skills format if skills params available' do
@@ -19,11 +19,11 @@ RSpec.describe SkillsBuilder do
       builder = described_class.new(
         skills_params: %w[1 2],
         job_profile: job_profile,
-        user_session: {}
+        user_session: UserSession.new({})
       )
 
       builder.build
-      expect(builder.user_session).to eq(job_profile_skills: { job_profile.id.to_s => [1, 2] })
+      expect(builder.user_session.job_profile_skills).to eq(job_profile.id.to_s => [1, 2])
     end
 
     it 'ignores empty skill param ids when setting user_session' do
@@ -31,11 +31,11 @@ RSpec.describe SkillsBuilder do
       builder = described_class.new(
         skills_params: ['1', ''],
         job_profile: job_profile,
-        user_session: {}
+        user_session: UserSession.new({})
       )
 
       builder.build
-      expect(builder.user_session).to eq(job_profile_skills: { job_profile.id.to_s => [1] })
+      expect(builder.user_session.job_profile_skills).to eq(job_profile.id.to_s => [1])
     end
 
     it 'overrides existing user session with new skill param ids' do
@@ -43,11 +43,13 @@ RSpec.describe SkillsBuilder do
       builder = described_class.new(
         skills_params: ['1', '', '5', '6'],
         job_profile: job_profile,
-        user_session: { job_profile_skills: { job_profile.id.to_s => [3, 4] } }
+        user_session: UserSession.new(
+          job_profile_skills: { job_profile.id.to_s => [3, 4] }
+        )
       )
 
       builder.build
-      expect(builder.user_session).to eq(job_profile_skills: { job_profile.id.to_s => [1, 5, 6] })
+      expect(builder.user_session.job_profile_skills).to eq(job_profile.id.to_s => [1, 5, 6])
     end
 
     it 'handles existing user session with new skill param ids if another job profile present' do
@@ -56,15 +58,15 @@ RSpec.describe SkillsBuilder do
       builder = described_class.new(
         skills_params: ['1', '', '5', '6'],
         job_profile: job_profile2,
-        user_session: { job_profile_skills: { job_profile1.id.to_s => [3, 4] } }
+        user_session: UserSession.new(
+          job_profile_skills: { job_profile1.id.to_s => [3, 4] }
+        )
       )
 
       builder.build
-      expect(builder.user_session).to eq(
-        job_profile_skills: {
-          job_profile1.id.to_s => [3, 4],
-          job_profile2.id.to_s => [1, 5, 6]
-        }
+      expect(builder.user_session.job_profile_skills).to eq(
+        job_profile1.id.to_s => [3, 4],
+        job_profile2.id.to_s => [1, 5, 6]
       )
     end
 
@@ -74,20 +76,18 @@ RSpec.describe SkillsBuilder do
       builder = described_class.new(
         skills_params: ['1', '', '5', '6'],
         job_profile: job_profile2,
-        user_session: {
+        user_session: UserSession.new(
           job_profile_skills: {
             job_profile1.id.to_s => [3, 4],
             job_profile2.id.to_s => [3]
           }
-        }
+        )
       )
 
       builder.build
-      expect(builder.user_session).to eq(
-        job_profile_skills: {
-          job_profile1.id.to_s => [3, 4],
-          job_profile2.id.to_s => [1, 5, 6]
-        }
+      expect(builder.user_session.job_profile_skills).to eq(
+        job_profile1.id.to_s => [3, 4],
+        job_profile2.id.to_s => [1, 5, 6]
       )
     end
   end
@@ -101,7 +101,7 @@ RSpec.describe SkillsBuilder do
       builder = described_class.new(
         skills_params: nil,
         job_profile: job_profile,
-        user_session: {}
+        user_session: UserSession.new({})
       )
 
       builder.build
@@ -115,7 +115,9 @@ RSpec.describe SkillsBuilder do
       builder = described_class.new(
         skills_params: nil,
         job_profile: job_profile,
-        user_session: { job_profile_skills: { job_profile.id.to_s => [skill1.id] } }
+        user_session: UserSession.new(
+          job_profile_skills: { job_profile.id.to_s => [skill1.id] }
+        )
       )
 
       builder.build
@@ -130,7 +132,9 @@ RSpec.describe SkillsBuilder do
       builder = described_class.new(
         skills_params: ['1', '', '2'],
         job_profile: job_profile,
-        user_session: { job_profile_skills: { job_profile.id.to_s => [3, 4] } }
+        user_session: UserSession.new(
+          job_profile_skills: { job_profile.id.to_s => [3, 4] }
+        )
       )
 
       builder.build
@@ -147,12 +151,12 @@ RSpec.describe SkillsBuilder do
       builder = described_class.new(
         skills_params: [skill3.id.to_s, ''],
         job_profile: job_profile2,
-        user_session: {
+        user_session: UserSession.new(
           job_profile_skills: {
             job_profile1.id.to_s => [skill1.id],
             job_profile2.id.to_s => [skill1.id]
           }
-        }
+        )
       )
 
       builder.build
@@ -166,7 +170,7 @@ RSpec.describe SkillsBuilder do
       builder = described_class.new(
         skills_params: [''],
         job_profile: job_profile,
-        user_session: {}
+        user_session: UserSession.new({})
       )
 
       expect(builder).not_to be_valid
@@ -177,7 +181,7 @@ RSpec.describe SkillsBuilder do
       builder = described_class.new(
         skills_params: ['1', '', '4'],
         job_profile: job_profile,
-        user_session: {}
+        user_session: UserSession.new({})
       )
 
       expect(builder).to be_valid

--- a/spec/models/skills_matcher_spec.rb
+++ b/spec/models/skills_matcher_spec.rb
@@ -3,10 +3,9 @@ require 'rails_helper'
 RSpec.describe SkillsMatcher do
   describe '#match' do
     it 'returns no jobs if no session skills selected' do
-      user_session = UserSession.new({})
-
+      session = create_fake_session({})
       create(:job_profile, skills: [create(:skill)])
-      matcher = described_class.new(user_session)
+      matcher = described_class.new(UserSession.new(session))
 
       expect(matcher.match).to be_empty
     end
@@ -16,13 +15,12 @@ RSpec.describe SkillsMatcher do
       job_profile1 = create(:job_profile, skills: [skill])
       job_profile2 = create(:job_profile, skills: [skill])
       job_profile3 = create(:job_profile, skills: [skill])
-      session = {
+      session = create_fake_session(
         job_profile_skills: {
           job_profile1.id.to_s => [skill.id]
         }
-      }
-      user_session = UserSession.new(session)
-      matcher = described_class.new(user_session)
+      )
+      matcher = described_class.new(UserSession.new(session))
 
       expect(matcher.match).to contain_exactly(job_profile2, job_profile3)
     end
@@ -35,13 +33,12 @@ RSpec.describe SkillsMatcher do
       create(:job_profile, skills: [skill2])
       job_profile2 = create(:job_profile, skills: [skill2, skill3])
       job_profile3 = create(:job_profile, skills: [skill1, skill3])
-      session = {
+      session = create_fake_session(
         job_profile_skills: {
           job_profile1.id.to_s => [skill1.id, skill3.id]
         }
-      }
-      user_session = UserSession.new(session)
-      matcher = described_class.new(user_session)
+      )
+      matcher = described_class.new(UserSession.new(session))
 
       expect(matcher.match).to contain_exactly(job_profile2, job_profile3)
     end
@@ -55,14 +52,13 @@ RSpec.describe SkillsMatcher do
       job_profile2 = create(:job_profile, skills: [skill3])
       job_profile3 = create(:job_profile, skills: [skill3])
       job_profile4 = create(:job_profile, skills: [skill1])
-      session = {
+      session = create_fake_session(
         job_profile_skills: {
           job_profile1.id.to_s => [skill1.id],
           job_profile2.id.to_s => [skill3.id]
         }
-      }
-      user_session = UserSession.new(session)
-      matcher = described_class.new(user_session)
+      )
+      matcher = described_class.new(UserSession.new(session))
 
       expect(matcher.match).to contain_exactly(job_profile3, job_profile4)
     end
@@ -76,14 +72,13 @@ RSpec.describe SkillsMatcher do
       job_profile3 = create(:job_profile, skills: [skill1, skill2, skill3])
       job_profile4 = create(:job_profile, skills: [skill1, skill2, skill3])
       job_profile5 = create(:job_profile, skills: [skill1, skill3])
-      session = {
+      session = create_fake_session(
         job_profile_skills: {
           job_profile3.id.to_s => [skill1.id, skill2.id],
           job_profile1.id.to_s => [skill1.id, skill3.id]
         }
-      }
-      user_session = UserSession.new(session)
-      matcher = described_class.new(user_session)
+      )
+      matcher = described_class.new(UserSession.new(session))
 
       expect(matcher.match).to eq([job_profile4, job_profile5, job_profile2])
     end
@@ -97,15 +92,14 @@ RSpec.describe SkillsMatcher do
       create(:job_profile, skills: [skill2])
       job_profile2 = create(:job_profile, skills: [skill1, skill2, skill3, skill4])
       job_profile3 = create(:job_profile, skills: [skill1, skill3])
-      session = {
+      session = create_fake_session(
         current_job_id: job_profile1.id,
         job_profile_skills: {
           job_profile2.id.to_s => [skill1.id, skill2.id],
           job_profile1.id.to_s => [skill1.id, skill3.id, skill4.id]
         }
-      }
-      user_session = UserSession.new(session)
-      matcher = described_class.new(user_session)
+      )
+      matcher = described_class.new(UserSession.new(session))
 
       expect(matcher.match).to eq([job_profile2, job_profile3])
     end
@@ -119,16 +113,15 @@ RSpec.describe SkillsMatcher do
       job_profile3 = create(:job_profile, name: 'Beekeeper', skills: [skill1, skill2, skill3])
       job_profile4 = create(:job_profile, name: 'Admin', skills: [skill1, skill2, skill3])
       job_profile5 = create(:job_profile, name: 'Boat builder', skills: [skill3])
-      session = {
+      session = create_fake_session(
         job_profile_skills: {
           job_profile1.id.to_s => [skill1.id, skill2.id, skill3.id]
         }
-      }
+      )
       puts "Profile #{job_profile4.name} skills: " + job_profile4.skills.pluck(:name).join(', ')
       puts "Profile #{job_profile3.name} skills: " + job_profile3.skills.pluck(:name).join(', ')
 
-      user_session = UserSession.new(session)
-      matcher = described_class.new(user_session).match
+      matcher = described_class.new(UserSession.new(session)).match
       puts 'Profile scores: ' + matcher.map(&:skills_matched).join(', ')
 
       expect(matcher).to eq(
@@ -146,13 +139,12 @@ RSpec.describe SkillsMatcher do
       job_profile1 = create(:job_profile, skills: [skill])
       create(:job_profile, :excluded, skills: [skill])
       job_profile2 = create(:job_profile, skills: [skill])
-      session = {
+      session = create_fake_session(
         job_profile_skills: {
           job_profile1.id.to_s => [skill.id]
         }
-      }
-      user_session = UserSession.new(session)
-      matcher = described_class.new(user_session)
+      )
+      matcher = described_class.new(UserSession.new(session))
 
       expect(matcher.match).to contain_exactly(job_profile2)
     end
@@ -164,13 +156,12 @@ RSpec.describe SkillsMatcher do
       job_profile1 = create(:job_profile, skills: [skill])
       job_profile2 = create(:job_profile, skills: [skill])
       job_profile3 = create(:job_profile, skills: [skill])
-      session = {
+      session = create_fake_session(
         job_profile_skills: {
           job_profile1.id.to_s => [skill.id]
         }
-      }
-      user_session = UserSession.new(session)
-      matcher = described_class.new(user_session)
+      )
+      matcher = described_class.new(UserSession.new(session))
 
       expect(matcher.job_profile_scores).to eq(
         job_profile2.id => 100.0,
@@ -184,13 +175,12 @@ RSpec.describe SkillsMatcher do
       job_profile1 = create(:job_profile, skills: [skill1, skill2])
       job_profile2 = create(:job_profile, skills: [skill1])
       job_profile3 = create(:job_profile, skills: [skill1, skill2])
-      session = {
+      session = create_fake_session(
         job_profile_skills: {
           job_profile1.id.to_s => [skill1.id, skill2.id]
         }
-      }
-      user_session = UserSession.new(session)
-      matcher = described_class.new(user_session)
+      )
+      matcher = described_class.new(UserSession.new(session))
 
       expect(matcher.job_profile_scores).to eq(
         job_profile2.id => 50.0,
@@ -205,15 +195,14 @@ RSpec.describe SkillsMatcher do
       job_profile2 = create(:job_profile, skills: [skill1])
       job_profile3 = create(:job_profile, skills: [skill1, skill2])
       job_profile4 = create(:job_profile, skills: [skill2])
-      session = {
+      session = create_fake_session(
         job_profile_skills: {
           job_profile1.id.to_s => [skill2.id],
           job_profile2.id.to_s => [skill1.id]
         }
-      }
+      )
 
-      user_session = UserSession.new(session)
-      matcher = described_class.new(user_session)
+      matcher = described_class.new(UserSession.new(session))
 
       expect(matcher.job_profile_scores).to eq(
         job_profile4.id => 50.0,
@@ -229,15 +218,14 @@ RSpec.describe SkillsMatcher do
       job_profile2 = create(:job_profile, skills: [skill1])
       job_profile3 = create(:job_profile, skills: [skill1, skill2])
       create(:job_profile, skills: [skill2])
-      session = {
+      session = create_fake_session(
         current_job_id: job_profile2.id,
         job_profile_skills: {
           job_profile1.id.to_s => [skill2.id],
           job_profile2.id.to_s => [skill1.id, skill3.id]
         }
-      }
-      user_session = UserSession.new(session)
-      matcher = described_class.new(user_session)
+      )
+      matcher = described_class.new(UserSession.new(session))
 
       expect(matcher.job_profile_scores).to eq(
         job_profile1.id => 50.0,

--- a/spec/models/user_sessions_spec.rb
+++ b/spec/models/user_sessions_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe UserSession do
 
   describe '#version' do
     it 'sets version on new session' do
-      user_session = described_class.new(create_fake_session(session, version: false))
+      user_session = described_class.new(create_fake_session(session, versioned: false))
 
       expect(user_session.version).to eq(1)
     end
 
     it 'retains correct version on existing session' do
       session = { version: 1 }
-      user_session = described_class.new(create_fake_session(session, version: false))
+      user_session = described_class.new(create_fake_session(session, versioned: false))
 
       expect(user_session.version).to eq(1)
     end
@@ -29,14 +29,14 @@ RSpec.describe UserSession do
         version: 1,
         job_profile_skills: { '11' => [2, 3, 5] }
       }
-      user_session = described_class.new(create_fake_session(session, version: false))
+      user_session = described_class.new(create_fake_session(session, versioned: false))
 
       expect(user_session.job_profile_skills).to eq('11' => [2, 3, 5])
     end
 
     it 'resets version when existing version does not equal current version' do
       session = { version: 0 }
-      user_session = described_class.new(create_fake_session(session, version: false))
+      user_session = described_class.new(create_fake_session(session, versioned: false))
 
       expect(user_session.version).to eq(1)
     end
@@ -46,14 +46,14 @@ RSpec.describe UserSession do
         version: 0,
         job_profile_skills: { '11' => [2, 3, 5] }
       }
-      user_session = described_class.new(create_fake_session(session, version: false))
+      user_session = described_class.new(create_fake_session(session, versioned: false))
 
       expect(user_session.job_profile_skills).to be_empty
     end
 
     it 'reset session when existing session does not have a version' do
       session = { job_profile_skills: { '11' => [2, 3, 5] } }
-      user_session = described_class.new(create_fake_session(session, version: false))
+      user_session = described_class.new(create_fake_session(session, versioned: false))
 
       expect(user_session.job_profile_skills).to be_empty
     end
@@ -65,7 +65,7 @@ RSpec.describe UserSession do
           version: 1,
           job_profile_skills: { '11' => [2, 3, 5] }
         }
-        user_session = described_class.new(create_fake_session(session, version: false))
+        user_session = described_class.new(create_fake_session(session, versioned: false))
 
         expect(user_session.job_profile_skills).to be_empty
       end
@@ -74,13 +74,25 @@ RSpec.describe UserSession do
 
   describe '#postcode' do
     it 'returns postcode value if set' do
-      session[:postcode] = 'NW118QE'
+      user_session.postcode = 'NW118QE'
 
       expect(user_session.postcode).to eq('NW118QE')
     end
 
     it 'returns nil if no postcode set' do
       expect(user_session.postcode).to be_nil
+    end
+  end
+
+  describe '#current_job_id' do
+    it 'returns current_job_id value if set' do
+      user_session.current_job_id = 1
+
+      expect(user_session.current_job_id).to eq(1)
+    end
+
+    it 'returns nil if no postcode set' do
+      expect(user_session.current_job_id).to be_nil
     end
   end
 
@@ -93,14 +105,6 @@ RSpec.describe UserSession do
 
     it 'returns empty hash if no job_profile_skills set' do
       expect(user_session.job_profile_skills).to eq({})
-    end
-  end
-
-  describe '#store_at' do
-    it 'stores the given value at the given key isnide the session' do
-      user_session.store_at(key: :some_key, value: 'some_value')
-
-      expect(session[:some_key]).to eq 'some_value'
     end
   end
 

--- a/spec/models/user_sessions_spec.rb
+++ b/spec/models/user_sessions_spec.rb
@@ -3,7 +3,74 @@ require 'rails_helper'
 RSpec.describe UserSession do
   subject(:user_session) { described_class.new(session) }
 
-  let(:session) { HashWithIndifferentAccess.new }
+  let(:session) { create_fake_session({}) }
+
+  before do
+    disable_feature! :skills_builder_v2
+    session[:version] = 1
+  end
+
+  describe '#version' do
+    it 'sets version on new session' do
+      user_session = described_class.new(create_fake_session(session, version: false))
+
+      expect(user_session.version).to eq(1)
+    end
+
+    it 'retains correct version on existing session' do
+      session = { version: 1 }
+      user_session = described_class.new(create_fake_session(session, version: false))
+
+      expect(user_session.version).to eq(1)
+    end
+
+    it 'retains session when version correct on existing session' do
+      session = {
+        version: 1,
+        job_profile_skills: { '11' => [2, 3, 5] }
+      }
+      user_session = described_class.new(create_fake_session(session, version: false))
+
+      expect(user_session.job_profile_skills).to eq('11' => [2, 3, 5])
+    end
+
+    it 'resets version when existing version does not equal current version' do
+      session = { version: 0 }
+      user_session = described_class.new(create_fake_session(session, version: false))
+
+      expect(user_session.version).to eq(1)
+    end
+
+    it 'reset session when existing session has wrong version' do
+      session = {
+        version: 0,
+        job_profile_skills: { '11' => [2, 3, 5] }
+      }
+      user_session = described_class.new(create_fake_session(session, version: false))
+
+      expect(user_session.job_profile_skills).to be_empty
+    end
+
+    it 'reset session when existing session does not have a version' do
+      session = { job_profile_skills: { '11' => [2, 3, 5] } }
+      user_session = described_class.new(create_fake_session(session, version: false))
+
+      expect(user_session.job_profile_skills).to be_empty
+    end
+
+    context 'when skills builder v2 is enabled' do
+      it 'reset session when existing session has wrong version' do
+        enable_feature! :skills_builder_v2
+        session = {
+          version: 1,
+          job_profile_skills: { '11' => [2, 3, 5] }
+        }
+        user_session = described_class.new(create_fake_session(session, version: false))
+
+        expect(user_session.job_profile_skills).to be_empty
+      end
+    end
+  end
 
   describe '#postcode' do
     it 'returns postcode value if set' do
@@ -64,13 +131,13 @@ RSpec.describe UserSession do
   describe '#current_job?' do
     context 'when current_job_id key is on the session' do
       let(:session) {
-        {
+        create_fake_session(
           current_job_id: 12,
           job_profile_skills: {
             '11' => [2, 3, 5],
             '12' => [2, 9, 4]
           }
-        }
+        )
       }
 
       it 'returns true when current_job_id key is on the session' do
@@ -80,12 +147,12 @@ RSpec.describe UserSession do
 
     context 'when current_job_id key is not on the session' do
       let(:session) {
-        {
+        create_fake_session(
           job_profile_skills: {
             '11' => [2, 3, 5],
             '12' => [2, 9, 4]
           }
-        }
+        )
       }
 
       it 'returns false when current_job_id key is not on the session' do
@@ -120,7 +187,7 @@ RSpec.describe UserSession do
 
   describe '#job_profiles_cap_reached?' do
     let(:session) {
-      {
+      create_fake_session(
         job_profile_skills: {
           '11' => [2, 3, 5],
           '12' => [2, 9, 4],
@@ -128,7 +195,7 @@ RSpec.describe UserSession do
           '4' => [9],
           '6' => []
         }
-      }
+      )
     }
 
     it 'returns false if the number profile ids with at least one skill is less than 5' do
@@ -178,13 +245,13 @@ RSpec.describe UserSession do
   describe '#skill_ids' do
     context 'when there is a current_job_id on the session and we are using Skills Builder v1' do
       let(:session) {
-        {
+        create_fake_session(
           current_job_id: 11,
           job_profile_skills: {
             '11' => [2, 3, 5],
             '12' => [2, 9, 4]
           }
-        }
+        )
       }
 
       it 'returns the skill ids on the session that belong to job profile id: 11' do
@@ -194,12 +261,12 @@ RSpec.describe UserSession do
 
     context 'when there is no current_job_id on the session' do
       let(:session) {
-        {
+        create_fake_session(
           job_profile_skills: {
             '11' => [2, 3, 5],
             '12' => [2, 9, 4]
           }
-        }
+        )
       }
 
       it 'returns the all skill ids on the session' do
@@ -211,13 +278,13 @@ RSpec.describe UserSession do
   describe '#job_profile_ids' do
     context 'when there is a current_job_id on the session and we are using Skills Builder v1' do
       let(:session) {
-        {
+        create_fake_session(
           current_job_id: 12,
           job_profile_skills: {
             '11' => [2, 3, 5],
             '12' => [2, 9, 4]
           }
-        }
+        )
       }
 
       it 'returns just the current job profile id on the session' do
@@ -227,12 +294,12 @@ RSpec.describe UserSession do
 
     context 'when there is no current_job_id on the session' do
       let(:session) {
-        {
+        create_fake_session(
           job_profile_skills: {
             '11' => [2, 3, 5],
             '12' => [2, 9, 4]
           }
-        }
+        )
       }
 
       it 'returns all the job profile ids on the session' do
@@ -243,12 +310,12 @@ RSpec.describe UserSession do
 
   describe '#skill_ids_for_profile' do
     let(:session) {
-      {
+      create_fake_session(
         job_profile_skills: {
           '11' => [2, 3, 5],
           '12' => [2, 9, 4]
         }
-      }
+      )
     }
 
     it 'returns the skills for a given job profile id' do

--- a/spec/models/user_sessions_spec.rb
+++ b/spec/models/user_sessions_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe UserSession do
     end
   end
 
+  describe '#postcode' do
+    it 'returns postcode value if set' do
+      session[:postcode] =  'NW118QE'
+
+      expect(user_session.postcode).to eq('NW118QE')
+    end
+
+    it 'returns nil if no postcode set' do
+      expect(user_session.postcode).to be_nil
+    end
+  end
+
   describe '#unblock_all_sections?' do
     it 'returns false if there are no sessions for all pages' do
       expect(user_session).not_to be_unblock_all_sections

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require 'rspec/rails'
 require 'support/capybara'
 require 'support/geocoder'
 require 'support/feature_flags'
+require 'support/session_helper'
 require 'simplecov'
 require 'vcr'
 SimpleCov.start

--- a/spec/support/session_helper.rb
+++ b/spec/support/session_helper.rb
@@ -1,0 +1,21 @@
+class SessionKlass < SimpleDelegator
+  def initialize(session)
+    super
+  end
+
+  def destroy
+    clear
+  end
+end
+
+module SessionHelper
+  def create_fake_session(values, version: true)
+    expected_version = Flipflop.skills_builder_v2? ? 2 : 1
+    values = version ? values.merge(version: expected_version) : values
+    SessionKlass.new(values)
+  end
+end
+
+RSpec.configure do |config|
+  config.include SessionHelper
+end

--- a/spec/support/session_helper.rb
+++ b/spec/support/session_helper.rb
@@ -9,9 +9,9 @@ class SessionKlass < SimpleDelegator
 end
 
 module SessionHelper
-  def create_fake_session(values, version: true)
+  def create_fake_session(values, versioned: true)
     expected_version = Flipflop.skills_builder_v2? ? 2 : 1
-    values = version ? values.merge(version: expected_version) : values
+    values.merge!(version: expected_version) if versioned
     SessionKlass.new(values)
   end
 end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-383

*  Move postcodes session read/write into user session
* Encapsulate job_profile_skills logic in user session rather than skills builder
* Rearrange user session methods per logic
* Add versioning to user_session:
  -  If user has existing session it is reset pre version
  - If user has existing session after versioning is set it remains intact
  - If skills builder switched between v1 and v2 session is reset
  - Add helper class for sessions as destroy method does not work on hashes
  - Fix up all tests that include sessions to work with versions