### PR TITLE
Remove old logging as it yielded unsatisfactory results

### DIFF
--- a/spec/models/skills_matcher_spec.rb
+++ b/spec/models/skills_matcher_spec.rb
@@ -118,13 +118,12 @@ RSpec.describe SkillsMatcher do
           job_profile1.id.to_s => [skill1.id, skill2.id, skill3.id]
         }
       )
-      puts "Profile #{job_profile4.name} skills: " + job_profile4.skills.pluck(:name).join(', ')
-      puts "Profile #{job_profile3.name} skills: " + job_profile3.skills.pluck(:name).join(', ')
 
-      matcher = described_class.new(UserSession.new(session)).match
-      puts 'Profile scores: ' + matcher.map(&:skills_matched).join(', ')
+      matcher = described_class.new(UserSession.new(session))
+      puts matcher.send(:build_query).to_sql
+      puts ActiveRecord::Base.connection.execute('select datname, datcollate from pg_database;').first
 
-      expect(matcher).to eq(
+      expect(matcher.match).to eq(
         [
           job_profile4,
           job_profile3,


### PR DESCRIPTION
Add logging for the query instead of the skills, as we have received
a failure with the skills logged and they seem correctly linked to
the job profiles.

Logging the query might indicate further information to help our debugging
We are also logging the collation just incase this might be an issue as well