### PR TITLE
PID Collection

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -30,6 +30,10 @@ class PagesController < ApplicationController
   end
 
   def location_eligibility_through_courses
-    @search.find_courses.any? ? redirect_to(task_list_path) : redirect_to(location_ineligible_path)
+    if @search.find_courses.any?
+      Flipflop.user_personal_data? ? redirect_to(your_information_path) : redirect_to(task_list_path)
+    else
+      redirect_to(location_ineligible_path)
+    end
   end
 end

--- a/app/controllers/user_personal_data_controller.rb
+++ b/app/controllers/user_personal_data_controller.rb
@@ -1,0 +1,35 @@
+class UserPersonalDataController < ApplicationController
+  def index
+    @user_personal_data = UserPersonalData.new(postcode: user_session.postcode)
+  end
+
+  def create
+    @user_personal_data = UserPersonalData.new(personal_data_params)
+
+    if @user_personal_data.save
+      redirect_to task_list_path
+    else
+      render 'index'
+    end
+  end
+
+  def skip
+    track_event(:user_personal_information_skipped)
+
+    redirect_to task_list_path
+  end
+
+  private
+
+  def personal_data_params
+    params.require(:user_personal_data).permit(
+      :first_name,
+      :last_name,
+      :postcode,
+      :birth_day,
+      :birth_month,
+      :birth_year,
+      :gender
+    )
+  end
+end

--- a/app/models/user_personal_data.rb
+++ b/app/models/user_personal_data.rb
@@ -1,0 +1,29 @@
+class UserPersonalData < RestrictedActiveRecordBase
+  attr_accessor :birth_day, :birth_month, :birth_year
+
+  enum gender: { female: 'female', male: 'male', not_mentioned: 'prefer not to say' }
+
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+  validates :postcode, presence: true
+  validates :postcode, postcode: true, allow_blank: true
+  validate  :dob_format
+  validate  :dob_in_the_past, if: -> { dob? }
+  validates :gender, presence: true
+
+  private
+
+  def dob_format
+    self.dob = Date.new(birth_year.to_i, birth_month.to_i, birth_day.to_i)
+  rescue ArgumentError
+    add_invalid_dob_error
+  end
+
+  def dob_in_the_past
+    add_invalid_dob_error if dob > DateTime.now
+  end
+
+  def add_invalid_dob_error
+    errors.add(:dob, I18n.t('dob.invalid', scope: 'activerecord.errors.models.user_personal_data.attributes'))
+  end
+end

--- a/app/views/pages/location_ineligible.html.erb
+++ b/app/views/pages/location_ineligible.html.erb
@@ -14,6 +14,6 @@
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
     <p class="govuk-body-m">We're a new service and currently do not offer any training courses in your area.</p>
     <p class="govuk-body-m">You can continue using this service to check your existing skills and explore the types of jobs you could apply to do.</p>
-    <%= link_to 'Continue', task_list_path, class: 'govuk-button' %>
+    <%= link_to 'Continue', Flipflop.user_personal_data? ? your_information_path : task_list_path, class: 'govuk-button' %>
   </div>
 </div>

--- a/app/views/user_personal_data/_form.html.erb
+++ b/app/views/user_personal_data/_form.html.erb
@@ -1,0 +1,71 @@
+<%= form_with model: @user_personal_data, url: your_information_path, local: true do |f| %>
+  <%= form_group_tag @user_personal_data, :first_name do %>
+    <%= f.label :first_name, class: 'govuk-label' %>
+    <%= errors_tag @user_personal_data, :first_name %>
+    <%= f.text_field :first_name, class: css_classes_for_input(@user_personal_data, :first_name, 'govuk-input govuk-!-width-two-thirds') %>
+  <% end %>
+  <%= form_group_tag @user_personal_data, :last_name do %>
+    <%= f.label :last_name, class: 'govuk-label' %>
+    <%= errors_tag @user_personal_data, :last_name %>
+    <%= f.text_field :last_name, class: css_classes_for_input(@user_personal_data, :last_name, 'govuk-input govuk-!-width-two-thirds') %>
+  <% end %>
+  <%= form_group_tag @user_personal_data, :postcode do %>
+    <%= f.label 'Postcode', class: 'govuk-label' %>
+    <%= errors_tag @user_personal_data, :postcode %>
+    <%= f.text_field :postcode, class: css_classes_for_input(@user_personal_data, :postcode, 'govuk-input govuk-input--width-10') %>
+  <% end %>
+  <div class="govuk-form-group">
+    <%= form_group_tag @user_personal_data, :dob do %>
+      <h3 class="govuk-heading-m govuk-!-margin-bottom-0">
+        Date of birth
+      </h3>
+      <span id="passport-issued-hint" class="govuk-hint">
+        For example, 12 11 1980
+      </span>
+      <%= errors_tag @user_personal_data, :dob %>
+      <div class="govuk-date-input">
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <%= f.label :day, class: 'govuk-label' %>
+            <%= f.number_field :birth_day, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-2') %>
+          </div>
+        </div>
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <%= f.label :month, class: 'govuk-label' %>
+            <%= f.number_field :birth_month, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-2') %>
+          </div>
+        </div>
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <%= f.label :year, class: 'govuk-label' %>
+            <%= f.number_field :birth_year, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-4') %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+  <div class="govuk-radios">
+    <%= form_group_tag @user_personal_data, :gender do %>
+      <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
+        Gender
+      </h3>
+      <%= errors_tag @user_personal_data, :gender %>
+      <div class="govuk-radios__item">
+        <%= f.radio_button :gender, :male, class: 'govuk-radios__input' %>
+        <%= f.label :male, class: 'govuk-label govuk-radios__label' %>
+      </div>
+      <div class="govuk-radios__item">
+        <%= f.radio_button :gender, :female, class: 'govuk-radios__input' %>
+        <%= f.label :female, class: 'govuk-label govuk-radios__label' %>
+      </div>
+      <div class="govuk-radios__item">
+        <%= f.radio_button :gender, :not_mentioned, class: 'govuk-radios__input' %>
+        <%= f.label :prefer_not_to_say, class: 'govuk-label govuk-radios__label' %>
+      </div>
+    <% end %>
+  </div>
+  <p class="govuk-body govuk-!-margin-top-8">By continuing you agree to allow us to use your information as explained in our <%= link_to 'privacy policy', '#', class: 'govuk-link'  %>.</p>
+  <p class="govuk-body govuk-!-margin-top-8"><%= link_to 'Skip this step', skip_step_path, class:'govuk-link' %></p>
+  <%= f.button('Continue', class: 'govuk-button govuk-!-margin-top-0 govuk-button govuk-!-margin-bottom-2') %>
+<% end %>

--- a/app/views/user_personal_data/_form.html.erb
+++ b/app/views/user_personal_data/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @user_personal_data, url: your_information_path, local: true do |f| %>
+<%= form_with model: @user_personal_data, url: your_information_path, local: true, html: { novalidate: true } do |f| %>
   <%= form_group_tag @user_personal_data, :first_name do %>
     <%= f.label :first_name, class: 'govuk-label' %>
     <%= errors_tag @user_personal_data, :first_name %>

--- a/app/views/user_personal_data/index.html.erb
+++ b/app/views/user_personal_data/index.html.erb
@@ -1,0 +1,21 @@
+<% page_title :user_personal_data %>
+
+<% content_for :breadcrumb do
+    generate_breadcrumbs(
+      t('breadcrumb.user_personal_data'),
+      [
+        [t('breadcrumb.home'), root_path]
+      ]
+    )
+  end
+%>
+
+<div class="govuk-grid-row govuk-!-margin-top-7">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('user_personal_data.title') %></h1>
+    <p class="govuk-body">We use this information to improve our service and make sure it's effective.</p>
+    <p class="govuk-body">We will share this information with other government departments.</p>
+    <p class="govuk-body">You don’t need to give us this information in order to use this service.</p>
+    <%= render 'form' %>
+  </div>
+</div>

--- a/app/views/user_personal_data/index.html.erb
+++ b/app/views/user_personal_data/index.html.erb
@@ -18,4 +18,5 @@
     <p class="govuk-body">You don’t need to give us this information in order to use this service.</p>
     <%= render 'form' %>
   </div>
+  <%= render 'shared/contact_us' %>
 </div>

--- a/config/features.rb
+++ b/config/features.rb
@@ -5,4 +5,5 @@ Flipflop.configure do
 
   feature :foo, description: 'Example feature flag', default: true
   feature :skills_builder_v2, description: 'Skills builder V2 feature'
+  feature :user_personal_data, description: 'User personal data collection feature'
 end

--- a/config/initializers/custom_errors.rb
+++ b/config/initializers/custom_errors.rb
@@ -1,0 +1,3 @@
+ActionView::Base.field_error_proc = proc do |html_tag, _instance|
+  html_tag.html_safe
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,7 +137,7 @@ en-GB:
             last_name:
               blank: Enter your last name
             gender:
-              blank: Enter a gender or chose 'Prefer not to say'
+              blank: Enter a gender or choose 'Prefer not to say'
             postcode:
               blank: Enter a postcode
             dob:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,7 @@ en-GB:
     location_eligibility: Your location
     location_ineligible: No courses in your area
     current_job_skills: Job skills
+    user_personal_data: Your information
 
   page_titles:
     default: Get help to retrain
@@ -33,6 +34,7 @@ en-GB:
     pages_english_overview: Get help to retrain - Benefits of English
     pages_training_hub: Get help to retrain - Training Hub
     pages_location_eligibility: Get help to retrain - Your location
+    user_personal_data: Get help to retrain - Your information
     pages_location_ineligible: Get help to retrain - No courses in your area
     errors_not_found: Get help to retrain - Not found
     errors_unprocessable_entity: Get help to retrain - Unprocessable entity
@@ -44,6 +46,7 @@ en-GB:
     check_your_skills_index_search: Check your skills - Job search
     courses_index_search: Courses near me - Postcode search
     skills_index_selected: Current job skills - Skills selected
+    user_personal_information_skipped: User personal information - Skip this step link clicked
 
   contact_us:
     title: Speak to an adviser
@@ -107,6 +110,8 @@ en-GB:
     invalid_postcode_error: Enter a valid postcode
     nonexisting_postcode_error: Enter a real postcode
     no_postcode_error: Enter a postcode
+  user_personal_data:
+    title: Your information
 
   pagination:
     previous: Previous
@@ -121,3 +126,19 @@ en-GB:
     feature_states:
       enabled: 'on'
       disabled: 'off'
+
+  activerecord:
+    errors:
+      models:
+        user_personal_data:
+          attributes:
+            first_name:
+              blank: Enter your first name
+            last_name:
+              blank: Enter your last name
+            gender:
+              blank: Enter a gender or chose 'Prefer not to say'
+            postcode:
+              blank: Enter a postcode
+            dob:
+              invalid: Enter a valid date of birth

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,15 @@ Rails.application.routes.draw do
   resources :skills_matcher, path: 'job-matches', only: %i[index]
   resources :skills, only: %i[index]
 
+  # Feature flags
+  constraints ->(_req) { Flipflop.user_personal_data? } do
+    get 'your-information', to: 'user_personal_data#index'
+    post 'your-information', to: 'user_personal_data#create'
+    get 'skip-step', to: 'user_personal_data#skip'
+
+    resources :user_personal_data, only: %i[index create]
+  end
+
   root to: 'home#index'
 end
 # rubocop:enable Metrics/BlockLength

--- a/db/restricted_migrate/20190909134904_create_user_personal_data.rb
+++ b/db/restricted_migrate/20190909134904_create_user_personal_data.rb
@@ -1,0 +1,13 @@
+class CreateUserPersonalData < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_personal_data do |t|
+      t.string :first_name
+      t.string :last_name
+      t.string :postcode
+      t.date :dob
+      t.string :gender
+
+      t.timestamps
+    end
+  end
+end

--- a/db/restricted_schema.rb
+++ b/db/restricted_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_09_104527) do
+ActiveRecord::Schema.define(version: 2019_09_09_134904) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -48,4 +48,13 @@ ActiveRecord::Schema.define(version: 2019_09_09_104527) do
     t.index ["session_id"], name: "index_users_on_session_id"
   end
 
+  create_table "user_personal_data", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.string "postcode"
+    t.date "dob"
+    t.string "gender"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 end

--- a/spec/features/your_information_spec.rb
+++ b/spec/features/your_information_spec.rb
@@ -1,0 +1,182 @@
+require 'rails_helper'
+
+RSpec.feature 'Your information' do
+  let(:i18n_scope) {
+    'activerecord.errors.models.user_personal_data.attributes'
+  }
+
+  let(:dob_invalid_error) {
+    I18n.t('dob.invalid', scope: i18n_scope)
+  }
+
+  let(:first_name_blank_error) {
+    I18n.t('first_name.blank', scope: i18n_scope)
+  }
+
+  let(:last_name_blank_error) {
+    I18n.t('last_name.blank', scope: i18n_scope)
+  }
+
+  let(:gender_blank_error) {
+    I18n.t('gender.blank', scope: i18n_scope)
+  }
+
+  background do
+    enable_feature! :user_personal_data
+
+    visit(your_information_path)
+  end
+
+  scenario 'When user fills the form correctly one gets taken to tasks-list page' do
+    fill_in('user_personal_data[first_name]', with: 'John')
+    fill_in('user_personal_data[last_name]', with: 'Mayer')
+    fill_in('user_personal_data[postcode]', with: 'NW6 1JJ')
+    fill_in('user_personal_data[birth_day]', with: '1')
+    fill_in('user_personal_data[birth_month]', with: '1')
+    fill_in('user_personal_data[birth_year]', with: DateTime.now.year - 20)
+    choose('user_personal_data[gender]', option: 'male')
+
+    click_on('Continue')
+
+    expect(page).to have_current_path(task_list_path)
+  end
+
+  scenario 'When user clicks Skip link one gets taken to tasks-list page' do
+    click_on('Skip this step')
+
+    expect(page).to have_current_path(task_list_path)
+  end
+
+  scenario 'Error message present when first name is missing' do
+    click_on('Continue')
+
+    expect(page).to have_content(first_name_blank_error)
+  end
+
+  scenario 'First name input field is highlighted when there is a validation error' do
+    click_on('Continue')
+
+    expect(page).to have_css('input#user_personal_data_first_name', class: 'govuk-input--error')
+  end
+
+  scenario 'Error message present when last name is missing' do
+    click_on('Continue')
+
+    expect(page).to have_content(last_name_blank_error)
+  end
+
+  scenario 'Last name input field is highlighted when there is a validation error' do
+    click_on('Continue')
+
+    expect(page).to have_css('input#user_personal_data_last_name', class: 'govuk-input--error')
+  end
+
+  scenario 'When postcode is missing users get: Enter a postcode' do
+    click_on('Continue')
+
+    expect(page).to have_content('Enter a postcode')
+  end
+
+  scenario 'When postcode is missing users get: Invalid UK postcode' do
+    fill_in('user_personal_data[postcode]', with: 'INVALID CODE')
+    click_on('Continue')
+
+    expect(page).to have_content('Invalid UK postcode')
+  end
+
+  scenario 'Postcode input field is highlighted when there is a validation error' do
+    click_on('Continue')
+
+    expect(page).to have_css('input#user_personal_data_postcode', class: 'govuk-input--error')
+  end
+
+  scenario 'Coming from the previous page postcode is persisted' do
+    Geocoder::Lookup::Test.add_stub(
+      'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+    )
+
+    create(:course, latitude: 0.1, longitude: 1.001, topic: 'maths')
+
+    visit(location_eligibility_path)
+    fill_in('postcode', with: 'NW6 8ET')
+    click_on('Continue')
+
+    expect(find_field('user_personal_data[postcode]').value).to eq 'NW6 8ET'
+  end
+
+  scenario 'When the date of birth is empty user gets: Enter a valid date of birth' do
+    click_on('Continue')
+
+    expect(page).to have_content(dob_invalid_error)
+  end
+
+  scenario 'When the date is valid but in future user gets: Enter a valid date of birth' do
+    fill_in('user_personal_data[birth_day]', with: '1')
+    fill_in('user_personal_data[birth_month]', with: '1')
+    fill_in('user_personal_data[birth_year]', with: DateTime.now.year + 3)
+
+    click_on('Continue')
+
+    expect(page).to have_content(dob_invalid_error)
+  end
+
+  scenario 'When the date is present but has invalid day, user gets: Enter a valid date of birth' do
+    fill_in('user_personal_data[birth_day]', with: '99')
+    fill_in('user_personal_data[birth_month]', with: '1')
+    fill_in('user_personal_data[birth_year]', with: DateTime.now.year - 20)
+
+    click_on('Continue')
+
+    expect(page).to have_content(dob_invalid_error)
+  end
+
+  scenario 'When the date is present but has invalid month, user gets: Enter a valid date of birth' do
+    fill_in('user_personal_data[birth_day]', with: '1')
+    fill_in('user_personal_data[birth_month]', with: '99')
+    fill_in('user_personal_data[birth_year]', with: DateTime.now.year - 20)
+
+    click_on('Continue')
+
+    expect(page).to have_content(dob_invalid_error)
+  end
+
+  scenario 'When the date is present but has invalid year, user gets: Enter a valid date of birth' do
+    fill_in('user_personal_data[birth_day]', with: '1')
+    fill_in('user_personal_data[birth_month]', with: '1')
+    fill_in('user_personal_data[birth_year]', with: '99999')
+
+    click_on('Continue')
+
+    expect(page).to have_content(dob_invalid_error)
+  end
+
+  scenario 'Birth day field is highlighted when there is a validation error' do
+    click_on('Continue')
+
+    expect(page).to have_css('input#user_personal_data_birth_day', class: 'govuk-input--error')
+  end
+
+  scenario 'Birth month field is highlighted when there is a validation error' do
+    click_on('Continue')
+
+    expect(page).to have_css('input#user_personal_data_birth_month', class: 'govuk-input--error')
+  end
+
+  scenario 'Birth year field is highlighted when there is a validation error' do
+    click_on('Continue')
+
+    expect(page).to have_css('input#user_personal_data_birth_year', class: 'govuk-input--error')
+  end
+
+  scenario 'When no gender is selected users get the error validation message' do
+    click_on('Continue')
+
+    expect(page).to have_content(gender_blank_error)
+  end
+
+  scenario 'breadcrumbs navigate back to home page' do
+    click_on('Home')
+
+    expect(page).to have_current_path(root_path)
+  end
+end

--- a/spec/requests/user_personal_data_spec.rb
+++ b/spec/requests/user_personal_data_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'User personal data', type: :request do
+  describe 'POST user_personal_data#create' do
+    before do
+      enable_feature! :user_personal_data
+    end
+
+    let(:params) {
+      {
+        user_personal_data: {
+          first_name: 'John',
+          last_name: 'Mayer',
+          postcode: 'NW6 1JJ',
+          gender: 'male',
+          birth_day: '1',
+          birth_month: '1',
+          birth_year: '2014'
+        }
+      }
+    }
+
+    it 'creates the resource' do
+      expect {
+        post your_information_path, params: params
+      }.to change(UserPersonalData, :count).from(0).to(1)
+    end
+
+    it 'stores the correct data' do
+      post your_information_path, params: params
+
+      expect(UserPersonalData.last).to have_attributes(
+        first_name: 'John',
+        last_name: 'Mayer',
+        postcode: 'NW6 1JJ',
+        gender: 'male',
+        dob: Date.new(2014, 1, 1)
+      )
+    end
+  end
+end

--- a/spec/routing/your_information_spec.rb
+++ b/spec/routing/your_information_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe 'routes for Your information page', type: :routing do
+  it 'does not map user_personal_data#index' do
+    expect(get(your_information_path)).not_to route_to('user_personal_data#index')
+  end
+
+  it 'does not map to user_personal_data#create' do
+    expect(post(your_information_path)).not_to route_to('user_personal_data#create')
+  end
+
+  it 'does not route to user_personal_data#index' do
+    expect(get(user_personal_data_path)).not_to route_to(controller: 'user_personal_data', action: 'index')
+  end
+
+  it 'does not route to user_personal_data#create' do
+    expect(post(user_personal_data_path)).not_to route_to(controller: 'user_personal_data', action: 'create')
+  end
+
+  it 'does not route to user_personal_data#skip' do
+    expect(get(skip_step_path)).not_to route_to(controller: 'user_personal_data', action: 'skip')
+  end
+
+  context 'when :user_personal_data feature is ON' do
+    before do
+      enable_feature! :user_personal_data
+    end
+
+    it 'successfully maps to user_personal_data#index' do
+      expect(get(your_information_path)).to route_to('user_personal_data#index')
+    end
+
+    it 'successfully maps to user_personal_data#create' do
+      expect(post(your_information_path)).to route_to('user_personal_data#create')
+    end
+
+    it 'successfully routes to user_personal_data#index' do
+      expect(get(user_personal_data_path)).to route_to(controller: 'user_personal_data', action: 'index')
+    end
+
+    it 'successfully routes to user_personal_data#create' do
+      expect(post(user_personal_data_path)).to route_to(controller: 'user_personal_data', action: 'create')
+    end
+
+    it 'successfully routes to user_personal_data#skip' do
+      expect(get(skip_step_path)).to route_to(controller: 'user_personal_data', action: 'skip')
+    end
+  end
+end


### PR DESCRIPTION
### Context

This feature is enabling us to capture personal
information about our users.

A couple of technical details:

1. The radio_button rails helper method wraps the
component with a div with class: field-with-errors breaking
the UI. We want to prevent this behaviour.

Here's a few resources around this:

https://stackoverflow.com/questions/22209855/radio-buttons-on-form-not-rendering-correctly-after-form-validation-failure-boo

The CSS approach won't solve the issue. Overriding approach:

From default behaviour:

```ruby
ActionView::Base.field_error_proc = Proc.new{ |html_tag, instance|
   "<div class=\"field_with_errors\">#{html_tag}</div>".html_safe
 }
```

```ruby
ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
  html_tag.html_safe
end
```

Works instead.

2. Handling the date of birth validation.

We collect the 3 components day/month/year separately from the form
and we put them together validating that the composed data is a
valid one.

3. The feature is flagged.

Ticket: https://dfedigital.atlassian.net/browse/GET-413

Some GDS error guides: https://design-system.service.gov.uk/components/radios/

# Screenshots

![Screen Shot 2019-09-10 at 16 35 09](https://user-images.githubusercontent.com/1955084/64628298-0a96b380-d3e9-11e9-8625-750efa65daea.png)
![Screen Shot 2019-09-10 at 16 35 20](https://user-images.githubusercontent.com/1955084/64628299-0a96b380-d3e9-11e9-9f22-fe683cbad36e.png)
