### PR TITLE
Updated styling for contact us phone number and added to missing pages

### DIFF
--- a/app/views/pages/location_eligibility.html.erb
+++ b/app/views/pages/location_eligibility.html.erb
@@ -10,7 +10,7 @@
 %>
 
 <div class="govuk-grid-row govuk-!-margin-top-7 govuk-body">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
     <p class="govuk-body-l">We'll use this to find training courses near you.</p>
     <%= form_tag location_eligibility_path, method: 'get' do %>
@@ -27,4 +27,5 @@
       <%= button_tag('Continue', class: 'govuk-button', data: { cy: "postcode-submit-btn" }) %>
     <% end %>
   </div>
+  <%= render "shared/contact_us" %>
 </div>

--- a/app/views/pages/location_ineligible.html.erb
+++ b/app/views/pages/location_ineligible.html.erb
@@ -16,4 +16,5 @@
     <p class="govuk-body-m">You can continue using this service to check your existing skills and explore the types of jobs you could apply to do.</p>
     <%= link_to 'Continue', task_list_path, class: 'govuk-button' %>
   </div>
+  <%= render "shared/contact_us" %>
 </div>

--- a/app/views/shared/_contact_us.html.erb
+++ b/app/views/shared/_contact_us.html.erb
@@ -2,8 +2,9 @@
   <div class="govuk-related-items govuk-!-padding-bottom-4 top-border__container">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= t('contact_us.title') %></h2>
     <p class="govuk-body-m govuk-!-margin-bottom-2"><%= t('contact_us.sub_title') %></p>
+    <p class="govuk-body-m govuk-!-margin-bottom-0"><%= t('contact_us.body') %></p>
     <p class="govuk-body-m govuk-!-margin-bottom-0">
-      <%= t('contact_us.body') %> <%= link_to t('contact_us.telephone'), t('contact_us.telephone_link'), class: 'govuk-!-padding-left-1 govuk-link' %>
+      <%= link_to t('contact_us.telephone'), t('contact_us.telephone_link'), class: 'govuk-heading-l govuk-!-margin-bottom-1 govuk-!-padding-top-1 govuk-link no-text-decoration' %>
     </p>
     <p class="govuk-body-s muted-text govuk-!-margin-bottom-0"><%= t('contact_us.telephone_times') %></p>
   </div>


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-418

### Changes proposed in this pull request
This appears at the top of all pages now with the exception of the home page and error pages. The home page already includes the phone number at the bottom and has not been restyled, whilst as the phone number is for "advice on finding work and training" it's not really appropriate for error pages.

### Guidance to review
I don't think there's any need to update test coverage for this; the styling changes are minor and the existing partial is now included on two additional pages.

See review app and prototype for comparison: https://get-help-to-retrain-prototype.herokuapp.com/main/release3_e2e_v2/
