### PR TITLE
GET-412 Retain email on validation on sign in, and add anchor to url

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   def new
     @user = User.new
-    user_session.registration_triggered_from(request.referer, [save_your_results_path]) if request.referer
+    set_redirect_path_for_registration
   end
 
   def create
@@ -23,7 +23,7 @@ class UsersController < ApplicationController
       sign_in_user unless @user.new_record?
       redirect_to(link_sent_path(email: @user.email))
     else
-      redirect_back(fallback_location: root_path, flash: { error: @user.errors[:email] })
+      redirect_to(build_redirect_url || root_path, flash: { error: @user.errors[:email] })
     end
   rescue NotifyService::NotifyAPIError
     # TODO: show user an error page, for now render link sent page
@@ -48,5 +48,26 @@ class UsersController < ApplicationController
   def sign_in_user
     passwordless_session = build_passwordless_session(@user)
     @user.register_existing_user(passwordless_session, request.base_url)
+  end
+
+  def set_redirect_path_for_registration
+    return unless request.referer
+
+    redirect_url = url_parser.get_redirect_path(paths_to_ignore: [save_your_results_path])
+    user_session.registration_triggered_path = redirect_url
+  end
+
+  def build_redirect_url
+    return unless request.referer
+
+    url_parser.build_redirect_url_with(
+      param_name: 'email',
+      param_value: @user.email,
+      anchor: 'sign-in'
+    )
+  end
+
+  def url_parser
+    @url_parser ||= UrlParser.new(request.referer, request.host)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,15 +51,11 @@ class UsersController < ApplicationController
   end
 
   def set_redirect_path_for_registration
-    return unless request.referer
-
     redirect_url = url_parser.get_redirect_path(paths_to_ignore: [save_your_results_path])
     user_session.registration_triggered_path = redirect_url
   end
 
   def build_redirect_url
-    return unless request.referer
-
     url_parser.build_redirect_url_with(
       param_name: 'email',
       param_value: @user.email,

--- a/app/lib/url_parser.rb
+++ b/app/lib/url_parser.rb
@@ -1,0 +1,33 @@
+class UrlParser
+  attr_reader :uri, :host
+
+  def initialize(referer, host)
+    @uri = URI(referer)
+    @host = host
+  end
+
+  def build_redirect_url_with(param_name:, param_value:, anchor:)
+    return unless recognized_host?
+
+    query = Rack::Utils.parse_query(uri.query)
+    query[param_name] = param_value
+    uri.query = Rack::Utils.build_query(query)
+    uri.fragment = anchor
+    uri.to_s
+  end
+
+  def get_redirect_path(paths_to_ignore: [])
+    return if paths_to_ignore.include?(uri.path)
+    return unless recognized_host?
+
+    uri.request_uri
+  end
+
+  private
+
+  def recognized_host?
+    uri.host == host
+  rescue ArgumentError, URI::Error
+    false
+  end
+end

--- a/app/lib/url_parser.rb
+++ b/app/lib/url_parser.rb
@@ -2,7 +2,7 @@ class UrlParser
   attr_reader :uri, :host
 
   def initialize(referer, host)
-    @uri = URI(referer)
+    @uri = URI(referer) if referer
     @host = host
   end
 
@@ -17,8 +17,8 @@ class UrlParser
   end
 
   def get_redirect_path(paths_to_ignore: [])
-    return if paths_to_ignore.include?(uri.path)
     return unless recognized_host?
+    return if paths_to_ignore.include?(uri.path)
 
     uri.request_uri
   end
@@ -26,6 +26,8 @@ class UrlParser
   private
 
   def recognized_host?
+    return unless uri
+
     uri.host == host
   rescue ArgumentError, URI::Error
     false

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -84,13 +84,11 @@ class UserSession
   end
 
   def job_profile_skills?
-    job_profile_ids.present?
+    job_profiles_with_skills.present?
   end
 
   def job_profiles_cap_reached?
-    job_profile_skills
-      .reject { |_k, v| v.size.zero? }
-      .keys
+    job_profiles_with_skills
       .size > 4
   end
 
@@ -119,5 +117,11 @@ class UserSession
 
   def expected_version
     Flipflop.skills_builder_v2? ? 2 : 1
+  end
+
+  def job_profiles_with_skills
+    job_profile_skills
+      .reject { |_k, v| v.size.zero? }
+      .keys
   end
 end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -48,14 +48,10 @@ class UserSession
     session[:registration_triggered_path]
   end
 
-  def registration_triggered_from(referer, paths_to_ignore = [])
-    uri = URI(referer)
-    return if paths_to_ignore.include?(uri.path)
-    return unless Rails.application.routes.recognize_path(uri.request_uri)
+  def registration_triggered_path=(url)
+    return unless url
 
-    session[:registration_triggered_path] = uri.request_uri
-  rescue ActionController::RoutingError => e
-    Rails.logger.error("Route not from app when registering: #{e.message}")
+    session[:registration_triggered_path] = url
   end
 
   def current_job_id

--- a/app/views/shared/_return_to_saved_results.html.erb
+++ b/app/views/shared/_return_to_saved_results.html.erb
@@ -1,6 +1,6 @@
 <% return unless user_not_authenticated? %>
 <div class="govuk-grid-column-one-third">
-  <div class="govuk-related-items govuk-!-padding-bottom-4 top-border__container">
+  <div class="govuk-related-items govuk-!-padding-bottom-4 top-border__container" id="sign-in">
     <h2 class="govuk-heading-m"><%= t('return_to_saved_results.title') %></h2>
     <p class="govuk-body"><%= t('return_to_saved_results.sub_title') %></p>
     <%= form_with local: true, url: sign_in_path do |form| %>

--- a/app/views/shared/_return_to_saved_results.html.erb
+++ b/app/views/shared/_return_to_saved_results.html.erb
@@ -9,7 +9,7 @@
         <%= errors_tag user_with_validation, :email %>
         <%= form.text_field(:email, value: params[:email], class: css_classes_for_input(user_with_validation, :email, " govuk-!-width-full")) %>
       <% end %>
-      <%= button_tag('Send a link', class: 'govuk-button govuk-button--secondary govuk-!-width-full govuk-!-margin-top-1') %>
+      <%= button_tag('Send a link', class: 'govuk-button govuk-button--secondary govuk-!-width-full govuk-!-margin-top-1 govuk-!-margin-bottom-2') %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_save_your_results.html.erb
+++ b/app/views/shared/_save_your_results.html.erb
@@ -3,6 +3,6 @@
   <div class="govuk-related-items govuk-!-padding-bottom-4 top-border__container">
     <h2 class="govuk-heading-m"><%= t('save_your_results.title') %></h2>
     <p class="govuk-body"><%= t('save_your_results.sub_title') %></p>
-    <%= link_to 'Save my results', save_your_results_path, class: 'govuk-button govuk-button--secondary govuk-!-width-full govuk-!-margin-top-1' %>
+    <%= link_to 'Save my results', save_your_results_path, class: 'govuk-button govuk-button--secondary govuk-!-width-full govuk-!-margin-top-1 govuk-!-margin-bottom-2' %>
   </div>
 </div>

--- a/spec/features/user_authentication_sidebar_spec.rb
+++ b/spec/features/user_authentication_sidebar_spec.rb
@@ -4,9 +4,9 @@ RSpec.feature 'User authentication in sidebar' do
   let!(:job_profile1) do
     create(
       :job_profile,
-      :with_skill,
       :with_html_content,
-      name: 'Hitman'
+      name: 'Hitman',
+      skills: [create(:skill, name: 'Baldness')]
     )
   end
 
@@ -142,6 +142,14 @@ RSpec.feature 'User authentication in sidebar' do
 
         expect(page).to have_text('Return to saved results')
       end
+    end
+
+    scenario 'user sees return to saved results in sidebar if user selects empty job skills' do
+      visit(job_profile_skills_path(job_profile_id: job_profile1.slug))
+      uncheck('Baldness', allow_label_click: true)
+      click_on('Select these skills')
+
+      expect(page).to have_text('Return to saved results')
     end
 
     scenario 'user does not see return to save results when having atleast one job profile skill' do

--- a/spec/features/user_sign_in_spec.rb
+++ b/spec/features/user_sign_in_spec.rb
@@ -79,6 +79,14 @@ RSpec.feature 'User sign in' do
     expect(page).to have_text(/Enter a valid email address/)
   end
 
+  scenario 'User is redirected back to page if email invalid with email' do
+    visit(root_path)
+    fill_in('email', with: 'wrong-email')
+    click_on('Send a link')
+
+    expect(page).to have_current_path(root_path(email: 'wrong-email'))
+  end
+
   scenario 'User does not see validation error if they continue on from page' do
     visit(root_path)
     fill_in('email', with: 'wrong email')

--- a/spec/lib/url_parser_spec.rb
+++ b/spec/lib/url_parser_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe UrlParser do
+  describe '#build_redirect_url_with' do
+    it 'does nothing if host is different than current host' do
+      parser = described_class.new('http://another-host.com/skills', 'myhost.com')
+
+      expect(
+        parser.build_redirect_url_with(
+          param_name: 'email',
+          param_value: 'test@test.test',
+          anchor: 'email'
+        )
+      ). to be_nil
+    end
+
+    it 'add params to url as well as anchor' do
+      parser = described_class.new('http://myhost.com/skills', 'myhost.com')
+
+      expect(
+        parser.build_redirect_url_with(
+          param_name: 'email',
+          param_value: 'test@test.test',
+          anchor: 'email'
+        )
+      ). to eq(
+        'http://myhost.com/skills?email=test%40test.test#email'
+      )
+    end
+
+    it 'does not duplicate params' do
+      parser = described_class.new('http://myhost.com/skills?email=another-test', 'myhost.com')
+
+      expect(
+        parser.build_redirect_url_with(
+          param_name: 'email',
+          param_value: 'test@test.test',
+          anchor: 'email'
+        )
+      ). to eq(
+        'http://myhost.com/skills?email=test%40test.test#email'
+      )
+    end
+
+    it 'adds params to url safely with existing params' do
+      parser = described_class.new('http://myhost.com/skills?some-params=test', 'myhost.com')
+
+      expect(
+        parser.build_redirect_url_with(
+          param_name: 'email',
+          param_value: 'test@test.test',
+          anchor: 'email'
+        )
+      ). to eq(
+        'http://myhost.com/skills?some-params=test&email=test%40test.test#email'
+      )
+    end
+  end
+
+  describe '#get_redirect_path' do
+    it 'returns path if host is part of app' do
+      referer = 'http://myhost.com/skills?job_profile_id=hitman'
+      parser = described_class.new(referer, 'myhost.com')
+
+      expect(parser.get_redirect_path). to eq('/skills?job_profile_id=hitman')
+    end
+
+    it 'does not return path if host is not part of app' do
+      referer = 'http://not-my-app/dodgy-path'
+      parser = described_class.new(referer, 'myhost.com')
+
+      expect(parser.get_redirect_path). to be_nil
+    end
+
+    it 'does not return path if its part of urls to ignore' do
+      referer = 'http://myhost.com/save-my-results'
+      parser = described_class.new(referer, 'myhost.com')
+
+      expect(parser.get_redirect_path(paths_to_ignore: ['/save-my-results'])). to be_nil
+    end
+
+    it 'does not return path if its part of urls to ignore and theres a query' do
+      referer = 'http://myhost.com/save-my-results?some-query'
+      parser = described_class.new(referer, 'myhost.com')
+
+      expect(parser.get_redirect_path(paths_to_ignore: ['/save-my-results'])). to be_nil
+    end
+  end
+end

--- a/spec/lib/url_parser_spec.rb
+++ b/spec/lib/url_parser_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UrlParser do
           param_value: 'test@test.test',
           anchor: 'email'
         )
-      ). to be_nil
+      ).to be_nil
     end
 
     it 'add params to url as well as anchor' do
@@ -23,7 +23,7 @@ RSpec.describe UrlParser do
           param_value: 'test@test.test',
           anchor: 'email'
         )
-      ). to eq(
+      ).to eq(
         'http://myhost.com/skills?email=test%40test.test#email'
       )
     end
@@ -37,7 +37,7 @@ RSpec.describe UrlParser do
           param_value: 'test@test.test',
           anchor: 'email'
         )
-      ). to eq(
+      ).to eq(
         'http://myhost.com/skills?email=test%40test.test#email'
       )
     end
@@ -51,9 +51,21 @@ RSpec.describe UrlParser do
           param_value: 'test@test.test',
           anchor: 'email'
         )
-      ). to eq(
+      ).to eq(
         'http://myhost.com/skills?some-params=test&email=test%40test.test#email'
       )
+    end
+
+    it 'returns nothing if no url passed' do
+      parser = described_class.new(nil, 'myhost.com')
+
+      expect(
+        parser.build_redirect_url_with(
+          param_name: 'email',
+          param_value: 'test@test.test',
+          anchor: 'email'
+        )
+      ).to be_nil
     end
   end
 
@@ -62,28 +74,34 @@ RSpec.describe UrlParser do
       referer = 'http://myhost.com/skills?job_profile_id=hitman'
       parser = described_class.new(referer, 'myhost.com')
 
-      expect(parser.get_redirect_path). to eq('/skills?job_profile_id=hitman')
+      expect(parser.get_redirect_path).to eq('/skills?job_profile_id=hitman')
     end
 
     it 'does not return path if host is not part of app' do
       referer = 'http://not-my-app/dodgy-path'
       parser = described_class.new(referer, 'myhost.com')
 
-      expect(parser.get_redirect_path). to be_nil
+      expect(parser.get_redirect_path).to be_nil
     end
 
     it 'does not return path if its part of urls to ignore' do
       referer = 'http://myhost.com/save-my-results'
       parser = described_class.new(referer, 'myhost.com')
 
-      expect(parser.get_redirect_path(paths_to_ignore: ['/save-my-results'])). to be_nil
+      expect(parser.get_redirect_path(paths_to_ignore: ['/save-my-results'])).to be_nil
     end
 
     it 'does not return path if its part of urls to ignore and theres a query' do
       referer = 'http://myhost.com/save-my-results?some-query'
       parser = described_class.new(referer, 'myhost.com')
 
-      expect(parser.get_redirect_path(paths_to_ignore: ['/save-my-results'])). to be_nil
+      expect(parser.get_redirect_path(paths_to_ignore: ['/save-my-results'])).to be_nil
+    end
+
+    it 'returns nothing if no url passed' do
+      parser = described_class.new(nil, 'myhost.com')
+
+      expect(parser.get_redirect_path(paths_to_ignore: ['/save-my-results'])).to be_nil
     end
   end
 end

--- a/spec/models/user_sessions_spec.rb
+++ b/spec/models/user_sessions_spec.rb
@@ -135,33 +135,19 @@ RSpec.describe UserSession do
     end
   end
 
-  describe '#registration_triggered_from' do
-    it 'sets registration_triggered_path if path is part of app' do
-      referer = 'http://myapp/skills?job_profile_id=hitman'
-      user_session.registration_triggered_from(referer)
+  describe '#registration_triggered_path' do
+    it 'sets registration_triggered_path' do
+      referer = '/skills?job_profile_id=hitman'
+      user_session.registration_triggered_path = referer
 
       expect(user_session.registration_triggered_path).to eq('/skills?job_profile_id=hitman')
     end
 
-    it 'does not set registration_triggered_path if path is not part of app' do
-      referer = 'http://not-my-app/dodgy-path'
-      user_session.registration_triggered_from(referer)
+    it 'does not overwrite registration_triggered_path if there is no referer' do
+      session[:registration_triggered_path] = 'some-path'
+      user_session.registration_triggered_path = nil
 
-      expect(user_session.registration_triggered_path).to be_nil
-    end
-
-    it 'does not set registration_triggered_path if its part of urls to ignore' do
-      referer = 'http://myapp/save-my-results'
-      user_session.registration_triggered_from(referer, ['/save-my-results'])
-
-      expect(user_session.registration_triggered_path).to be_nil
-    end
-
-    it 'does not set registration_triggered_path if its part of urls to ignore and theres a query' do
-      referer = 'http://myapp/save-your-results?some-query'
-      user_session.registration_triggered_from(referer, ['/save-your-results'])
-
-      expect(user_session.registration_triggered_path).to be_nil
+      expect(user_session.registration_triggered_path).to eq('some-path')
     end
   end
 

--- a/spec/models/user_sessions_spec.rb
+++ b/spec/models/user_sessions_spec.rb
@@ -246,12 +246,18 @@ RSpec.describe UserSession do
 
   describe '#job_profile_skills?' do
     it 'returns true if the session already contains job profile skills' do
-      session[:job_profile_ids] = [1]
+      session[:job_profile_skills] = { '1' => [1] }
 
       expect(user_session.job_profile_skills?).to be true
     end
 
     it 'returns false if the session does not contain job profile skills' do
+      expect(user_session.job_profile_skills?).to be false
+    end
+
+    it 'returns false if the session contains job profiles with no skills' do
+      session[:job_profile_skills] = { '1' => [] }
+
       expect(user_session.job_profile_skills?).to be false
     end
   end


### PR DESCRIPTION
When a user adds an invalid email and is redirected back from the sign in
page, we should retain the email. We pass this as a query param in the redirect url.
Since `redirect_back` does not allow us to do this, build this functionality ourselves.
Also add an anchor to the email to make sure we scroll back down to the sign in form.

Move previous redirect logic to same URL Parser class as it shares the url is part of host
functionally.