### PR TITLE
Add google analytics tracking Id for prod environment

### DIFF
--- a/azure/config/uat.parameters.json
+++ b/azure/config/uat.parameters.json
@@ -64,7 +64,7 @@
       "value": "https://www.smartsurvey.co.uk/s/1BBQK/"
     },
     "googleAnalyticsTrackingId": {
-      "value": ""
+      "value": "UA-147538067-2"
     },
     "applyAlerts": {
       "value": true


### PR DESCRIPTION
This just adds a dedicated tracking id for prod (aka uat).

