### PR TITLE
Don't merge params when submitting sign in form

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,8 +57,7 @@ class UsersController < ApplicationController
 
   def build_redirect_url
     url_parser.build_redirect_url_with(
-      param_name: 'email',
-      param_value: @user.email,
+      params: { 'email' => @user.email },
       anchor: 'sign-in'
     )
   end

--- a/app/lib/url_parser.rb
+++ b/app/lib/url_parser.rb
@@ -6,12 +6,10 @@ class UrlParser
     @host = host
   end
 
-  def build_redirect_url_with(param_name:, param_value:, anchor:)
+  def build_redirect_url_with(params:, anchor:)
     return unless recognized_host?
 
-    query = Rack::Utils.parse_query(uri.query)
-    query[param_name] = param_value
-    uri.query = Rack::Utils.build_query(query)
+    uri.query = Rack::Utils.build_query(params)
     uri.fragment = anchor
     uri.to_s
   end

--- a/spec/features/user_sign_in_spec.rb
+++ b/spec/features/user_sign_in_spec.rb
@@ -275,4 +275,20 @@ RSpec.feature 'User sign in' do
       visit(token_sign_in_path(token: Passwordless::Session.last.token))
     }.to raise_error(ActionController::RoutingError)
   end
+
+  scenario 'if user submits location eligibility form then sign in form user should not see one validation message' do
+    visit(location_eligibility_path)
+    click_on('Continue')
+    click_on('Send a link')
+
+    expect(page).not_to have_text(/Enter a postcode/)
+  end
+
+  scenario 'if user submits check your skills form then sign in form user should not see one validation message' do
+    visit(check_your_skills_path)
+    click_on('Search')
+    click_on('Send a link')
+
+    expect(page).not_to have_text(/Enter a job title/)
+  end
 end

--- a/spec/lib/url_parser_spec.rb
+++ b/spec/lib/url_parser_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe UrlParser do
 
       expect(
         parser.build_redirect_url_with(
-          param_name: 'email',
-          param_value: 'test@test.test',
+          params: { 'email' => 'test@test.test' },
           anchor: 'email'
         )
       ).to be_nil
@@ -19,8 +18,7 @@ RSpec.describe UrlParser do
 
       expect(
         parser.build_redirect_url_with(
-          param_name: 'email',
-          param_value: 'test@test.test',
+          params: { 'email' => 'test@test.test' },
           anchor: 'email'
         )
       ).to eq(
@@ -33,8 +31,7 @@ RSpec.describe UrlParser do
 
       expect(
         parser.build_redirect_url_with(
-          param_name: 'email',
-          param_value: 'test@test.test',
+          params: { 'email' => 'test@test.test' },
           anchor: 'email'
         )
       ).to eq(
@@ -42,17 +39,16 @@ RSpec.describe UrlParser do
       )
     end
 
-    it 'adds params to url safely with existing params' do
+    it 'adds params to url safely with existing params and removes those params' do
       parser = described_class.new('http://myhost.com/skills?some-params=test', 'myhost.com')
 
       expect(
         parser.build_redirect_url_with(
-          param_name: 'email',
-          param_value: 'test@test.test',
+          params: { 'email' => 'test@test.test' },
           anchor: 'email'
         )
       ).to eq(
-        'http://myhost.com/skills?some-params=test&email=test%40test.test#email'
+        'http://myhost.com/skills?email=test%40test.test#email'
       )
     end
 
@@ -61,8 +57,7 @@ RSpec.describe UrlParser do
 
       expect(
         parser.build_redirect_url_with(
-          param_name: 'email',
-          param_value: 'test@test.test',
+          params: { 'email' => 'test@test.test' },
           anchor: 'email'
         )
       ).to be_nil


### PR DESCRIPTION
To avoid having validation errors in other forms when submitting sign in
form, always overwrite params in url when there are validation errors


