### PR TITLE
GET-420 Add new page for registration resend email

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,15 @@ class UsersController < ApplicationController
     render(:registration_results_saved)
   end
 
+  def registration_send_email_again
+    @user = User.find_or_initialize_by(email: user_params[:email])
+    register_user
+    render(:registration_email_sent_again)
+  rescue NotifyService::NotifyAPIError
+    # TODO: show user an error page, for now render email sent again page
+    render(:registration_email_sent_again)
+  end
+
   def sign_in
     @user = User.find_or_initialize_by(email: user_params[:email])
     if @user.valid?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,13 +8,13 @@ class UsersController < ApplicationController
     @user = User.find_or_initialize_by(email: user_params[:email])
     if @user.valid?
       register_user
-      render(:registration_link_sent)
+      render(:registration_results_saved)
     else
       render(:new)
     end
   rescue NotifyService::NotifyAPIError
     # TODO: show user an error page, for now render link sent page
-    render(:registration_link_sent)
+    render(:registration_results_saved)
   end
 
   def sign_in

--- a/app/views/users/registration_email_sent_again.html.erb
+++ b/app/views/users/registration_email_sent_again.html.erb
@@ -1,0 +1,24 @@
+<% page_title :email_sent_again %>
+<% content_for :breadcrumb do
+    generate_breadcrumbs(
+      t('breadcrumb.email_sent_again'),
+      [
+        [t('breadcrumb.task_list_home'), task_list_path]
+      ]
+    )
+  end
+%>
+<div class="govuk-grid-row govuk-!-margin-top-7">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
+    <p class="govuk-body">We've sent an email to</p>
+    <h3 class="govuk-heading-m"><%= params[:email] %></h3>
+    <p class="govuk-body">If you haven't received this email</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>check the email address you entered is correct</li>
+      <li>check your junk mail</li>
+    </ul>
+    <%= link_to 'Continue', user_session.registration_triggered_path || task_list_path, class: 'govuk-button' %>
+  </div>
+  <%= render "shared/contact_us" %>
+</div>

--- a/app/views/users/registration_results_saved.html.erb
+++ b/app/views/users/registration_results_saved.html.erb
@@ -14,7 +14,7 @@
     <p class="govuk-body">We've sent an email to</p>
     <h3 class="govuk-heading-m"><%= @user.email %></h3>
     <p class="govuk-body">Check your email inbox to make sure you've received the email. You may need to verify your email address by clicking a link in the email.</p>
-    <p class="govuk-body">If you haven't received this email you can <%= link_to 'send it again', send_email_again_path(email: @user.email), method: :post, class: 'govuk-link' %>.</p>
+    <p class="govuk-body">If you haven't received this email you can <%= link_to 'send it again', email_sent_again_path(email: @user.email), method: :post, class: 'govuk-link' %>.</p>
     <p class="govuk-body">If the email address above is incorrect, <%= link_to 'enter your email address again',save_your_results_path, class: 'govuk-link' %>.</p>
     <%= link_to 'Continue', user_session.registration_triggered_path || task_list_path, class: 'govuk-button' %>
   </div>

--- a/app/views/users/registration_results_saved.html.erb
+++ b/app/views/users/registration_results_saved.html.erb
@@ -1,7 +1,7 @@
-<% page_title :link_sent %>
+<% page_title :results_saved %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
-      t('breadcrumb.link_sent'),
+      t('breadcrumb.results_saved'),
       [
         [t('breadcrumb.task_list_home'), task_list_path]
       ]
@@ -14,7 +14,7 @@
     <p class="govuk-body">We've sent an email to</p>
     <h3 class="govuk-heading-m"><%= @user.email %></h3>
     <p class="govuk-body">Check your email inbox to make sure you've received the email. You may need to verify your email address by clicking a link in the email.</p>
-    <p class="govuk-body">If you haven't received this email you can <%= link_to 'send it again', save_your_results_path(email: @user.email), method: :post, class: 'govuk-link' %>.</p>
+    <p class="govuk-body">If you haven't received this email you can <%= link_to 'send it again', send_email_again_path(email: @user.email), method: :post, class: 'govuk-link' %>.</p>
     <p class="govuk-body">If the email address above is incorrect, <%= link_to 'enter your email address again',save_your_results_path, class: 'govuk-link' %>.</p>
     <%= link_to 'Continue', user_session.registration_triggered_path || task_list_path, class: 'govuk-button' %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,7 @@ en-GB:
     user_personal_data: Your information
     save_your_results: Save your results
     link_sent: Link sent
+    results_saved: Results saved
 
   page_titles:
     default: Get help to retrain
@@ -44,6 +45,7 @@ en-GB:
     errors_postcode_search_error: Get help to retrain - Postcode search error
     save_your_results: Get help to retrain - Save your results
     link_sent: Get help to retrain - Link sent
+    results_saved: Get help to retrain - Results saved
 
   events:
     pages_location_eligibility_search: Your location - Postcode search
@@ -122,7 +124,7 @@ en-GB:
   users:
     new:
       title: Save your results
-    registration_link_sent:
+    registration_results_saved:
       title: Your results have been saved
     show:
       title: Link sent

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@ en-GB:
     save_your_results: Save your results
     link_sent: Link sent
     results_saved: Results saved
+    email_sent_again: Email sent again
 
   page_titles:
     default: Get help to retrain
@@ -46,6 +47,7 @@ en-GB:
     save_your_results: Get help to retrain - Save your results
     link_sent: Get help to retrain - Link sent
     results_saved: Get help to retrain - Results saved
+    email_sent_again: Get help to retrain - Email sent again
 
   events:
     pages_location_eligibility_search: Your location - Postcode search
@@ -128,6 +130,8 @@ en-GB:
       title: Your results have been saved
     show:
       title: Link sent
+    registration_email_sent_again:
+      title: Email sent again
   return_to_saved_results:
     title: Return to saved results
     sub_title: If you've already used this service before and saved your results, enter your email address. We'll send you a link you can use to return to your saved results.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
     get 'save-your-results', to: 'users#new'
     post 'save-your-results', to: 'users#create'
     post 'sign-in', to: 'users#sign_in'
+    post 'email-sent-again', to: 'users#registration_send_email_again'
     get 'link-sent', to: 'users#show'
 
     get '/sign-in/:token', to: 'passwordless/sessions#show', authenticatable: 'user', as: :token_sign_in

--- a/spec/features/user_registration_spec.rb
+++ b/spec/features/user_registration_spec.rb
@@ -93,11 +93,29 @@ RSpec.feature 'User registration' do
     expect(page).to have_text(/Your results have been saved/)
   end
 
-  scenario 'User can resend email and is redirected to same page' do
+  scenario 'User can resend email and is redirected to email sent page' do
     register_user
     click_on('send it again')
 
-    expect(page).to have_text(/Your results have been saved/)
+    expect(page).to have_current_path(email_sent_again_path(email: 'test@test.test'))
+  end
+
+  scenario 'User resends email and can see their email on email sent again page' do
+    register_user
+    click_on('send it again')
+
+    expect(page).to have_text(/test@test.test/)
+  end
+
+  scenario 'User can resume their journey from resend page to where they first clicked save my results' do
+    visit(next_steps_path)
+    click_on('Save my results')
+    fill_in('email', with: 'test@test.test')
+    click_on('Save your results')
+    click_on('send it again')
+    click_on('Continue')
+
+    expect(page).to have_current_path(next_steps_path)
   end
 
   scenario 'User can resume their journey to where they first clicked save my results' do
@@ -108,6 +126,14 @@ RSpec.feature 'User registration' do
     click_on('Continue')
 
     expect(page).to have_current_path(next_steps_path)
+  end
+
+  scenario 'User redirected to task list page if they directly linked to email sent page' do
+    register_user
+    click_on('send it again')
+    click_on('Continue')
+
+    expect(page).to have_current_path(task_list_path)
   end
 
   scenario 'User redirected to task list page if they directly linked to save results page' do
@@ -122,6 +148,17 @@ RSpec.feature 'User registration' do
     click_on('enter your email address again')
     fill_in('email', with: 'test@test.test')
     click_on('Save your results')
+    click_on('Continue')
+
+    expect(page).to have_current_path(task_list_path)
+  end
+
+  scenario 'User redirected to task list page if they went back from save your results page on resend' do
+    register_user
+    click_on('enter your email address again')
+    fill_in('email', with: 'test@test.test')
+    click_on('Save your results')
+    click_on('send it again')
     click_on('Continue')
 
     expect(page).to have_current_path(task_list_path)

--- a/spec/routing/users_spec.rb
+++ b/spec/routing/users_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe 'routes for Users', type: :routing do
     expect(post(sign_in_path)).not_to route_to('users#sign_in')
   end
 
+  it 'does not route to users#registration_send_email_again' do
+    expect(post(email_sent_again_path)).not_to route_to('users#registration_send_email_again')
+  end
+
   it 'does not route to passwordless/sessions#show' do
     expect(get(token_sign_in_path(token: 'token'))).not_to route_to('passwordless/sessions#show')
   end
@@ -45,6 +49,10 @@ RSpec.describe 'routes for Users', type: :routing do
         authenticatable: 'user',
         token: 'token'
       )
+    end
+
+    it 'successfully routes users#registration_send_email_again' do
+      expect(post(email_sent_again_path)).to route_to('users#registration_send_email_again')
     end
   end
 end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-420

Add new page when user clicks resend email on registration. This will continue on to where they clicked register, and show their email.

Also we needed to change the breadcrumbs for the previous confirmation page on registration as well as the title of the page
