### PR TITLE
Filter sensitive data in logs

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
+  config.log_level = :info
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,14 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += %i[
+  password
+  first_name
+  last_name
+  gender
+  birth_day
+  birth_month
+  birth_year
+  postcode
+  email
+]


### PR DESCRIPTION
This PR is doing the following:

1. Ensures form field values are filtered in the logs so there
is no risk potential for leaking sensitive data.
2. Changes the log level to :INFO in PRD so the SQL statements
are not visible anymore as they carry sensitive information.

### Screenshots

<img width="625" alt="Screen Shot 2019-09-19 at 10 11 32" src="https://user-images.githubusercontent.com/1955084/65234243-1dd20f00-dacc-11e9-95b4-e3e6a91de7b7.png">
<img width="837" alt="Screen Shot 2019-09-19 at 10 42 03" src="https://user-images.githubusercontent.com/1955084/65234244-1dd20f00-dacc-11e9-830d-35f0eb13f90c.png">
<img width="566" alt="Screen Shot 2019-09-19 at 10 52 57" src="https://user-images.githubusercontent.com/1955084/65234245-1e6aa580-dacc-11e9-9008-17a455df8202.png">
<img width="640" alt="Screen Shot 2019-09-19 at 11 10 28" src="https://user-images.githubusercontent.com/1955084/65235255-24fa1c80-dace-11e9-970b-d3a0668f3380.png">
<img width="624" alt="Screen Shot 2019-09-19 at 11 12 03" src="https://user-images.githubusercontent.com/1955084/65235379-5d99f600-dace-11e9-9b83-cd9c1b4cb333.png">

### IMPORTANT

Needs checking Loggly as well.