### PR TITLE
Add health check endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ruby:2.6.4-alpine as assets
 
+ARG GIT_SHA="unknown"
+ENV GIT_SHA="${GIT_SHA}"
+
 ENV RAILS_ENV production
 ENV NODE_ENV production
 ENV BUILD_PACKAGES build-base nodejs yarn tzdata postgresql-dev git
@@ -30,6 +33,8 @@ ENV RAILS_SERVE_STATIC_FILES true
 ENV RAILS_LOG_TO_STDOUT true
 ENV NODE_ENV production
 ENV BUILD_PACKAGES nodejs yarn tzdata libpq
+
+RUN export GIT_SHA=$(git rev-parse --short HEAD)
 
 RUN apk add --update $BUILD_PACKAGES && \
     rm -rf /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM ruby:2.6.4-alpine as assets
 
-ARG GIT_SHA="unknown"
-ENV GIT_SHA="${GIT_SHA}"
-
 ENV RAILS_ENV production
 ENV NODE_ENV production
 ENV BUILD_PACKAGES build-base nodejs yarn tzdata postgresql-dev git
@@ -34,7 +31,8 @@ ENV RAILS_LOG_TO_STDOUT true
 ENV NODE_ENV production
 ENV BUILD_PACKAGES nodejs yarn tzdata libpq
 
-RUN export GIT_SHA=$(git rev-parse --short HEAD)
+ARG GIT_SHA="unknown"
+ENV GIT_SHA=${GIT_SHA}
 
 RUN apk add --update $BUILD_PACKAGES && \
     rm -rf /var/cache/apk/*

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,0 +1,17 @@
+class StatusController < ApplicationController
+  layout false
+
+  STATUS_CODES = {
+    pass: :ok,
+    warn: :multi_status,
+    fail: :service_unavailable
+  }.freeze
+
+  def index
+    health = HealthCheck::ReportService.new
+
+    render json: health.report.to_json,
+           status: STATUS_CODES[health.status],
+           content_type: 'application/health+json'
+  end
+end

--- a/app/services/health_check/check_base.rb
+++ b/app/services/health_check/check_base.rb
@@ -1,0 +1,28 @@
+module HealthCheck
+  class CheckBase
+    attr_reader :output
+
+    def name
+      raise NotImplementedError
+    end
+
+    def status
+      raise NotImplementedError
+    end
+
+    def time
+      Time.now.iso8601
+    end
+
+    def detail
+      {
+        status: status,
+        time: time
+      }.tap do |details|
+        details[:metricValue] = value if respond_to?(:value)
+        details[:metricUnit] = unit if respond_to?(:unit)
+        details[:output] = output if output.present?
+      end
+    end
+  end
+end

--- a/app/services/health_check/courses_check.rb
+++ b/app/services/health_check/courses_check.rb
@@ -1,0 +1,19 @@
+module HealthCheck
+  class CoursesCheck < CheckBase
+    def name
+      'database:courses'
+    end
+
+    def value
+      @value ||= Course.count
+    end
+
+    def unit
+      'Integer'
+    end
+
+    def status
+      value.zero? ? :fail : :pass
+    end
+  end
+end

--- a/app/services/health_check/features_check.rb
+++ b/app/services/health_check/features_check.rb
@@ -5,7 +5,6 @@ module HealthCheck
     end
 
     def value
-      @output = Flipflop::FeatureSet.current.features.map(&:as_json)
       @value ||= Flipflop.health_check?
     rescue StandardError => e
       @output = "SplitIO error: #{e.inspect}"

--- a/app/services/health_check/features_check.rb
+++ b/app/services/health_check/features_check.rb
@@ -8,11 +8,11 @@ module HealthCheck
       @value ||= Flipflop.health_check?
     rescue StandardError => e
       @output = "SplitIO error: #{e.inspect}"
-      nil
+      false
     end
 
     def unit
-      'JSON'
+      'Boolean'
     end
 
     def status

--- a/app/services/health_check/features_check.rb
+++ b/app/services/health_check/features_check.rb
@@ -1,0 +1,23 @@
+module HealthCheck
+  class FeaturesCheck < CheckBase
+    def name
+      'api:split.io'
+    end
+
+    def value
+      @output = Flipflop::FeatureSet.current.features.map(&:as_json)
+      @value ||= Flipflop.health_check?
+    rescue StandardError => e
+      @output = "SplitIO error: #{e.inspect}"
+      nil
+    end
+
+    def unit
+      'JSON'
+    end
+
+    def status
+      value ? :pass : :fail
+    end
+  end
+end

--- a/app/services/health_check/job_profiles_check.rb
+++ b/app/services/health_check/job_profiles_check.rb
@@ -1,0 +1,19 @@
+module HealthCheck
+  class JobProfilesCheck < CheckBase
+    def name
+      'database:jobProfiles'
+    end
+
+    def value
+      @value ||= JobProfile.count
+    end
+
+    def unit
+      'Integer'
+    end
+
+    def status
+      value.zero? ? :fail : :pass
+    end
+  end
+end

--- a/app/services/health_check/notify_check.rb
+++ b/app/services/health_check/notify_check.rb
@@ -5,14 +5,14 @@ module HealthCheck
     end
 
     def value
-      @value ||= NotifyService.new.health_check.id
-    rescue Notifications::Client::RequestError, RuntimeError => e
+      @value ||= NotifyService.new.health_check
+    rescue Notifications::Client::RequestError, RuntimeError, ArgumentError => e
       @output = "Notify API error: #{e.message}"
       nil
     end
 
     def unit
-      'GUID'
+      'UUID'
     end
 
     def status

--- a/app/services/health_check/notify_check.rb
+++ b/app/services/health_check/notify_check.rb
@@ -1,0 +1,22 @@
+module HealthCheck
+  class NotifyCheck < CheckBase
+    def name
+      'api:notifications.service.gov.uk'
+    end
+
+    def value
+      @value ||= NotifyService.new.health_check.id
+    rescue Notifications::Client::RequestError, RuntimeError => e
+      @output = "Notify API error: #{e.message}"
+      nil
+    end
+
+    def unit
+      'GUID'
+    end
+
+    def status
+      value.present? ? :pass : :warn
+    end
+  end
+end

--- a/app/services/health_check/postcodes_check.rb
+++ b/app/services/health_check/postcodes_check.rb
@@ -8,7 +8,7 @@ module HealthCheck
       @value ||= Geocoder.coordinates('B1 2JP')
     rescue SocketError, Timeout::Error, Geocoder::Error => e
       @output = "Geocoder API error: #{e.message}"
-      nil
+      []
     end
 
     def unit

--- a/app/services/health_check/postcodes_check.rb
+++ b/app/services/health_check/postcodes_check.rb
@@ -1,0 +1,22 @@
+module HealthCheck
+  class PostcodesCheck < CheckBase
+    def name
+      'api:postcodes.io'
+    end
+
+    def value
+      @value ||= Geocoder.coordinates('B1 2JP')
+    rescue SocketError, Timeout::Error, Geocoder::Error => e
+      @output = "Geocoder API error: #{e.message}"
+      nil
+    end
+
+    def unit
+      'Array'
+    end
+
+    def status
+      value.present? ? :pass : :warn
+    end
+  end
+end

--- a/app/services/health_check/report_service.rb
+++ b/app/services/health_check/report_service.rb
@@ -1,3 +1,8 @@
+unless Rails.env.production?
+  # Explicitly load health check classes in development and test mode
+  Dir.glob(Rails.root.join('app', 'services', 'health_check', '*.rb')) { |f| require f }
+end
+
 module HealthCheck
   class ReportService
     def report
@@ -27,17 +32,7 @@ module HealthCheck
     end
 
     def checks
-      @checks ||= begin
-        preload_check_classes
-        CheckBase.descendants.map(&:new)
-      end
-    end
-
-    def preload_check_classes
-      # Zeitwerk handles eager loading all classes in production mode
-      return if Rails.env.production?
-
-      Dir.glob(Rails.root.join('app', 'services', 'health_check', '*.rb')) { |f| require f }
+      @checks ||= CheckBase.descendants.map(&:new)
     end
   end
 end

--- a/app/services/health_check/report_service.rb
+++ b/app/services/health_check/report_service.rb
@@ -1,0 +1,43 @@
+module HealthCheck
+  class ReportService
+    def report
+      {
+        status: status,
+        version: Rails.configuration.git_commit,
+        details: details,
+        description: 'Get help to retrain service health check'
+      }
+    end
+
+    def status
+      return :pass if statuses.all?(:pass)
+      return :fail if statuses.any?(:fail)
+
+      :warn
+    end
+
+    def details
+      checks.map { |check| [check.name, [check.detail]] }.to_h
+    end
+
+    private
+
+    def statuses
+      @statuses ||= checks.map(&:status)
+    end
+
+    def checks
+      @checks ||= begin
+        preload_check_classes
+        CheckBase.descendants.map(&:new)
+      end
+    end
+
+    def preload_check_classes
+      # Zeitwerk handles eager loading all classes in production mode
+      return if Rails.env.production?
+
+      Dir.glob(Rails.root.join('app', 'services', 'health_check', '*.rb')) { |f| require f }
+    end
+  end
+end

--- a/app/services/health_check/sessions_check.rb
+++ b/app/services/health_check/sessions_check.rb
@@ -1,0 +1,19 @@
+module HealthCheck
+  class SessionsCheck < CheckBase
+    def name
+      'database:sessions'
+    end
+
+    def value
+      @value ||= Session.count
+    end
+
+    def unit
+      'Integer'
+    end
+
+    def status
+      value.zero? ? :warn : :pass
+    end
+  end
+end

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -26,7 +26,7 @@ class NotifyService
     client.send_email(
       email_address: HEALTH_CHECK_EMAIL,
       template_id: HEALTH_CHECK_TEMPLATE_ID
-    )
+    ).id
   end
 
   private

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -4,6 +4,8 @@ class NotifyService
   NotifyAPIError = Class.new(StandardError)
   CONFIRMATION_TEMPLATE_ID = '02534375-5b5e-4da7-9884-009715421301'.freeze
   LINK_TO_RESULTS_TEMPLATE_ID = '7d186e79-31d6-4f11-b5d9-5f1f83b0d159'.freeze
+  HEALTH_CHECK_TEMPLATE_ID = '73a33b7d-d9a2-4de1-8f54-848d22a5ea21'.freeze
+  HEALTH_CHECK_EMAIL = 'simulate-delivered@notifications.service.gov.uk'.freeze
 
   def initialize(api_key: Rails.configuration.notify_api_key)
     @api_key = api_key
@@ -18,6 +20,13 @@ class NotifyService
   rescue Notifications::Client::RequestError, RuntimeError => e
     Rails.logger.error("Notify API error: #{e.message}")
     raise NotifyAPIError
+  end
+
+  def health_check
+    client.send_email(
+      email_address: HEALTH_CHECK_EMAIL,
+      template_id: HEALTH_CHECK_TEMPLATE_ID
+    )
   end
 
   private

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,7 +152,7 @@ stages:
           command: build
           imageName: $(IMAGE_NAME):$(Build.BuildNumber)
           dockerFile: Dockerfile
-          arguments: '--cache-from=$(IMAGE_NAME):assets-latest,$(IMAGE_NAME):latest'
+          arguments: '--cache-from=$(IMAGE_NAME):assets-latest,$(IMAGE_NAME):latest --build-arg GIT_SHA=$(Build.BuildNumber)'
 
       - task: Docker@2
         displayName: Push new image with current tag

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,6 @@ module GetHelpToRetrain
     config.google_analytics_tracking_id = ENV['GOOGLE_ANALYTICS_TRACKING_ID']
     config.smart_survey_user_feedback_link = ENV['USER_FEEDBACK_SMART_SURVEY_LINK']
     config.notify_api_key = ENV['NOTIFY_API_KEY']
-    config.git_commit = ENV['HEROKU_SLUG_COMMIT'] || ENV['TODO_AZURE_GIT_SHA']
+    config.git_commit = ENV['GIT_SHA']
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,6 @@ module GetHelpToRetrain
     config.google_analytics_tracking_id = ENV['GOOGLE_ANALYTICS_TRACKING_ID']
     config.smart_survey_user_feedback_link = ENV['USER_FEEDBACK_SMART_SURVEY_LINK']
     config.notify_api_key = ENV['NOTIFY_API_KEY']
+    config.git_commit = ENV['HEROKU_SLUG_COMMIT'] || ENV['TODO_AZURE_GIT_SHA']
   end
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -4,6 +4,7 @@ Flipflop.configure do
   strategy :split_client, api_key: ENV['SPLIT_API_KEY'] if ENV['SPLIT_API_KEY'].present?
 
   feature :foo, description: 'Example feature flag', default: true
+  feature :health_check, description: 'Dummy feature for split.io health check'
   feature :skills_builder_v2, description: 'Skills builder V2 feature'
   feature :user_personal_data, description: 'User personal data collection feature'
   feature :user_authentication, description: 'User authentication and save progress feature'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
 
   get '/pages/:page', to: 'pages#show'
 
+  get '/status', to: 'status#index'
+
   get '/404', to: 'errors#not_found', via: :all
   get '/422', to: 'errors#unprocessable_entity', via: :all
   get '/500', to: 'errors#internal_server_error', via: :all

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'User personal data', type: :request do
+  describe 'GET status#index' do
+    let(:report) { { foo: 'bar' } }
+    let(:health_check) { instance_double(HealthCheck::ReportService, report: report, status: status) }
+
+    before do
+      allow(HealthCheck::ReportService).to receive(:new).and_return(health_check)
+    end
+
+    it 'has correct content type' do
+      get status_path
+      expect(response.content_type).to eq 'application/health+json; charset=utf-8'
+    end
+
+    context 'when health check passes' do
+      let(:status) { :pass }
+
+      it 'has 200 response' do
+        get status_path
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'when health check has warnings' do
+      let(:status) { :warn }
+
+      it 'has 207 response' do
+        get status_path
+        expect(response.status).to eq 207
+      end
+    end
+
+    context 'when health check fails' do
+      let(:status) { :fail }
+
+      it 'has 503 response' do
+        get status_path
+        expect(response.status).to eq 503
+      end
+    end
+  end
+end

--- a/spec/services/health_check/courses_check_spec.rb
+++ b/spec/services/health_check/courses_check_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe HealthCheck::CoursesCheck do
+  subject(:check) { described_class.new }
+
+  describe '#status' do
+    context 'with no courses populated' do
+      it 'returns fail' do
+        expect(check.status).to eq :fail
+      end
+    end
+
+    context 'with at least one course populated' do
+      before do
+        create(:course)
+      end
+
+      it 'returns pass' do
+        expect(check.status).to eq :pass
+      end
+    end
+  end
+
+  describe '#detail' do
+    let(:timestamp) { Time.httpdate('Fri, 20 Sep 2019 13:03:20 GMT') }
+
+    before do
+      allow(Course).to receive(:count).and_return(100)
+      allow(Time).to receive(:now).and_return(timestamp)
+    end
+
+    it 'returns hash' do
+      expect(check.detail).to eq(
+        metricUnit: 'Integer',
+        metricValue: 100,
+        status: :pass,
+        time: '2019-09-20T13:03:20Z'
+      )
+    end
+  end
+end

--- a/spec/services/health_check/features_check_spec.rb
+++ b/spec/services/health_check/features_check_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe HealthCheck::FeaturesCheck do
+  subject(:check) { described_class.new }
+
+  describe '#status' do
+    context 'with failed split.io API call' do
+      before do
+        disable_feature!(:health_check)
+      end
+
+      it 'returns fail' do
+        expect(check.status).to eq :fail
+      end
+    end
+
+    context 'with successful split.io API call' do
+      before do
+        enable_feature!(:health_check)
+      end
+
+      it 'returns pass' do
+        expect(check.status).to eq :pass
+      end
+    end
+  end
+
+  describe '#detail' do
+    let(:timestamp) { Time.httpdate('Fri, 20 Sep 2019 13:03:20 GMT') }
+
+    before do
+      enable_feature!(:health_check)
+      allow(Time).to receive(:now).and_return(timestamp)
+    end
+
+    it 'returns hash' do
+      expect(check.detail).to eq(
+        metricUnit: 'Boolean',
+        metricValue: true,
+        status: :pass,
+        time: '2019-09-20T13:03:20Z'
+      )
+    end
+  end
+end

--- a/spec/services/health_check/job_profiles_check_spec.rb
+++ b/spec/services/health_check/job_profiles_check_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe HealthCheck::JobProfilesCheck do
+  subject(:check) { described_class.new }
+
+  describe '#status' do
+    context 'with no job profiles populated' do
+      it 'returns fail' do
+        expect(check.status).to eq :fail
+      end
+    end
+
+    context 'with at least one job profile populated' do
+      before do
+        create(:job_profile)
+      end
+
+      it 'returns pass' do
+        expect(check.status).to eq :pass
+      end
+    end
+  end
+
+  describe '#detail' do
+    let(:timestamp) { Time.httpdate('Fri, 20 Sep 2019 13:03:20 GMT') }
+
+    before do
+      allow(JobProfile).to receive(:count).and_return(850)
+      allow(Time).to receive(:now).and_return(timestamp)
+    end
+
+    it 'returns hash' do
+      expect(check.detail).to eq(
+        metricUnit: 'Integer',
+        metricValue: 850,
+        status: :pass,
+        time: '2019-09-20T13:03:20Z'
+      )
+    end
+  end
+end

--- a/spec/services/health_check/notify_check_spec.rb
+++ b/spec/services/health_check/notify_check_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe HealthCheck::NotifyCheck do
+  subject(:check) { described_class.new }
+
+  let(:notify_service) { instance_double(NotifyService) }
+  let(:id) { SecureRandom.uuid }
+
+  before do
+    allow(NotifyService).to receive(:new).and_return(notify_service)
+  end
+
+  describe '#status' do
+    context 'with failed notify API call' do
+      before do
+        allow(notify_service).to receive(:health_check).and_raise(RuntimeError)
+      end
+
+      it 'returns warn' do
+        expect(check.status).to eq :warn
+      end
+    end
+
+    context 'with successful notify API call' do
+      before do
+        allow(notify_service).to receive(:health_check).and_return(id)
+      end
+
+      it 'returns pass' do
+        expect(check.status).to eq :pass
+      end
+    end
+  end
+
+  describe '#detail' do
+    let(:timestamp) { Time.httpdate('Fri, 20 Sep 2019 13:03:20 GMT') }
+
+    before do
+      allow(notify_service).to receive(:health_check).and_return(id)
+      allow(Time).to receive(:now).and_return(timestamp)
+    end
+
+    it 'returns hash' do
+      expect(check.detail).to eq(
+        metricUnit: 'UUID',
+        metricValue: id,
+        status: :pass,
+        time: '2019-09-20T13:03:20Z'
+      )
+    end
+  end
+end

--- a/spec/services/health_check/postcodes_check_spec.rb
+++ b/spec/services/health_check/postcodes_check_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe HealthCheck::PostcodesCheck do
+  subject(:check) { described_class.new }
+
+  describe '#status' do
+    context 'with failed geocoding API call' do
+      before do
+        allow(Geocoder).to receive(:coordinates).and_raise(Geocoder::ServiceUnavailable)
+      end
+
+      it 'returns warn' do
+        expect(check.status).to eq :warn
+      end
+    end
+
+    context 'with successful geocoding API call' do
+      before do
+        Geocoder::Lookup::Test.add_stub('B1 2JP', [{ 'coordinates' => [0.1, 0.2] }])
+      end
+
+      it 'returns pass' do
+        expect(check.status).to eq :pass
+      end
+    end
+  end
+
+  describe '#detail' do
+    let(:timestamp) { Time.httpdate('Fri, 20 Sep 2019 13:03:20 GMT') }
+
+    before do
+      Geocoder::Lookup::Test.add_stub('B1 2JP', [{ 'coordinates' => [0.1, 0.2] }])
+      allow(Time).to receive(:now).and_return(timestamp)
+    end
+
+    it 'returns hash' do
+      expect(check.detail).to eq(
+        metricUnit: 'Array',
+        metricValue: [0.1, 0.2],
+        status: :pass,
+        time: '2019-09-20T13:03:20Z'
+      )
+    end
+  end
+end

--- a/spec/services/health_check/report_service_spec.rb
+++ b/spec/services/health_check/report_service_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe HealthCheck::ReportService do
+  subject(:service) { described_class.new }
+
+  describe '#report' do
+    let(:report) { service.report }
+
+    before do
+      allow(HealthCheck::CheckBase).to receive(:descendants).and_return([])
+    end
+
+    it 'includes overall status' do
+      expect(report[:status]).to eq :pass
+    end
+
+    it 'includes version' do
+      Rails.configuration.git_commit = '123456abcdef'
+      expect(report[:version]).to eq '123456abcdef'
+    end
+
+    it 'includes details of each service' do
+      expect(report[:details]).to be_a Hash
+    end
+
+    it 'includes description' do
+      expect(report[:description]).to eq 'Get help to retrain service health check'
+    end
+  end
+
+  describe '#status' do
+    before do
+      allow(HealthCheck::CheckBase).to receive(:descendants).and_return(
+        [
+          HealthCheck::JobProfilesCheck,
+          HealthCheck::SessionsCheck
+        ]
+      )
+    end
+
+    context 'with all services passing' do
+      before do
+        create :job_profile
+        create :session
+      end
+
+      it 'returns pass status' do
+        expect(service.status).to eq(:pass)
+      end
+    end
+
+    context 'with one or more service warnings' do
+      before do
+        create :job_profile
+      end
+
+      it 'returns warn status' do
+        expect(service.status).to eq(:warn)
+      end
+    end
+
+    context 'with one or more service errors' do
+      it 'returns fail status' do
+        expect(service.status).to eq(:fail)
+      end
+    end
+  end
+
+  describe '#details' do
+    let(:timestamp) { Time.httpdate('Fri, 20 Sep 2019 13:03:20 GMT') }
+
+    before do
+      allow(HealthCheck::CheckBase).to receive(:descendants).and_return(
+        [
+          HealthCheck::CoursesCheck
+        ]
+      )
+      allow(Time).to receive(:now).and_return(timestamp)
+    end
+
+    it 'returns details of each service' do
+      expect(service.details).to eq(
+        'database:courses' => [
+          {
+            metricUnit: 'Integer',
+            metricValue: 0,
+            status: :fail,
+            time: '2019-09-20T13:03:20Z'
+          }
+        ]
+      )
+    end
+  end
+end

--- a/spec/services/health_check/sessions_check_spec.rb
+++ b/spec/services/health_check/sessions_check_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe HealthCheck::SessionsCheck do
+  subject(:check) { described_class.new }
+
+  describe '#status' do
+    context 'with no sessions populated' do
+      it 'returns warn' do
+        expect(check.status).to eq :warn
+      end
+    end
+
+    context 'with at least one session populated' do
+      before do
+        create(:session)
+      end
+
+      it 'returns pass' do
+        expect(check.status).to eq :pass
+      end
+    end
+  end
+
+  describe '#detail' do
+    let(:timestamp) { Time.httpdate('Fri, 20 Sep 2019 13:03:20 GMT') }
+
+    before do
+      allow(Session).to receive(:count).and_return(100)
+      allow(Time).to receive(:now).and_return(timestamp)
+    end
+
+    it 'returns hash' do
+      expect(check.detail).to eq(
+        metricUnit: 'Integer',
+        metricValue: 100,
+        status: :pass,
+        time: '2019-09-20T13:03:20Z'
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Context
Health endpoint reports status of dependencies (Data and API endpoints) and meta data.
https://dfedigital.atlassian.net/browse/GET-340

### Changes proposed in this pull request
This adds new Healthcheck service and check classes for key models and required integration points. The endpoint also includes select metadata - on Azure we'll need a pipeline change to populate `GIT_SHA` ENV var that can be read in `application.rb`.

This also adds a new health_check method to Notify service; that simulates sending a health check template to a smoke test email address. This exercises the Notify service without sending an actual email. If this fails a warn state is returned as we can still use the service otherwise.

For postcodes.io a geocoding call to a postcode is made - that should return lat/long, if not then a warn state is returned as we can still skip past the postcode eligibility page.

For split.io a new health_check feature flag has been added - this is turned on in staging and prod environments so should always return true. If not then a fail status is returned as the site may not work as expected with all features disabled.

Reference data checks for courses and job profiles are made simply by counting records. If these are not present a fail status is returned. Session count is also included to ensure that the restricted database is available.

If all checks pass then the overall result is a pass with a 200 response returned. If any checks fail the overall result is a fail with a 5XX response. Otherwise a warn result (partially degraded service) is returned with a 2XX response. I'm open to other suggestions for response codes from the list here (but also see notes in the health check standard above). https://apidock.com/rails/ActionController/Base/render#254-List-of-status-codes-and-their-symbols

### Guidance to review
The health endpoint is available at `/status` - that can be checked on the review app.

This returns a JSON structure so I'd recommend installing a JSON formatting browser extension. I'm using this one with Chrome: https://chrome.google.com/webstore/search/json%20formatter

The `GIT_SHA` environment variable isn't working yet - a problem with setting this in the docker image. I'm hoping @mafonso can give a hand with that.