### PR TITLE
Handle user token expired

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -9,10 +9,8 @@ Passwordless::SessionsController.class_eval do
     sign_in passwordless_session
 
     redirect_to main_app.task_list_path
-  rescue Passwordless::Errors::TokenAlreadyClaimedError
-    raise ActionController::RoutingError, 'Not Found'
-  rescue Passwordless::Errors::SessionTimedOutError
-    raise ActionController::RoutingError, 'Not Found'
+  rescue Passwordless::Errors::TokenAlreadyClaimedError, Passwordless::Errors::SessionTimedOutError
+    redirect_to main_app.link_expired_path
   end
 
   def restore_user_session

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -9,7 +9,9 @@ Passwordless::SessionsController.class_eval do
     sign_in passwordless_session
 
     redirect_to main_app.task_list_path
-  rescue Passwordless::Errors::TokenAlreadyClaimedError, Passwordless::Errors::SessionTimedOutError
+  rescue Passwordless::Errors::TokenAlreadyClaimedError,
+         Passwordless::Errors::SessionTimedOutError,
+         ActiveRecord::RecordNotFound
     redirect_to main_app.link_expired_path
   end
 

--- a/app/views/users/link_expired.html.erb
+++ b/app/views/users/link_expired.html.erb
@@ -13,7 +13,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">We can’t show your saved results</h1>
     <p class="govuk-body">For some reason, we can’t show you your saved results.</p>
-    <p class="govuk-body">You could try to <%= link_to 'send yourself the link again', return_to_saved_results_path %>. Remember the link expires after one hour.</p>
+    <p class="govuk-body">You could try to <%= link_to 'send yourself the link again', return_to_saved_results_path, class: 'govuk-link' %>. Remember the link expires after one hour.</p>
     <p class="govuk-body">If that doesn't work, you may need to enter your information again.</p>
   </div>
   <%= render "shared/contact_us" %>

--- a/app/views/users/link_expired.html.erb
+++ b/app/views/users/link_expired.html.erb
@@ -1,0 +1,21 @@
+<% page_title :link_expired %>
+<% content_for :breadcrumb do
+    generate_breadcrumbs(
+      t('breadcrumb.link_expired'),
+      [
+        [t('breadcrumb.task_list_home'), task_list_path]
+      ]
+    )
+  end
+%>
+
+<div class="govuk-grid-row govuk-!-margin-top-7">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">We can’t show your saved results</h1>
+    <p class="govuk-body">For some reason, we can’t show you your saved results.</p>
+    <p class="govuk-body">You could try to <%= link_to 'send yourself the link again', return_to_saved_results_path %>. Remember the link expires after one hour.</p>
+    <p class="govuk-body">If that doesn't work, you may need to enter your information again.</p>
+  </div>
+  <%= render "shared/contact_us" %>
+</div>
+

--- a/app/views/users/return_to_saved_results.html.erb
+++ b/app/views/users/return_to_saved_results.html.erb
@@ -1,0 +1,27 @@
+<% page_title :return_to_saved_results %>
+<% content_for :breadcrumb do
+    generate_breadcrumbs(
+      t('breadcrumb.return_to_saved_results'),
+      [
+        [t('breadcrumb.task_list_home'), task_list_path]
+      ]
+    )
+  end
+%>
+
+<div class="govuk-grid-row govuk-!-margin-top-7">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('return_to_saved_results.title') %></h1>
+    <p class="govuk-body"><%= t('return_to_saved_results.sub_title') %></p>
+    <p class="govuk-body">The link expires after one hour.</p>
+    <%= form_with local: true, url: sign_in_path do |form| %>
+      <%= form_group_tag user_with_validation, :email do %>
+        <%= form.label :email, class: 'govuk-label' %>
+        <%= errors_tag user_with_validation, :email %>
+        <%= text_field_tag(:email, params[:email], class: css_classes_for_input(user_with_validation, :email, "govuk-input govuk-!-width-two-thirds")) %>
+      <% end %>
+      <%= button_tag('Send link', class: 'govuk-button') %>
+    <% end %>
+  </div>
+  <%= render "shared/contact_us" %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,10 +18,12 @@ en-GB:
     current_job_skills: Job skills
     user_personal_data: Your information
     save_your_results: Save your results
+    return_to_saved_results: Return to saved results
     link_sent: Link sent
     results_saved: Results saved
     email_sent_again: Email sent again
     link_sent_again: Link sent again
+    link_expired: Link expired
 
   page_titles:
     default: Get help to retrain
@@ -46,10 +48,12 @@ en-GB:
     errors_internal_server_error: Get help to retrain - Internal server error
     errors_postcode_search_error: Get help to retrain - Postcode search error
     save_your_results: Get help to retrain - Save your results
+    return_to_saved_results: Get help to retrain - Return to saved results
     link_sent: Get help to retrain - Link sent
     results_saved: Get help to retrain - Results saved
     email_sent_again: Get help to retrain - Email sent again
     link_sent_again: Get help to retrain - Link sent again
+    link_expired: Get help to retrain - Link expired
 
   events:
     pages_location_eligibility_search: Your location - Postcode search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,8 @@ Rails.application.routes.draw do
 
   constraints ->(_req) { Flipflop.user_authentication? } do
     get 'save-your-results', to: 'users#new'
+    get 'return-to-saved-results', to: 'users#return_to_saved_results'
+    get 'link-expired', to: 'users#link_expired'
     post 'save-your-results', to: 'users#create'
     post 'sign-in', to: 'users#sign_in'
     post 'email-sent-again', to: 'users#registration_send_email_again'

--- a/spec/features/user_sign_in_spec.rb
+++ b/spec/features/user_sign_in_spec.rb
@@ -284,6 +284,15 @@ RSpec.feature 'User sign in' do
     expect(page).to have_current_path(link_expired_path)
   end
 
+  scenario 'if user signs in, and token does not exist user should be redirected to link-expired path' do
+    register_user
+    sign_in_user
+
+    visit(token_sign_in_path(token: '123eextr'))
+
+    expect(page).to have_current_path(link_expired_path)
+  end
+
   scenario 'when the user lands on link-expired page one can navigate to Return to saved results page' do
     visit link_expired_path
 

--- a/spec/routing/users_spec.rb
+++ b/spec/routing/users_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe 'routes for Users', type: :routing do
     expect(get(token_sign_in_path(token: 'token'))).not_to route_to('passwordless/sessions#show')
   end
 
+  it 'does not route to users#link_expired' do
+    expect(get(link_expired_path)).not_to route_to('users#link_expired')
+  end
+
+  it 'does not route to users#return_to_saved_results' do
+    expect(get(return_to_saved_results_path)).not_to route_to('users#return_to_saved_results')
+  end
+
   context 'when :user_authentication feature is ON' do
     before do
       enable_feature! :user_authentication
@@ -61,6 +69,14 @@ RSpec.describe 'routes for Users', type: :routing do
 
     it 'successfully routes users#sign_in_send_email_again' do
       expect(post(link_sent_again_path)).to route_to('users#sign_in_send_email_again')
+    end
+
+    it 'successfully routes to users#link_expired' do
+      expect(get(link_expired_path)).to route_to('users#link_expired')
+    end
+
+    it 'successfully routes to users#return_to_saved_results' do
+      expect(get(return_to_saved_results_path)).to route_to('users#return_to_saved_results')
     end
   end
 end


### PR DESCRIPTION
When the user has a token expired/claimed one
gets redirected to a link expired page.

From there one can request the link again.


![Screen Shot 2019-09-20 at 16 58 08](https://user-images.githubusercontent.com/1955084/65341385-2c055580-dbc8-11e9-959b-3d0f7e30fac5.png)
![Screen Shot 2019-09-20 at 16 55 30](https://user-images.githubusercontent.com/1955084/65341423-40e1e900-dbc8-11e9-96e7-2abe77839377.png)

https://dfedigital.atlassian.net/browse/GET-452

