### PR TITLE
GET-520 Add a second postgres database

### DIFF
--- a/azure/config/dev1.parameters.json
+++ b/azure/config/dev1.parameters.json
@@ -2,26 +2,42 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "databaseName": {
-      "value": "ghtr"
+    "domainDatabaseName": {
+      "value": "domain"
     },
-    "databaseUsername": {
+    "domainDatabaseUsername": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
         },
-        "secretName": "dev-databaseUsername"
+        "secretName": "dev-domainDatabaseUsername"
       }
     },
-    "databasePort": {
-      "value": "5432"
-    },
-    "databasePassword": {
+    "domainDatabasePassword": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
         },
-        "secretName": "dev-databasePassword"
+        "secretName": "dev-domainDatabasePassword"
+      }
+    },
+    "restrictedDatabaseName": {
+      "value": "restricted"
+    },
+    "restrictedDatabaseUsername": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "dev-restrictedDatabaseUsername"
+      }
+    },
+    "restrictedDatabasePassword": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "dev-restrictedDatabasePassword"
       }
     },
     "secretKeyBase": {

--- a/azure/config/dev2.parameters.json
+++ b/azure/config/dev2.parameters.json
@@ -2,26 +2,42 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "databaseName": {
-      "value": "ghtr"
+    "domainDatabaseName": {
+      "value": "domain"
     },
-    "databaseUsername": {
+    "domainDatabaseUsername": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
         },
-        "secretName": "dev-databaseUsername"
+        "secretName": "dev-domainDatabaseUsername"
       }
     },
-    "databasePort": {
-      "value": "5432"
-    },
-    "databasePassword": {
+    "domainDatabasePassword": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
         },
-        "secretName": "dev-databasePassword"
+        "secretName": "dev-domainDatabasePassword"
+      }
+    },
+    "restrictedDatabaseName": {
+      "value": "restricted"
+    },
+    "restrictedDatabaseUsername": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "dev-restrictedDatabaseUsername"
+      }
+    },
+    "restrictedDatabasePassword": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "dev-restrictedDatabasePassword"
       }
     },
     "secretKeyBase": {

--- a/azure/config/dev3.parameters.json
+++ b/azure/config/dev3.parameters.json
@@ -2,26 +2,42 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "databaseName": {
-      "value": "ghtr"
+    "domainDatabaseName": {
+      "value": "domain"
     },
-    "databaseUsername": {
+    "domainDatabaseUsername": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
         },
-        "secretName": "dev-databaseUsername"
+        "secretName": "dev-domainDatabaseUsername"
       }
     },
-    "databasePort": {
-      "value": "5432"
-    },
-    "databasePassword": {
+    "domainDatabasePassword": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
         },
-        "secretName": "dev-databasePassword"
+        "secretName": "dev-domainDatabasePassword"
+      }
+    },
+    "restrictedDatabaseName": {
+      "value": "restricted"
+    },
+    "restrictedDatabaseUsername": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "dev-restrictedDatabaseUsername"
+      }
+    },
+    "restrictedDatabasePassword": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "dev-restrictedDatabasePassword"
       }
     },
     "secretKeyBase": {

--- a/azure/config/prod.parameters.json
+++ b/azure/config/prod.parameters.json
@@ -2,26 +2,42 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "databaseName": {
-      "value": "ghtr"
+    "domainDatabaseName": {
+      "value": "domain"
     },
-    "databaseUsername": {
+    "domainDatabaseUsername": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/eaff0b89-17c5-4a97-9a00-f77551fe2c27/resourceGroups/s108p01-shared/providers/Microsoft.KeyVault/vaults/s108p01-shared-kv-01"
         },
-        "secretName": "prod-databaseUsername"
+        "secretName": "prod-domainDatabaseUsername"
       }
     },
-    "databasePort": {
-      "value": "5432"
-    },
-    "databasePassword": {
+    "domainDatabasePassword": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/eaff0b89-17c5-4a97-9a00-f77551fe2c27/resourceGroups/s108p01-shared/providers/Microsoft.KeyVault/vaults/s108p01-shared-kv-01"
         },
-        "secretName": "prod-databasePassword"
+        "secretName": "prod-domainDatabasePassword"
+      }
+    },
+    "restrictedDatabaseName": {
+      "value": "restricted"
+    },
+    "restrictedDatabaseUsername": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/eaff0b89-17c5-4a97-9a00-f77551fe2c27/resourceGroups/s108p01-shared/providers/Microsoft.KeyVault/vaults/s108p01-shared-kv-01"
+        },
+        "secretName": "prod-restrictedDatabaseUsername"
+      }
+    },
+    "restrictedDatabasePassword": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/eaff0b89-17c5-4a97-9a00-f77551fe2c27/resourceGroups/s108p01-shared/providers/Microsoft.KeyVault/vaults/s108p01-shared-kv-01"
+        },
+        "secretName": "prod-restrictedDatabasePassword"
       }
     },
     "secretKeyBase": {

--- a/azure/config/qa.parameters.json
+++ b/azure/config/qa.parameters.json
@@ -2,26 +2,42 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "databaseName": {
-      "value": "ghtr"
+    "domainDatabaseName": {
+      "value": "domain"
     },
-    "databaseUsername": {
+    "domainDatabaseUsername": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
         },
-        "secretName": "qa-databaseUsername"
+        "secretName": "qa-domainDatabaseUsername"
       }
     },
-    "databasePort": {
-      "value": "5432"
-    },
-    "databasePassword": {
+    "domainDatabasePassword": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
         },
-        "secretName": "qa-databasePassword"
+        "secretName": "qa-domainDatabasePassword"
+      }
+    },
+    "restrictedDatabaseName": {
+      "value": "restricted"
+    },
+    "restrictedDatabaseUsername": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
+        },
+        "secretName": "qa-restrictedDatabaseUsername"
+      }
+    },
+    "restrictedDatabasePassword": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
+        },
+        "secretName": "qa-restrictedDatabasePassword"
       }
     },
     "secretKeyBase": {

--- a/azure/config/uat.parameters.json
+++ b/azure/config/uat.parameters.json
@@ -2,26 +2,42 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "databaseName": {
-      "value": "ghtr"
+    "domainDatabaseName": {
+      "value": "domain"
     },
-    "databaseUsername": {
+    "domainDatabaseUsername": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
         },
-        "secretName": "uat-databaseUsername"
+        "secretName": "uat-domainDatabaseUsername"
       }
     },
-    "databasePort": {
-      "value": "5432"
-    },
-    "databasePassword": {
+    "domainDatabasePassword": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
         },
-        "secretName": "uat-databasePassword"
+        "secretName": "uat-domainDatabasePassword"
+      }
+    },
+    "restrictedDatabaseName": {
+      "value": "restricted"
+    },
+    "restrictedDatabaseUsername": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
+        },
+        "secretName": "uat-restrictedDatabaseUsername"
+      }
+    },
+    "restrictedDatabasePassword": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
+        },
+        "secretName": "uat-restrictedDatabasePassword"
       }
     },
     "secretKeyBase": {

--- a/azure/config/ut.parameters.json
+++ b/azure/config/ut.parameters.json
@@ -2,26 +2,42 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "databaseName": {
-      "value": "ghtr"
+    "domainDatabaseName": {
+      "value": "domain"
     },
-    "databaseUsername": {
+    "domainDatabaseUsername": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
         },
-        "secretName": "ut-databaseUsername"
+        "secretName": "ut-domainDatabaseUsername"
       }
     },
-    "databasePort": {
-      "value": "5432"
-    },
-    "databasePassword": {
+    "domainDatabasePassword": {
       "reference": {
         "keyVault": {
           "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
         },
-        "secretName": "ut-databasePassword"
+        "secretName": "ut-domainDatabasePassword"
+      }
+    },
+    "restrictedDatabaseName": {
+      "value": "restricted"
+    },
+    "restrictedDatabaseUsername": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "ut-restrictedDatabaseUsername"
+      }
+    },
+    "restrictedDatabasePassword": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "ut-restrictedDatabasePassword"
       }
     },
     "secretKeyBase": {

--- a/azure/template.json
+++ b/azure/template.json
@@ -30,31 +30,43 @@
         "description": "The name of the certificate in key vault."
       }
     },
-    "databaseName": {
+    "domainDatabaseName": {
       "type": "string",
       "metadata": {
         "description": "The name of the database that the app will connect to."
       }
     },
-    "databaseUsername": {
+    "domainDatabaseUsername": {
       "type": "string",
       "metadata": {
         "description": "The username used to connect to the database."
       }
     },
-    "databasePassword": {
+    "domainDatabasePassword": {
       "type": "securestring",
       "metadata": {
         "description": "The password used to connect to the database."
       }
     },
-    "databasePort": {
+    "restrictedDatabaseName": {
       "type": "string",
       "metadata": {
-        "description": "The default port for the psql server."
+        "description": "The name of the database that the app will connect to."
       }
     },
-    "databaseIPWhiteList": {
+    "restrictedDatabaseUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "The username used to connect to the database."
+      }
+    },
+    "restrictedDatabasePassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password used to connect to the database."
+      }
+    },
+    "domainDatabaseIPWhiteList": {
       "type": "array",
       "defaultValue": [],
       "metadata": {
@@ -171,7 +183,8 @@
     "keyvaultCertificateName": "[if(greater(length(parameters('certificateName')),0), parameters('certificateName'), replace(parameters('customHostName'), '.', '-'))]",
     "storageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'str'), '-', '')]",
     "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",
-    "databaseServerName": "[concat(variables('resourceNamePrefix'), '-psql')]",
+    "domainDatabaseServerName": "[concat(variables('resourceNamePrefix'), '-domainPsql')]",
+    "restrictedDatabaseServerName": "[concat(variables('resourceNamePrefix'), '-restricedPsql')]",
     "actionGroupName": "[concat(variables('resourceNamePrefix'), '-ag')]",
     "appServiceRuntimeStack": "[concat('DOCKER|', parameters('containerImageReference'))]"
   },
@@ -222,7 +235,7 @@
     },
     {
       "apiVersion": "2017-05-10",
-      "name": "postgresql-server",
+      "name": "postgresql-domain-server",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
@@ -232,13 +245,13 @@
         },
         "parameters": {
           "postgresServerName": {
-            "value": "[variables('databaseServerName')]"
+            "value": "[variables('domainDatabaseServerName')]"
           },
           "postgresAdminLogin": {
-            "value": "[parameters('databaseUsername')]"
+            "value": "[parameters('domainDatabaseUsername')]"
           },
           "postgresAdminPassword": {
-            "value": "[parameters('databasePassword')]"
+            "value": "[parameters('domainDatabasePassword')]"
           },
           "securityAlertEmailAddress": {
             "value": "[coalesce(parameters('supportEmailAddresses'))[0].email]"
@@ -254,7 +267,39 @@
     },
     {
       "apiVersion": "2017-05-10",
-      "name": "postgresql-database",
+      "name": "postgresql-restricted-server",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'postgresql-server.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "postgresServerName": {
+            "value": "[variables('restrictedDatabaseServerName')]"
+          },
+          "postgresAdminLogin": {
+            "value": "[parameters('restrictedDatabaseUsername')]"
+          },
+          "postgresAdminPassword": {
+            "value": "[parameters('restrictedDatabasePassword')]"
+          },
+          "securityAlertEmailAddress": {
+            "value": "[coalesce(parameters('supportEmailAddresses'))[0].email]"
+          },
+          "storageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          }
+        }
+      },
+      "dependsOn": [
+        "storage-account"
+      ]
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "postgresql-domain-database",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
@@ -264,20 +309,43 @@
         },
         "parameters": {
           "serverName": {
-            "value": "[variables('databaseServerName')]"
+            "value": "[variables('domainDatabaseServerName')]"
           },
           "databaseName": {
-            "value": "[parameters('databaseName')]"
+            "value": "[parameters('domainDatabaseName')]"
           }
         }
       },
       "dependsOn": [
-        "postgresql-server"
+        "postgresql-domain-server"
       ]
     },
     {
       "apiVersion": "2017-05-10",
-      "name": "postgresql-server-firewall-rules",
+      "name": "postgresql-restricted-database",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'postgresql-database.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "serverName": {
+            "value": "[variables('restrictedDatabaseServerName')]"
+          },
+          "databaseName": {
+            "value": "[parameters('restrictedDatabaseName')]"
+          }
+        }
+      },
+      "dependsOn": [
+        "postgresql-restricted-server"
+      ]
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "postgresql-domain-server-firewall-rules",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
@@ -290,15 +358,41 @@
             "value": "[concat(variables('appServicePlanName'),'-AZURE_IP-')]"
           },
           "ipAddresses": {
-            "value": "[concat(reference('app-service').outputs.possibleOutboundIpAddresses.value,parameters('databaseIPWhiteList'))]"
+            "value": "[concat(reference('app-service').outputs.possibleOutboundIpAddresses.value,parameters('domainDatabaseIPWhiteList'))]"
           },
           "serverName": {
-            "value": "[variables('databaseServerName')]"
+            "value": "[variables('domainDatabaseServerName')]"
           }
         }
       },
       "dependsOn": [
-        "postgresql-server"
+        "postgresql-domain-server"
+      ]
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "postgresql-restricted-server-firewall-rules",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'postgresql-server-firewall-rules.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "firewallRuleNamePrefix": {
+            "value": "[concat(variables('appServicePlanName'),'-AZURE_IP-')]"
+          },
+          "ipAddresses": {
+            "value": "[reference('app-service').outputs.possibleOutboundIpAddresses.value]"
+          },
+          "serverName": {
+            "value": "[variables('restrictedDatabaseServerName')]"
+          }
+        }
+      },
+      "dependsOn": [
+        "postgresql-restricted-server"
       ]
     },
     {
@@ -391,35 +485,35 @@
               },
               {
                 "name": "DB_DATABASE",
-                "value": "[parameters('databaseName')]"
+                "value": "[parameters('domainDatabaseName')]"
               },
               {
                 "name": "DB_PASSWORD",
-                "value": "[parameters('databasePassword')]"
+                "value": "[parameters('domainDatabasePassword')]"
               },
               {
                 "name": "DB_USERNAME",
-                "value": "[concat(parameters('databaseUsername'), '@', variables('databaseServerName'))]"
+                "value": "[concat(parameters('domainDatabaseUsername'), '@', variables('domainDatabaseServerName'))]"
               },
               {
                 "name": "DB_HOST",
-                "value": "[reference('postgresql-server').outputs.fullyQualifiedDomainName.value]"
+                "value": "[reference('postgresql-domain-server').outputs.fullyQualifiedDomainName.value]"
               },
               {
                 "name": "RESTRICTED_DB_DATABASE",
-                "value": "[parameters('databaseName')]"
+                "value": "[parameters('restrictedDatabaseName')]"
               },
               {
                 "name": "RESTRICTED_DB_PASSWORD",
-                "value": "[parameters('databasePassword')]"
+                "value": "[parameters('restrictedDatabasePassword')]"
               },
               {
                 "name": "RESTRICTED_DB_USERNAME",
-                "value": "[concat(parameters('databaseUsername'), '@', variables('databaseServerName'))]"
+                "value": "[concat(parameters('restrictedDatabaseName'), '@', variables('restrictedDatabaseServerName'))]"
               },
               {
                 "name": "RESTRICTED_DB_HOST",
-                "value": "[reference('postgresql-server').outputs.fullyQualifiedDomainName.value]"
+                "value": "[reference('postgresql-restricted-server').outputs.fullyQualifiedDomainName.value]"
               },
               {
                 "name": "LOGGLY_TOKEN",
@@ -428,10 +522,6 @@
               {
                 "name": "SPLIT_API_KEY",
                 "value": "[parameters('splitApiKey')]"
-              },
-              {
-                "name": "POSTGRESQL_SERVICE_PORT",
-                "value": "[parameters('databasePort')]"
               },
               {
                 "name": "SECRET_KEY_BASE",
@@ -499,7 +589,7 @@
                 "value": "[variables('appServiceName')]"
               },
               "databaseName": {
-                  "value": "[variables('databaseServerName')]"
+                  "value": "[variables('domainDatabaseServerName')]"
               },
               "actionGroupName": {
                   "value": "[variables('actionGroupName')]"
@@ -527,7 +617,7 @@
               }
           }
       },
-      "dependsOn": ["app-service-plan","postgresql-database"]
+      "dependsOn": ["app-service-plan","postgresql-domain-database"]
   }
   ],
   "outputs": {


### PR DESCRIPTION
### Context

Following up the spike in https://dfedigital.atlassian.net/browse/GET-381 we decided to add a second database with different credentials to the infrastructure.   Since the credentials in azure database are managed at the server level and not the database level we had to create a new dedicated server.

### Changes proposed in this pull request

This PR adds the necessary resources to the main ARM template to create this second database server, second logical database and reference the respective secrets from KeyVault 

### Guidance to review

