### PR TITLE
Get 384 tracking refactor

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,9 +16,8 @@ class ApplicationController < ActionController::Base
   private
 
   def track_event(event_key, properties = {})
-    return unless defined?(TELEMETRY_CLIENT)
-
-    TELEMETRY_CLIENT.track_event(I18n.t(event_key, scope: :events), properties: properties)
+    event = I18n.t(event_key, scope: :events)
+    properties.present? ? TrackingService.track_event(event, properties) : TrackingService.track_event(event)
   end
 
   def protect_feature(feature)

--- a/app/services/tracking_service.rb
+++ b/app/services/tracking_service.rb
@@ -1,0 +1,45 @@
+class TrackingService
+  def self.track_event(event_text, properties = {})
+    return false unless key.present?
+
+    client.track_event(event_text, properties: properties)
+  end
+
+  def self.key
+    @key ||= Rails.configuration.app_insights_instrumentation_key
+  end
+
+  def self.key=(key)
+    @key = key
+    @sender = nil
+    @queue = nil
+    @channel = nil
+    @client = nil
+  end
+
+  def self.sender
+    @sender ||= ApplicationInsights::Channel::AsynchronousSender.new
+  end
+
+  def self.queue
+    @queue ||= ApplicationInsights::Channel::AsynchronousQueue.new(sender)
+  end
+
+  def self.channel
+    @channel ||= ApplicationInsights::Channel::TelemetryChannel.new(nil, queue)
+  end
+
+  def self.client
+    @client ||= ApplicationInsights::TelemetryClient.new(key, channel).tap do |tc|
+      # flush telemetry if we have 10 or more telemetry items in our queue
+      tc.channel.queue.max_queue_length = 10
+      # send telemetry to the service in batches of 5
+      tc.channel.sender.send_buffer_size = 5
+      # the background worker thread will be active for 5 seconds before it shuts down. if
+      # during this time items are picked up from the queue, the timer is reset.
+      tc.channel.sender.send_time = 5
+      # the background worker thread will poll the queue every 0.5 seconds for new items
+      tc.channel.sender.send_interval = 0.5
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,8 @@ module GetHelpToRetrain
 
     config.i18n.default_locale = :'en-GB'
 
+    config.app_insights_instrumentation_key = ENV['APPINSIGHTS_INSTRUMENTATIONKEY']
+    config.app_insights_javascript = ENV['APPINSIGHTS_JAVASCRIPT_ENABLED'] == 'true'
     config.google_analytics_tracking_id = ENV['GOOGLE_ANALYTICS_TRACKING_ID']
     config.smart_survey_user_feedback_link = ENV['USER_FEEDBACK_SMART_SURVEY_LINK']
     config.notify_api_key = ENV['NOTIFY_API_KEY']

--- a/config/initializers/application_insights.rb
+++ b/config/initializers/application_insights.rb
@@ -1,30 +1,11 @@
-if Rails.env.production?
-  Rails.application.configure do
-    if (app_insights_key = ENV['APPINSIGHTS_INSTRUMENTATIONKEY']) && app_insights_key.present?
-      config.middleware.use(ApplicationInsights::Rack::TrackRequest, app_insights_key)
-      if ENV['APPINSIGHTS_JAVASCRIPT_ENABLED'] == 'true'
-        config.middleware.use(ApplicationInsights::Rack::InjectJavaScriptTracking, app_insights_key)
-      end
-
-      # setup asynchronous sender and channel for use with telemetry client
-      sender = ApplicationInsights::Channel::AsynchronousSender.new
-      queue = ApplicationInsights::Channel::AsynchronousQueue.new(sender)
-      channel = ApplicationInsights::Channel::TelemetryChannel.new(nil, queue)
-
-      TELEMETRY_CLIENT = ApplicationInsights::TelemetryClient.new(app_insights_key, channel).tap do |tc|
-        # flush telemetry if we have 10 or more telemetry items in our queue
-        tc.channel.queue.max_queue_length = 10
-        # send telemetry to the service in batches of 5
-        tc.channel.sender.send_buffer_size = 5
-        # the background worker thread will be active for 5 seconds before it shuts down. if
-        # during this time items are picked up from the queue, the timer is reset.
-        tc.channel.sender.send_time = 5
-        # the background worker thread will poll the queue every 0.5 seconds for new items
-        tc.channel.sender.send_interval = 0.5
-      end
-
-      # setup unhandled exception handler
-      ApplicationInsights::UnhandledException.collect(app_insights_key)
+Rails.application.configure do
+  if (app_insights_key = config.app_insights_instrumentation_key) && app_insights_key.present?
+    config.middleware.use(ApplicationInsights::Rack::TrackRequest, app_insights_key)
+    if config.app_insights_javascript
+      config.middleware.use(ApplicationInsights::Rack::InjectJavaScriptTracking, app_insights_key)
     end
+
+    # setup unhandled exception handler
+    ApplicationInsights::UnhandledException.collect(app_insights_key)
   end
 end

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -28,6 +28,16 @@ RSpec.feature 'Check your skills', type: :feature do
     expect(page).to have_text('No results found')
   end
 
+  scenario 'tracks search string' do
+    allow(TrackingService).to receive(:track_event)
+
+    visit(check_your_skills_path)
+    fill_in('search', with: 'Bodyguard')
+    find('.search-button').click
+
+    expect(TrackingService).to have_received(:track_event).with('Check your skills - Job search', search: 'Bodyguard')
+  end
+
   scenario 'paginates results of search' do
     create_list(:job_profile, 12, name: 'Hacker')
     visit(check_your_skills_path)

--- a/spec/features/find_training_courses_spec.rb
+++ b/spec/features/find_training_courses_spec.rb
@@ -106,6 +106,16 @@ RSpec.feature 'Find training courses', type: :feature do
     expect(page).to have_text(/Enter a postcode/)
   end
 
+  scenario 'tracks search postcode' do
+    allow(TrackingService).to receive(:track_event)
+
+    visit(courses_path(topic_id: 'maths'))
+    fill_in('postcode', with: 'NW6 8ET')
+    find('.search-button-results').click
+
+    expect(TrackingService).to have_received(:track_event).with('Courses near me - Postcode search', search: 'NW6 8ET')
+  end
+
   def capture_user_location(postcode)
     visit(location_eligibility_path)
     fill_in('postcode', with: postcode)

--- a/spec/features/location_eligibility_spec.rb
+++ b/spec/features/location_eligibility_spec.rb
@@ -115,4 +115,14 @@ RSpec.feature 'Check your location is eligible', type: :feature do
 
     expect(page).to have_text(/Enter a postcode/)
   end
+
+  scenario 'tracks search postcode' do
+    allow(TrackingService).to receive(:track_event)
+
+    visit(location_eligibility_path)
+    fill_in('postcode', with: 'NW6 8ET')
+    click_on('Continue')
+
+    expect(TrackingService).to have_received(:track_event).with('Your location - Postcode search', search: 'NW6 8ET')
+  end
 end

--- a/spec/features/your_information_spec.rb
+++ b/spec/features/your_information_spec.rb
@@ -47,6 +47,14 @@ RSpec.feature 'Your information' do
     expect(page).to have_current_path(task_list_path)
   end
 
+  scenario 'When user clicks Skip link action is tracked' do
+    allow(TrackingService).to receive(:track_event)
+
+    click_on('Skip this step')
+
+    expect(TrackingService).to have_received(:track_event).with('User personal information - Skip this step link clicked')
+  end
+
   scenario 'Error message present when first name is missing' do
     click_on('Continue')
 

--- a/spec/services/tracking_service_spec.rb
+++ b/spec/services/tracking_service_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe TrackingService do
+  subject(:service) { described_class }
+
+  describe '.track_event' do
+    context 'without an instrumentation key' do
+      before do
+        service.key = nil
+      end
+
+      it 'does not track events' do
+        expect(service.track_event('foo')).to eq false
+      end
+    end
+
+    context 'with a valid instrumentation key' do
+      before do
+        service.key = 'VALID'
+      end
+
+      it 'tracks event without additional properties' do
+        allow(service.channel).to receive(:write).and_return(true)
+        expect(service.track_event('foo')).to eq true
+      end
+
+      it 'tracks event with additional properties' do
+        allow(service.channel).to receive(:write).and_return(true)
+        expect(service.track_event('foo', bar: 'baz')).to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Refactor Azure Application Insights implementation to support better testing

### Changes proposed in this pull request
This adds a new TrackingService class for custom event tracking so that we can set expectations on tracking data within associated feature specs. Moved AAI configuration to centralised Rails config object and cleaned up the existing initialiser code so that only the client side JS tracking and exception tracking are created on startup.

Custom tracking events lazily load Azure tracking telemetry client and cached at class level.

Also added feature specs for custom tracking to ensure this gets called with the correct payload.

### Guidance to review
This shouldn't affect any existing tracking, but just means we're able to add test coverage. I noticed whilst working on this that we don't have any custom event tracking for skills builder v2; will need to discuss with wider team to see if this is still a requirement (given we can now determine selected job profiles and skills from session data instead).
