### PR TITLE
Alter locked sections user flow on task-list

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,6 +7,16 @@ class PagesController < ApplicationController
     user_session.track_page('next_steps')
   end
 
+  def task_list
+    if user_session.job_profile_skills?
+      current_job = JobProfile.find(user_session.job_profile_ids.first)
+
+      @skills_summary_path = skills_path(job_profile_id: current_job.slug)
+    else
+      @skills_summary_path = check_your_skills_path
+    end
+  end
+
   def location_eligibility
     track_event(:pages_location_eligibility_search, search: postcode) if postcode.present?
     @search = CourseGeospatialSearch.new(postcode: postcode)

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -96,11 +96,6 @@ class UserSession
     job_profile_ids.size > 4
   end
 
-  def unblock_all_sections?
-    page_visited?('skills_matcher_index') &&
-      (page_visited?('training_hub') || page_visited?('next_steps'))
-  end
-
   def skill_ids
     return skill_ids_for_profile(current_job_id) if current_job?
 

--- a/app/views/pages/task_list_items/_item_1.html.erb
+++ b/app/views/pages/task_list_items/_item_1.html.erb
@@ -5,8 +5,8 @@
   <ul class="app-task-list__items">
     <li class="app-task-list__item">
       <div class="app-task-list__task-name">
-        <%= link_to check_your_skills_path, class: 'govuk-link' do %>
-          Check your existing skills <span class="app-step-nav__context">5 minutes</span>
+        <%= link_to @skills_summary_path, class: 'govuk-link' do %>
+          Check your existing skills
         <% end %>
         <p class="govuk-body govuk-!-margin-bottom-0">You'll be surprised at what you already know.</p>
       </div>

--- a/app/views/pages/task_list_items/_item_2.html.erb
+++ b/app/views/pages/task_list_items/_item_2.html.erb
@@ -5,8 +5,8 @@
   <ul class="app-task-list__items">
     <li class="app-task-list__item">
       <div class="app-task-list__task-name">
-        <%= link_or_blocked(path: skills_matcher_index_path, enabled: user_session.page_visited?('skills_matcher_index'), span_id: 2) do %>
-          See types of jobs that match your skills <span class="app-step-nav__context">5 to 20 minutes</span>
+        <%= link_or_blocked(path: skills_matcher_index_path, enabled: user_session.job_profile_skills?, span_id: 2) do %>
+          See types of jobs that match your skills
         <% end %>
         <p class="govuk-body govuk-!-margin-bottom-0">You already have many of the skills to do these types of jobs. Find out what additional training you might need.</p>
       </div>

--- a/app/views/pages/task_list_items/_item_3.html.erb
+++ b/app/views/pages/task_list_items/_item_3.html.erb
@@ -5,8 +5,8 @@
   <ul class="app-task-list__items">
     <li class="app-task-list__item">
       <div class="app-task-list__task-name">
-        <%= link_or_blocked(path: training_hub_path, enabled: user_session.unblock_all_sections?, span_id: 3) do %>
-          Find a training course <span class="app-step-nav__context">10 to 20 minutes</span>
+        <%= link_or_blocked(path: training_hub_path, enabled: user_session.job_profile_skills?, span_id: 3) do %>
+          Find a training course
         <% end %>
         <p class="govuk-body govuk-!-margin-bottom-0">Training can help you access a broader range of jobs and stay in secure work.</p>
       </div>

--- a/app/views/pages/task_list_items/_item_4.html.erb
+++ b/app/views/pages/task_list_items/_item_4.html.erb
@@ -1,14 +1,14 @@
 <li>
   <h2 class="app-task-list__section">
-    <span class="app-task-list__section-number">4. </span> Further help to find work
+    <span class="app-task-list__section-number">4. </span> Get help changing jobs
   </h2>
   <ul class="app-task-list__items">
     <li class="app-task-list__item">
       <div class="app-task-list__task-name">
-        <%= link_or_blocked(path: next_steps_path, enabled: user_session.unblock_all_sections?, span_id: 4) do %>
-          Find other ways to change jobs
+        <%= link_or_blocked(path: next_steps_path, enabled: user_session.job_profile_skills?, span_id: 4) do %>
+          Further help to find work
         <% end %>
-        <p class="govuk-body govuk-!-margin-bottom-0">Connecting you to further advice, ideas and help.</p>
+        <p class="govuk-body govuk-!-margin-bottom-0">Get help writing a CV and cover letter and preparing for interview. See if on-the-job training is right for you and find local support.</p>
       </div>
     </li>
   </ul>

--- a/app/views/pages/task_list_items/_item_5.html.erb
+++ b/app/views/pages/task_list_items/_item_5.html.erb
@@ -5,8 +5,8 @@
   <ul class="app-task-list__items">
     <li class="app-task-list__item">
       <div class="app-task-list__task-name">
-        <%= link_or_blocked(path: 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', enabled: user_session.unblock_all_sections?, span_id: 5, data: { tracked_event: 'TaskList - User Exit Survey Link', tracked_event_props: { url: 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/' } }, target: '_blank') do %>
-          Take a quick survey <span class="app-step-nav__context">3 to 5 minutes</span>
+        <%= link_or_blocked(path: 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', enabled: user_session.job_profile_skills?, span_id: 5, data: { tracked_event: 'TaskList - User Exit Survey Link' }, target: '_blank') do %>
+          Take a quick survey
         <% end %>
         <p class="govuk-body govuk-!-margin-bottom-0">Tell us about your experience using Get help to retrain.</p>
       </div>

--- a/spec/features/task_list_spec.rb
+++ b/spec/features/task_list_spec.rb
@@ -49,6 +49,68 @@ RSpec.feature 'Tasks List', type: :feature do
     end
   end
 
+  scenario 'With a clean new session Check your skills takes user to your current job page when Skills builder v2 OFF' do
+    disable_feature! :skills_builder_v2
+
+    visit(task_list_path)
+
+    click_on('Check your existing skills')
+
+    expect(page).to have_current_path(check_your_skills_path)
+  end
+
+  scenario 'With a clean new session Check your skills takes user to your current job page when Skills builder v2 ON' do
+    enable_feature! :skills_builder_v2
+
+    visit(task_list_path)
+
+    click_on('Check your existing skills')
+
+    expect(page).to have_current_path(check_your_skills_path)
+  end
+
+  scenario 'When the session already has profile skills Check your skills takes user to the skills summary page when Skills builder v2 is OFF' do
+    disable_feature! :skills_builder_v2
+
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      name: 'Assassin',
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics')
+      ]
+    )
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    click_on('Select these skills')
+
+    visit(task_list_path)
+    click_on('Check your existing skills')
+
+    expect(page).to have_current_path(skills_path(job_profile_id: job_profile.slug))
+  end
+
+  scenario 'When the session already has profile skills Check your skills takes user to the skills summary page when Skills builder v2 is ON' do
+    enable_feature! :skills_builder_v2
+
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      name: 'Assassin',
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics')
+      ]
+    )
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    click_on('Select these skills')
+
+    visit(task_list_path)
+    click_on('Check your existing skills')
+
+    expect(page).to have_current_path(skills_path(job_profile_id: job_profile.slug))
+  end
+
   scenario 'With a clean new session the user will not be able to click sections 2,3,4,5' do
     visit(task_list_path)
 
@@ -57,7 +119,7 @@ RSpec.feature 'Tasks List', type: :feature do
     end
   end
 
-  scenario 'User unlocks skill matcher section when clicking on Find out what you can do with these skills from /jobs-match' do
+  scenario 'User unlocks skill matcher section when one has skills on the session' do
     skill = create(:skill)
 
     job_profile = create(
@@ -74,7 +136,6 @@ RSpec.feature 'Tasks List', type: :feature do
 
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     click_on('Select these skills')
-    click_on('Find out what you can do with these skills')
 
     visit(task_list_path)
 
@@ -83,7 +144,7 @@ RSpec.feature 'Tasks List', type: :feature do
     expect(page).to have_text('Types of jobs that match your skills')
   end
 
-  scenario 'Unlocking skill matcher section does not unlock sections 3,4,5' do
+  scenario 'User unlocks the training course section when one has skills on the session' do
     job_profile = create(
       :job_profile,
       :with_html_content,
@@ -95,51 +156,6 @@ RSpec.feature 'Tasks List', type: :feature do
 
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     click_on('Select these skills')
-    click_on('Find out what you can do with these skills')
-
-    visit(task_list_path)
-
-    (3..5).each do |section_no|
-      expect(page).to have_css("span#section-#{section_no}-blocked")
-    end
-  end
-
-  scenario 'Unlocking skill matcher section does not allow clicking sections 3,4,5' do
-    job_profile = create(
-      :job_profile,
-      :with_html_content,
-      name: 'Assassin',
-      skills: [
-        create(:skill, name: 'Chameleon-like blend in tactics')
-      ]
-    )
-
-    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
-    click_on('Select these skills')
-    click_on('Find out what you can do with these skills')
-
-    visit(task_list_path)
-
-    ['Find a training course', 'Find other ways to change jobs', 'Take a quick survey'].each do |link|
-      expect(page).to have_no_link(link)
-    end
-  end
-
-  scenario 'User unlocks the training course section by clicking Other ways to change jobs from job profile page' do
-    job_profile = create(
-      :job_profile,
-      :with_html_content,
-      name: 'Assassin',
-      skills: [
-        create(:skill, name: 'Chameleon-like blend in tactics')
-      ]
-    )
-
-    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
-    click_on('Select these skills')
-    click_on('Find out what you can do with these skills')
-    visit(job_profile_path(job_profile.slug))
-    click_on('Get help changing jobs')
 
     visit(task_list_path)
     click_on('Find a training course')
@@ -147,7 +163,7 @@ RSpec.feature 'Tasks List', type: :feature do
     expect(page).to have_text('Find training that boosts your job options')
   end
 
-  scenario 'User unlocks the training course section by clicking Find a training course from job profile page' do
+  scenario 'User unlocks next steps section when one has skills on the session' do
     job_profile = create(
       :job_profile,
       :with_html_content,
@@ -159,39 +175,14 @@ RSpec.feature 'Tasks List', type: :feature do
 
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     click_on('Select these skills')
-    click_on('Find out what you can do with these skills')
-    visit("job-profiles/#{job_profile.slug}")
-    click_on('Find a training course')
 
     visit(task_list_path)
-    click_on('Find a training course')
-
-    expect(page).to have_text('Find training that boosts your job options')
-  end
-
-  scenario 'User unlocks next steps section by clicking Find a training course from job profile page' do
-    job_profile = create(
-      :job_profile,
-      :with_html_content,
-      name: 'Assassin',
-      skills: [
-        create(:skill, name: 'Chameleon-like blend in tactics')
-      ]
-    )
-
-    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
-    click_on('Select these skills')
-    click_on('Find out what you can do with these skills')
-    visit("job-profiles/#{job_profile.slug}")
-    click_on('Find a training course')
-
-    visit(task_list_path)
-    click_on('Find other ways to change jobs')
+    click_on('Further help to find work')
 
     expect(page).to have_text('Further help to find work')
   end
 
-  scenario 'User unlocks next steps section by clicking Other ways to change jobs from job profile page' do
+  scenario 'User unlocks survey section when one has skills on the session' do
     job_profile = create(
       :job_profile,
       :with_html_content,
@@ -203,31 +194,6 @@ RSpec.feature 'Tasks List', type: :feature do
 
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     click_on('Select these skills')
-    click_on('Find out what you can do with these skills')
-    visit("job-profiles/#{job_profile.slug}")
-    click_on('Get help changing jobs')
-
-    visit(task_list_path)
-    click_on('Find other ways to change jobs')
-
-    expect(page).to have_text('Further help to find work')
-  end
-
-  scenario 'User unlocks survey section by clicking Find a training course from job profile page' do
-    job_profile = create(
-      :job_profile,
-      :with_html_content,
-      name: 'Assassin',
-      skills: [
-        create(:skill, name: 'Chameleon-like blend in tactics')
-      ]
-    )
-
-    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
-    click_on('Select these skills')
-    click_on('Find out what you can do with these skills')
-    visit("job-profiles/#{job_profile.slug}")
-    click_on('Find a training course')
 
     visit(task_list_path)
 
@@ -239,64 +205,5 @@ RSpec.feature 'Tasks List', type: :feature do
         '_blank'
       ]
     )
-  end
-
-  scenario 'User unlocks survey section by clicking Other ways to change jobs from job profile page' do
-    job_profile = create(
-      :job_profile,
-      :with_html_content,
-      name: 'Assassin',
-      skills: [
-        create(:skill, name: 'Chameleon-like blend in tactics')
-      ]
-    )
-
-    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
-    click_on('Select these skills')
-    click_on('Find out what you can do with these skills')
-    visit("job-profiles/#{job_profile.slug}")
-    click_on('Get help changing jobs')
-
-    visit(task_list_path)
-
-    link = find_link('Take a quick survey')
-
-    expect([link[:href], link[:target]]).to eq(
-      [
-        'https://www.smartsurvey.co.uk/s/get-help-to-retrain/',
-        '_blank'
-      ]
-    )
-  end
-
-  scenario 'User does not unlock 3,4,5 by deep linking into training course' do
-    visit(training_hub_path)
-    visit(task_list_path)
-
-    (2..5).each do |section_no|
-      expect(page).to have_css("span#section-#{section_no}-blocked")
-    end
-  end
-
-  scenario 'User does not unlock 3,4,5 by deep linking into next steps' do
-    visit(next_steps_path)
-    visit(task_list_path)
-
-    (2..5).each do |section_no|
-      expect(page).to have_css("span#section-#{section_no}-blocked")
-    end
-  end
-
-  context 'when next steps v2 is ON' do
-    background do
-      enable_feature! :next_steps_v2
-    end
-
-    # TODO: remove test when we remove the feature flag
-    scenario 'User sees new and improved next steps page' do
-      visit(next_steps_path)
-
-      expect(page).to have_text('Get help changing jobs')
-    end
   end
 end

--- a/spec/models/user_sessions_spec.rb
+++ b/spec/models/user_sessions_spec.rb
@@ -308,39 +308,6 @@ RSpec.describe UserSession do
     end
   end
 
-  describe '#unblock_all_sections?' do
-    it 'returns false if there are no sessions for all pages' do
-      expect(user_session).not_to be_unblock_all_sections
-    end
-
-    it 'returns false if only skills matcher unblocked' do
-      user_session.track_page('skills_matcher_index')
-
-      expect(user_session).not_to be_unblock_all_sections
-    end
-
-    it 'returns true if skills matcher and training hub unblocked' do
-      user_session.track_page('skills_matcher_index')
-      user_session.track_page('training_hub')
-
-      expect(user_session).to be_unblock_all_sections
-    end
-
-    it 'returns true if skills matcher and next steps unblocked' do
-      user_session.track_page('skills_matcher_index')
-      user_session.track_page('next_steps')
-
-      expect(user_session).to be_unblock_all_sections
-    end
-
-    it 'returns false if training hub and next steps unblocked' do
-      user_session.track_page('training_hub')
-      user_session.track_page('next_steps')
-
-      expect(user_session).not_to be_unblock_all_sections
-    end
-  end
-
   describe '#skill_ids' do
     context 'when there is a current_job_id on the session and we are using Skills Builder v1' do
       let(:session) {


### PR DESCRIPTION
The new flow is as follows:

1. When the user has no session, lands on task-list page
clicks on Check your existing skills, gets taken to search
for current job title form (check_your_skills path).

2. When the user selects a set of skills, which are persisted
already in the session by that time, all the sections on
task-list get unlocked. The user DOES NOT have to click on
Find what you can do next button anymore as per discussion with
Shelina & Lois.

3. If a user already has skills persisted on the session, when
landing to the task-list and clicking Check your skills link,
this will take the user to the skills summary page (skills_path).

This is compatible with bothe Skills Builder v1 & v2.

https://dfedigital.atlassian.net/browse/GET-417

### NOTE
We are aware that we are breaking the breadcrumbs search link currently as we are not passing a search term anymore at the task list level. Lois is aware of it and it will be tackled in the next sprints.