### PR TITLE
GET-497 Order by growth then alphabetically on skills matching

### DIFF
--- a/app/models/skills_matcher.rb
+++ b/app/models/skills_matcher.rb
@@ -31,7 +31,7 @@ class SkillsMatcher
   def job_profiles_subquery
     JobProfile
       .recommended
-      .select(:skills_matched, 'array_agg(id order by name ASC) as alphabetically_ordered_ids')
+      .select(:skills_matched, 'array_agg(id order by growth DESC, name ASC) as ordered_ids')
       .from(Arel.sql("(#{job_profile_skills_subquery}) as ranked_job_profiles"))
       .joins('LEFT JOIN job_profiles ON job_profiles.id = ranked_job_profiles.job_profile_id')
       .where.not(id: user_session.job_profile_ids)
@@ -52,6 +52,6 @@ class SkillsMatcher
   end
 
   def job_profile_ids_unnest_query
-    "(#{job_profiles_subquery}) as ordered_query, unnest(alphabetically_ordered_ids) WITH ORDINALITY ordered_id"
+    "(#{job_profiles_subquery}) as ordered_query, unnest(ordered_ids) WITH ORDINALITY ordered_id"
   end
 end

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -119,6 +119,27 @@ RSpec.feature 'Skills matcher', type: :feature do
     )
   end
 
+  scenario 'arranges profiles by growth if they share a score' do
+    create(:job_profile, name: 'Hacker', skills: [skill1, skill2], growth: 50)
+    create(:job_profile, name: 'Admin', skills: [skill1, skill2], growth: -5)
+    visit_skills_for_current_job_profile
+
+    expect(page.all('ul.govuk-list li a,p:contains("Skills match")').collect(&:text)).to eq(
+      ['Assasin', 'Skills match: Good', 'Hacker', 'Skills match: Good', 'Admin', 'Skills match: Good']
+    )
+  end
+
+  scenario 'arranges profiles by growth, then alphabetically if they share a score' do
+    create(:job_profile, name: 'Hitman', skills: [skill1, skill2], growth: 50)
+    create(:job_profile, name: 'Hacker', skills: [skill1, skill2], growth: 50)
+    create(:job_profile, name: 'Admin', skills: [skill1, skill2], growth: -5)
+    visit_skills_for_current_job_profile
+
+    expect(page.all('ul.govuk-list li a,p:contains("Skills match")').collect(&:text)).to eq(
+      ['Assasin', 'Skills match: Good', 'Hacker', 'Skills match: Good', 'Hitman', 'Skills match: Good', 'Admin', 'Skills match: Good']
+    )
+  end
+
   scenario 'paginates results of search' do
     create_list(:job_profile, 12, name: 'Hacker', skills: [skill1])
     visit_skills_for_current_job_profile


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-497

After grouping on skills match, order by growth, and then order alphabetically. I'd like to tackle the flakiness next in another ticket

Please find below a few examples of the ordering. I’ve uncovered the values for testing purposes:

First order through score:
<img width="795" alt="Screenshot 2019-09-27 at 13 00 02" src="https://user-images.githubusercontent.com/2732945/65768033-ab92a780-e127-11e9-973a-0ee6b00ed33e.png">
Then through growth if the score is equal:
<img width="676" alt="Screenshot 2019-09-27 at 12 47 14" src="https://user-images.githubusercontent.com/2732945/65768067-c7964900-e127-11e9-8a14-65587206d49f.png">
Then Alphabetically if the score and growth are equal:
<img width="736" alt="Screenshot 2019-09-27 at 12 46 08" src="https://user-images.githubusercontent.com/2732945/65768087-d846bf00-e127-11e9-82a0-33287dc0b16a.png">
Edgecase for growth being nil means it will appear at the top of the equal score group:
<img width="693" alt="Screenshot 2019-09-27 at 12 46 20" src="https://user-images.githubusercontent.com/2732945/65768095-dda40980-e127-11e9-90ee-90f2eabf5fcc.png">
