### PR TITLE
Skip PID/Postcode Eligibility pages

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,2 +1,5 @@
 class HomeController < ApplicationController
+  def index
+    @postcode_pid_or_task_list_path = helpers.postcode_step || helpers.pid_step || task_list_path
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,6 +18,8 @@ class PagesController < ApplicationController
   end
 
   def location_eligibility
+    return redirect_to_pid_or_task_list if user_session.postcode.present?
+
     track_event(:pages_location_eligibility_search, search: postcode) if postcode.present?
     @search = CourseGeospatialSearch.new(postcode: postcode)
     if postcode && @search.valid?
@@ -41,9 +43,13 @@ class PagesController < ApplicationController
 
   def location_eligibility_through_courses
     if @search.find_courses.any?
-      Flipflop.user_personal_data? ? redirect_to(your_information_path) : redirect_to(task_list_path)
+      redirect_to_pid_or_task_list
     else
       redirect_to(location_ineligible_path)
     end
+  end
+
+  def redirect_to_pid_or_task_list
+    redirect_to helpers.pid_step || task_list_path
   end
 end

--- a/app/controllers/user_personal_data_controller.rb
+++ b/app/controllers/user_personal_data_controller.rb
@@ -1,5 +1,7 @@
 class UserPersonalDataController < ApplicationController
   def index
+    redirect_to task_list_path if user_session.pid_submitted?
+
     @user_personal_data = UserPersonalData.new(postcode: user_session.postcode)
   end
 
@@ -7,6 +9,8 @@ class UserPersonalDataController < ApplicationController
     @user_personal_data = UserPersonalData.new(personal_data_params)
 
     if @user_personal_data.save
+      user_session.pid = true
+
       redirect_to task_list_path
     else
       render 'index'

--- a/app/helpers/user_journey_helper.rb
+++ b/app/helpers/user_journey_helper.rb
@@ -1,0 +1,11 @@
+module UserJourneyHelper
+  def pid_step
+    return unless Flipflop.user_personal_data?
+
+    your_information_path unless user_session.pid_submitted?
+  end
+
+  def postcode_step
+    location_eligibility_path unless user_session.postcode.present?
+  end
+end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -6,6 +6,7 @@ class UserSession
     job_profile_skills
     job_profile_ids
     postcode
+    pid
     current_job_id
     version
   ].freeze
@@ -21,6 +22,7 @@ class UserSession
     @session[:visited_pages] ||= []
     @session[:job_profile_skills] ||= {}
     @session[:job_profile_ids] ||= []
+    @session[:pid] ||= false
     @session[:version] ||= expected_version
   end
 
@@ -38,6 +40,14 @@ class UserSession
 
   def registered?
     session[:registered]
+  end
+
+  def pid_submitted?
+    session[:pid]
+  end
+
+  def pid=(value)
+    session[:pid] = value
   end
 
   def registered=(value)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,7 +13,7 @@
       <li>and you're earning below £35,000 a year</li>
     </ul>
     <p class="govuk-body">If these don’t all apply to you, try visiting the <%= link_to 'National Careers Service', 'https://nationalcareers.service.gov.uk/', class: 'govuk-link', target: '_blank' %> or your local <%= link_to 'Jobcentre Plus', 'https://find-your-nearest-jobcentre.dwp.gov.uk/', class: 'govuk-link', target: '_blank' %> instead.</p>
-    <%= link_to 'Start now', location_eligibility_path, class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8', role: 'button', data: { cy: 'start-now-btn' } %>
+    <%= link_to 'Start now', @postcode_pid_or_task_list_path, class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8', role: 'button', data: { cy: 'start-now-btn' } %>
     <p class="govuk-body govuk-!-margin-bottom-1">Other ways to use this service</p>
     <h2 class="govuk-heading-s govuk-!-margin-bottom-2"><%= t('contact_us.by_phone') %></h2>
     <p class="govuk-body-m govuk-!-margin-bottom-0">

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+RSpec.feature 'Navigation from home page' do
+  background do
+    disable_feature! :user_personal_data
+  end
+
+  scenario 'POSTCODE - absent from session, PID - absent from session - user gets redirected to location_eligibility page' do
+    visit(root_path)
+
+    click_on('Start now')
+
+    expect(page).to have_current_path(location_eligibility_path)
+  end
+
+  scenario 'POSTCODE - absent from session, PID - present on session - user gets redirected to location_eligibility page' do
+    enable_feature! :user_personal_data
+
+    visit(your_information_path)
+
+    fill_in('user_personal_data[first_name]', with: 'John')
+    fill_in('user_personal_data[last_name]', with: 'Mayer')
+    fill_in('user_personal_data[postcode]', with: 'NW6 1JJ')
+    fill_in('user_personal_data[birth_day]', with: '1')
+    fill_in('user_personal_data[birth_month]', with: '1')
+    fill_in('user_personal_data[birth_year]', with: DateTime.now.year - 20)
+    choose('user_personal_data[gender]', option: 'male')
+
+    click_on('Continue')
+
+    visit(root_path)
+
+    click_on('Start now')
+
+    expect(page).to have_current_path(location_eligibility_path)
+  end
+
+  scenario 'POSTCODE - present on session, PID - absent from session, user_personal_data feature is OFF - user gets redirected to task-list page' do
+    Geocoder::Lookup::Test.add_stub(
+      'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+    )
+
+    create(:course, latitude: 0.1, longitude: 1.001, topic: 'maths')
+
+    visit(location_eligibility_path)
+    fill_in('postcode', with: 'NW6 8ET')
+    click_on('Continue')
+
+    visit(root_path)
+
+    click_on('Start now')
+
+    expect(page).to have_current_path(task_list_path)
+  end
+
+  scenario 'POSTCODE - present on session, PID - absent from session, user_personal_data feature is ON - user gets redirected to pid page' do
+    enable_feature! :user_personal_data
+
+    Geocoder::Lookup::Test.add_stub(
+      'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+    )
+
+    create(:course, latitude: 0.1, longitude: 1.001, topic: 'maths')
+
+    visit(location_eligibility_path)
+    fill_in('postcode', with: 'NW6 8ET')
+    click_on('Continue')
+
+    visit(root_path)
+
+    click_on('Start now')
+
+    expect(page).to have_current_path(your_information_path)
+  end
+
+  scenario 'POSTCODE - present on session, PID - present on the session - user gets redirected to task-list page' do
+    enable_feature! :user_personal_data
+
+    Geocoder::Lookup::Test.add_stub(
+      'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+    )
+
+    create(:course, latitude: 0.1, longitude: 1.001, topic: 'maths')
+
+    visit(location_eligibility_path)
+    fill_in('postcode', with: 'NW6 8ET')
+    click_on('Continue')
+
+    fill_in('user_personal_data[first_name]', with: 'John')
+    fill_in('user_personal_data[last_name]', with: 'Mayer')
+    fill_in('user_personal_data[postcode]', with: 'NW6 1JJ')
+    fill_in('user_personal_data[birth_day]', with: '1')
+    fill_in('user_personal_data[birth_month]', with: '1')
+    fill_in('user_personal_data[birth_year]', with: DateTime.now.year - 20)
+    choose('user_personal_data[gender]', option: 'male')
+
+    click_on('Continue')
+
+    visit(root_path)
+
+    click_on('Start now')
+
+    expect(page).to have_current_path(task_list_path)
+  end
+end

--- a/spec/features/location_eligibility_spec.rb
+++ b/spec/features/location_eligibility_spec.rb
@@ -33,6 +33,41 @@ RSpec.feature 'Check your location is eligible', type: :feature do
     expect(page).to have_current_path(task_list_path)
   end
 
+  scenario 'User skips eligibilty page straight to task-list if the postcode is already stored on the session' do
+    Geocoder::Lookup::Test.add_stub(
+      'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+    )
+
+    create(:course, latitude: 0.1, longitude: 1.001, topic: 'maths')
+
+    visit(location_eligibility_path)
+    fill_in('postcode', with: 'NW6 8ET')
+    click_on('Continue')
+
+    visit(location_eligibility_path)
+
+    expect(page).to have_current_path(task_list_path)
+  end
+
+  scenario 'User skips eligibilty page straight to pid if the postcode is already stored on the session and personal_data feature is ON' do
+    enable_feature! :user_personal_data
+
+    Geocoder::Lookup::Test.add_stub(
+      'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+    )
+
+    create(:course, latitude: 0.1, longitude: 1.001, topic: 'maths')
+
+    visit(location_eligibility_path)
+    fill_in('postcode', with: 'NW6 8ET')
+    click_on('Continue')
+
+    visit(root_path)
+    click_on('Start now')
+
+    expect(page).to have_current_path(your_information_path)
+  end
+
   scenario 'User can will proceed to your information even if postcode is not eligible' do
     enable_feature! :user_personal_data
 
@@ -52,6 +87,22 @@ RSpec.feature 'Check your location is eligible', type: :feature do
     visit(location_eligibility_path)
     fill_in('postcode', with: 'NW6 8ET')
     click_on('Continue')
+
+    expect(page).to have_current_path(task_list_path)
+  end
+
+  scenario 'User follows through to task list when POSTCODE info has been already provided' do
+    Geocoder::Lookup::Test.add_stub(
+      'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+    )
+
+    create(:course, latitude: 0.1, longitude: 1.001, topic: 'maths')
+
+    visit(location_eligibility_path)
+    fill_in('postcode', with: 'NW6 8ET')
+    click_on('Continue')
+
+    visit(location_eligibility_path(postcode: 'NW6 8ET'))
 
     expect(page).to have_current_path(task_list_path)
   end

--- a/spec/features/your_information_spec.rb
+++ b/spec/features/your_information_spec.rb
@@ -27,6 +27,30 @@ RSpec.feature 'Your information' do
     visit(your_information_path)
   end
 
+  scenario 'Redirects to task-list page if the information has already been submitted' do
+    fill_in('user_personal_data[first_name]', with: 'John')
+    fill_in('user_personal_data[last_name]', with: 'Mayer')
+    fill_in('user_personal_data[postcode]', with: 'NW6 1JJ')
+    fill_in('user_personal_data[birth_day]', with: '1')
+    fill_in('user_personal_data[birth_month]', with: '1')
+    fill_in('user_personal_data[birth_year]', with: DateTime.now.year - 20)
+    choose('user_personal_data[gender]', option: 'male')
+
+    click_on('Continue')
+
+    visit(your_information_path)
+
+    expect(page).to have_current_path(task_list_path)
+  end
+
+  scenario 'If PID is skipped and user comes back one should see the page again' do
+    click_on('Skip this step')
+
+    visit(your_information_path)
+
+    expect(page).to have_current_path(your_information_path)
+  end
+
   scenario 'When user fills the form correctly one gets taken to tasks-list page' do
     fill_in('user_personal_data[first_name]', with: 'John')
     fill_in('user_personal_data[last_name]', with: 'Mayer')

--- a/spec/helpers/user_journey_helper_spec.rb
+++ b/spec/helpers/user_journey_helper_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe UserJourneyHelper do
+  before do
+    helper.singleton_class.class_eval do
+      def user_session
+        UserSession.new(session)
+      end
+    end
+  end
+
+  describe '#postcode_step' do
+    context 'when POSTCODE is on the session' do
+      it 'returns nil' do
+        user_session = UserSession.new(session)
+        user_session.postcode = 'NW6 11F'
+
+        expect(helper.postcode_step).to be_nil
+      end
+    end
+
+    context 'when POSTCODE is not on the session' do
+      it 'returns location_eligibility_path' do
+        expect(helper.postcode_step).to eq location_eligibility_path
+      end
+    end
+  end
+
+  describe '#pid_step' do
+    context 'when PID feature is OFF' do
+      it 'returns nil' do
+        disable_feature! :user_personal_data
+
+        expect(helper.pid_step).to be_nil
+      end
+    end
+
+    context 'when PID feature is ON, PID is on the session' do
+      it 'returns nil' do
+        enable_feature! :user_personal_data
+
+        user_session = UserSession.new(session)
+        user_session.pid = true
+
+        expect(helper.pid_step).to be_nil
+      end
+    end
+
+    context 'when PID feature is ON, PID is not the session' do
+      it 'returns' do
+        enable_feature! :user_personal_data
+
+        expect(helper.pid_step).to eq your_information_path
+      end
+    end
+  end
+end

--- a/spec/models/user_sessions_spec.rb
+++ b/spec/models/user_sessions_spec.rb
@@ -123,6 +123,18 @@ RSpec.describe UserSession do
     end
   end
 
+  describe '#pid' do
+    it 'returns true if the pid value is set to true' do
+      user_session.pid = true
+
+      expect(user_session).to be_pid_submitted
+    end
+
+    it 'returns false if the pid value is set to false' do
+      expect(user_session).not_to be_pid_submitted
+    end
+  end
+
   describe '#registration_triggered_path' do
     it 'returns registration_triggered_path value if set' do
       session[:registration_triggered_path] = 'some-path'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe User do
 
     it 'overrides current session data set to user' do
       user = create(:user, session: create(:session, data: { postcode: 'bar' }))
-      session = create(:session, data: { postcode: 'baz' })
+      session = create(:session, data: { postcode: 'baz',  pid: true })
       new_session = create_fake_session(id: session.session_id)
 
       user.restore_session(new_session)


### PR DESCRIPTION
Skip PID/Postcode eligibility pages if the the information
has already been captured.

When user clicks start now:

a) if new session, go to postcode (eligibility) page
b) if user has a postcode (eligibility) but no personal
data in session, redirect to personal data page
c) if user has a postcode and personal data in session,
redirect to tasklist

When saving/returning to the journey, the same behaviour applies
for a user that has previously supplied the data.

https://dfedigital.atlassian.net/browse/GET-482
