### PR TITLE
Add custom healthcheck and swap parameters

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -194,7 +194,9 @@
     "domainDatabaseServerName": "[concat(variables('resourceNamePrefix'), '-domainPsql')]",
     "restrictedDatabaseServerName": "[concat(variables('resourceNamePrefix'), '-restricedPsql')]",
     "actionGroupName": "[concat(variables('resourceNamePrefix'), '-ag')]",
-    "appServiceRuntimeStack": "[concat('DOCKER|', parameters('containerImageReference'))]"
+    "appServiceRuntimeStack": "[concat('DOCKER|', parameters('containerImageReference'))]",
+    "warmupPingPath": "/status",
+    "containerStartTimeLimit": "300"
   },
   "resources": [
     {
@@ -483,6 +485,18 @@
           },
           "appServiceAppSettings": {
             "value": [
+              {
+                "name": "WEBSITE_SLOT_POLL_WORKER_FOR_CHANGE_NOTIFICATION",
+                "value": "0"
+              },
+              {
+                "name": "WEBSITE_SWAP_WARMUP_PING_PATH",
+                "value": "[variables('warmupPingPath')]"
+              },
+              {
+                "name": "WEBSITES_CONTAINER_START_TIME_LIMIT",
+                "value": "[variables('containerStartTimeLimit')]"
+              },
               {
                 "name": "ENVIRONMENT_NAME",
                 "value": "[variables('environmentName')]"


### PR DESCRIPTION
### Context

The Slot Swap operation is a bit flaky. 
After going through the documentation and by experimentation we surfaced a few internal settings that seem to improve how this internal operation works. 

### Changes proposed in this pull request

This PR adds a custom health-check endpoint which is more adequate to probe the healthiness of the application. And another setting aimed and improve the behaviour for Linux custom containers that do not interface with Azure the same way native .NET apps do.  

### Guidance to review

