### PR TITLE
Fix flaky test output for tracking service

### DIFF
--- a/spec/services/tracking_service_spec.rb
+++ b/spec/services/tracking_service_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe TrackingService do
         service.key = 'VALID'
       end
 
+      after do
+        service.key = nil
+      end
+
       it 'tracks event without additional properties' do
         allow(service.channel).to receive(:write).and_return(true)
         expect(service.track_event('foo')).to eq true


### PR DESCRIPTION
### Context
Because this uses a class level instance variable, if the tests for tracking service run before other tests that make use of the tracking service, then the test output is polluted with warnings:

WARN -- application_insights: Failed to send data: Invalid instrumentation key

This doesn't cause tests to fail, but is a bit noisy. Explicitly clearing the key after the relevant test fixes this.