### PR TITLE
GET-407 Refactor query and tidy up because there is no need for complexity

### DIFF
--- a/app/models/skills_matcher.rb
+++ b/app/models/skills_matcher.rb
@@ -20,7 +20,7 @@ class SkillsMatcher
 
   private
 
-  def job_profile_skills_subquery
+  def skills_matched_query
     JobProfileSkill
       .select(:job_profile_id, 'COUNT(job_profile_id) AS skills_matched')
       .where(skill_id: user_session.skill_ids)
@@ -28,31 +28,21 @@ class SkillsMatcher
       .to_sql
   end
 
-  def job_profiles_subquery
-    JobProfile
-      .recommended
-      .select(:skills_matched, 'array_agg(id order by growth DESC, name ASC) as ordered_ids')
-      .from(Arel.sql("(#{job_profile_skills_subquery}) as ranked_job_profiles"))
-      .joins('LEFT JOIN job_profiles ON job_profiles.id = ranked_job_profiles.job_profile_id')
-      .where.not(id: user_session.job_profile_ids)
-      .group(:skills_matched)
-      .to_sql
-  end
-
   def build_query
     @build_query ||= begin
-      JobProfile
+      job_profile_scope
         .select(
           :skills_matched, :id, :name, :description, :alternative_titles, :salary_min, :salary_max, :slug, :growth
         )
-        .from(Arel.sql(job_profile_ids_unnest_query))
-        .joins('LEFT JOIN job_profiles ON job_profiles.id = ordered_id')
-        .order(skills_matched: :desc)
-        .order(ordinality: :asc)
+        .from(Arel.sql("(#{skills_matched_query}) as ranked_job_profiles"))
+        .joins('LEFT JOIN job_profiles ON job_profiles.id = ranked_job_profiles.job_profile_id')
+        .order(skills_matched: :desc, growth: :desc, name: :asc)
     end
   end
 
-  def job_profile_ids_unnest_query
-    "(#{job_profiles_subquery}) as ordered_query, unnest(ordered_ids) WITH ORDINALITY as x(ordered_id, ordinality)"
+  def job_profile_scope
+    JobProfile
+      .recommended
+      .where.not(id: user_session.job_profile_ids)
   end
 end

--- a/app/models/skills_matcher.rb
+++ b/app/models/skills_matcher.rb
@@ -36,7 +36,6 @@ class SkillsMatcher
       .joins('LEFT JOIN job_profiles ON job_profiles.id = ranked_job_profiles.job_profile_id')
       .where.not(id: user_session.job_profile_ids)
       .group(:skills_matched)
-      .order(skills_matched: :desc)
       .to_sql
   end
 
@@ -48,10 +47,12 @@ class SkillsMatcher
         )
         .from(Arel.sql(job_profile_ids_unnest_query))
         .joins('LEFT JOIN job_profiles ON job_profiles.id = ordered_id')
+        .order(skills_matched: :desc)
+        .order(ordinality: :asc)
     end
   end
 
   def job_profile_ids_unnest_query
-    "(#{job_profiles_subquery}) as ordered_query, unnest(ordered_ids) WITH ORDINALITY ordered_id"
+    "(#{job_profiles_subquery}) as ordered_query, unnest(ordered_ids) WITH ORDINALITY as x(ordered_id, ordinality)"
   end
 end


### PR DESCRIPTION
When unnesting an aggregate array with ordinality with minimal syntax:
`WITH ORDINALITY ordered_id`, this was minimising the following
syntax:
`WITH ORDINALITY some_table(ids, ordinality_number)`
But this does not guarantee the order of the unnested arrays is maintained.
Explicitly ordering on the ordinality number as a secondary order
after the skills match makes sure the order is retained.
`

EDIT:
After some consideration realised we can tidy up this query and remove the unnecessary step of array aggregate ordering and un-nesting. This can be done with a normal `.order`

The following query should maintain the previous behaviour as well as eliminate the flakiness

jira-ticket: https://dfedigital.atlassian.net/browse/GET-407