### PR TITLE
Add libncurses5-dev to azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ stages:
 
       - script: |
           sudo apt-get update
-          sudo apt-get install libpq-dev bison libgdbm-dev libsqlite3-dev libyaml-dev sqlite3 libreadline6-dev
+          sudo apt-get install libpq-dev bison libgdbm-dev libsqlite3-dev libyaml-dev sqlite3 libreadline6-dev libncurses5-dev
           gpg --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
           curl -sSL https://get.rvm.io | bash -s -- --autolibs=read-fail
           source /home/vsts/.rvm/scripts/rvm


### PR DESCRIPTION
This seems to be required by RVM: https://github.com/rvm/rvm/search?q=libncurses5-dev&unscoped_q=libncurses5-dev

