### PR TITLE
Update rubyzip (dependency of roo) because of CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,7 @@ GEM
     ruby-graphviz (1.2.4)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    rubyzip (1.2.3)
+    rubyzip (1.3.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)


### PR DESCRIPTION
https://github.com/DFE-Digital/get-help-to-retrain/network/alert/Gemfile.lock/rubyzip/open