### PR TITLE
Restrict number of job profile matches to 50 maximum

### DIFF
--- a/app/models/skills_matcher.rb
+++ b/app/models/skills_matcher.rb
@@ -37,6 +37,7 @@ class SkillsMatcher
         .from(Arel.sql("(#{skills_matched_query}) as ranked_job_profiles"))
         .joins('LEFT JOIN job_profiles ON job_profiles.id = ranked_job_profiles.job_profile_id')
         .order(skills_matched: :desc, growth: :desc, name: :asc)
+        .limit(50)
     end
   end
 

--- a/spec/models/skills_matcher_spec.rb
+++ b/spec/models/skills_matcher_spec.rb
@@ -10,6 +10,21 @@ RSpec.describe SkillsMatcher do
       expect(matcher.match).to be_empty
     end
 
+    it 'limits maximum number of job matches to 50' do
+      skill = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill])
+      create_list(:job_profile, 51, skills: [skill])
+      session = create_fake_session(
+        job_profile_ids: [job_profile1.id],
+        job_profile_skills: {
+          job_profile1.id.to_s => [skill.id]
+        }
+      )
+      matcher = described_class.new(UserSession.new(session))
+
+      expect(matcher.match.size).to eq 50
+    end
+
     it 'returns multiple jobs matching skill selected ignoring job profiles in the session' do
       skill = create(:skill)
       job_profile1 = create(:job_profile, skills: [skill])


### PR DESCRIPTION
### Context
This still respects the original ordering, but limits results to 50.

### Changes proposed in this pull request

### Guidance to review
* Add lots of common skills to skill builder
* Skill matcher results should return maximum 5 pages (50 job profiles)
