### PR TITLE
GET-432 Add Accessibility fixes

### DIFF
--- a/app/views/check_your_skills/_results_list.html.erb
+++ b/app/views/check_your_skills/_results_list.html.erb
@@ -5,6 +5,7 @@
         <%= link_to job_profile.name, job_profile_skills_path(job_profile.slug, search: params[:search]), class: 'govuk-link no-text-decoration' %>
       </h3>
       <% if job_profile.alternative_titles.present? %>
+        <span class="sr-only">Alternative titles for this job include:</span>
         <p class="govuk-body-s govuk-!-margin-bottom-2 muted-text"><%= job_profile.alternative_titles %></p>
       <% end %>
       <p class="govuk-!-margin-0"><%= job_profile.description %></p>

--- a/app/views/skills_matcher/_job_matches.html.erb
+++ b/app/views/skills_matcher/_job_matches.html.erb
@@ -5,6 +5,7 @@
          <%= link_to job_profile.name, job_profile_path(job_profile.slug, search: params[:search]), class: 'govuk-link no-text-decoration' %>
       </h3>
       <% if job_profile.alternative_titles.present? %>
+        <span class="sr-only">Alternative titles for this job include:</span>
         <p class="govuk-body-s govuk-!-margin-bottom-2 muted-text"><%= job_profile.alternative_titles %></p>
       <% end %>
       <p class="govuk-!-margin-0 govuk-!-margin-bottom-3"><%= job_profile.description %></p>

--- a/app/webpacker/styles/_job-profile.scss
+++ b/app/webpacker/styles/_job-profile.scss
@@ -217,3 +217,17 @@
 .underlined-text {
   text-decoration: underline;
 }
+
+.sr-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: polygon(0 0, 0 0, 0 0);
+  -webkit-clip-path: polygon(0 0, 0 0, 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
+}


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-432

* Add a new screen reader hidden section to explain alternative jobs. There is
  a discussion about using aria-label vs css solution but the css solution
  is preferable. https://cloudfour.com/thinks/see-no-evil-hidden-content-and-accessibility/
I tried using `aria-label` and it puts the list into a group which is obscure

* For other changes required in the ticket, skills builder markup changed making it not an issue anymore, and the hidden text is not an issue after revisiting and discussing

