### PR TITLE
GET-441 Fix Job Profile page accessibility as well as courses and navigation

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,7 +11,7 @@ module ApplicationHelper
             link_to(title, link, class: 'govuk-breadcrumbs__link')
           }
         },
-        content_tag(:li, current_page, class: 'govuk-breadcrumbs__list-item')
+        content_tag(:li, current_page, class: 'govuk-breadcrumbs__list-item', aria: { current: 'page' })
       ]
     )
   end

--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -1,6 +1,6 @@
 <li>
   <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-heading-l title"><%= course.title %></h2>
-  <h3 class="govuk-heading-s govuk-!-margin-bottom-0 muted-text"><%= course.provider %></h3>
+  <h3 class="govuk-heading-s govuk-!-margin-bottom-0 muted-text"><span class="sr-only">Provider:</span><%= course.provider %></h3>
   <p class="govuk-body govuk-!-margin-bottom-0">Distance: <b><%= course.distance.round(1) %> miles</b></p>
   <p class="govuk-body-s"><%= course.full_address %></p>
   <p class="govuk-body-s">Tel:<%= link_to(course.phone_number, "tel:#{course.phone_number}", class: 'govuk-!-padding-left-1 govuk-link' ) %></p>

--- a/app/views/job_profiles/_highlights.html.erb
+++ b/app/views/job_profiles/_highlights.html.erb
@@ -2,16 +2,12 @@
   <div class="govuk-grid-column-one-half">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-quarter govuk-!-margin-top-5 govuk-!-margin-bottom-6">
-        <div class="profile-highlights salary-icon"></div>
+        <div class="profile-highlights salary-icon" role="img" aria-label="Pound sterling icon"></div>
       </div>
       <div class="govuk-grid-column-three-quarters">
         <h4 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-1">Average Salary</h4>
         <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-2 responsive-section-break">
-        <ul class="govuk-list">
-          <li>
-            <%= @job_profile.salary_range %>
-          </li>
-        </ul>
+        <p class="govuk-body"><%= @job_profile.salary_range %></p>
       </div>
     </div>
   </div>
@@ -19,12 +15,12 @@
   <div class="govuk-grid-column-one-half">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-quarter govuk-!-margin-top-5 govuk-!-margin-bottom-6">
-        <div class="profile-highlights time-icon"></div>
+        <div class="profile-highlights time-icon" role="img" aria-label="Clock icon"></div>
       </div>
       <div class="govuk-grid-column-three-quarters">
         <h4 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-1">Typical hours</h4>
         <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-2 responsive-section-break">
-        <p class="govuk-body"><span id="hours"><%= @job_profile.working_hours %></span> a week</p>
+        <p class="govuk-body"><%= @job_profile.working_hours %> a week</p>
       </div>
     </div>
   </div>
@@ -34,7 +30,7 @@
   <div class="govuk-grid-column-one-half">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-quarter govuk-!-margin-top-5 govuk-!-margin-bottom-6">
-        <div class="profile-highlights calendar-icon"></div>
+        <div class="profile-highlights calendar-icon" role="img" aria-label="Calendar icon"></div>
       </div>
       <div class="govuk-grid-column-three-quarters">
         <h4 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-1">You could work</h4>
@@ -48,7 +44,7 @@
     <div class="govuk-grid-column-one-half">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-quarter govuk-!-margin-top-5 govuk-!-margin-bottom-6">
-          <div class="profile-highlights <%= @job_profile.growth_icon %>"></div>
+          <div class="profile-highlights <%= @job_profile.growth_icon %>" role="img" aria-label="Arrow pointing upwards"></div>
         </div>
         <div class="govuk-grid-column-three-quarters">
           <h4 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-1">Recent job growth</h4>


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-441

For background images accessiblity there were quite a few implementations.
I went with the simpler one seen here: https://stackoverflow.com/questions/48913759/how-to-add-alt-text-to-background-images-making-background-images-accessible/#48913760
There is another approach with much more markup, having tested this, this seems adequate for now.

Also add hidden text to courses for providers 

Whilst we can't remove the extra list due to the clearfix class
being added by govuk frontend, we can point to the current page:
https://design-system.service.gov.uk/components/breadcrumbs/

We are adhering exactly to the rules of breadcrumbs seen there,
so Im going to keep it that way for now