### PR TITLE
GET-561 Run two instances in QA, UAT, PROD

### DIFF
--- a/azure/config/prod.parameters.json
+++ b/azure/config/prod.parameters.json
@@ -92,6 +92,9 @@
     },
     "applyAlerts": {
       "value": true
+    },
+    "appServicePlanInstances": {
+      "value": 2
     }
   }
 }

--- a/azure/config/qa.parameters.json
+++ b/azure/config/qa.parameters.json
@@ -92,6 +92,9 @@
     },
     "applyAlerts": {
       "value": true
+    },
+    "appServicePlanInstances": {
+      "value": 2
     }
   }
 }

--- a/azure/config/uat.parameters.json
+++ b/azure/config/uat.parameters.json
@@ -92,6 +92,9 @@
     },
     "applyAlerts": {
       "value": true
+    },
+    "appServicePlanInstances": {
+      "value": 2
     }
   }
 }


### PR DESCRIPTION
### Context

Before going live we want to run our application in HA, so that we don't suffer an outage if one instance of application dies due to a crash or other instance specific isshue. 

### Changes proposed in this pull request

This PR passes a parameter that overrides the default number of instances of 1.

### Guidance to review

This parameter overrides the default defined in the generic templates.

https://github.com/DFE-Digital/get-help-to-retrain-devops/blob/master/templates/app-service-plan.json#L32-L35

