### PR TITLE
GET-538 Do not destroy session if versions are different

### DIFF
--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -17,7 +17,9 @@ class UserSession
 
   def initialize(session)
     @session = session
-    @session.destroy unless version == expected_version
+
+    # TODO: This should be removed after we go live with skills builder v2
+    @session.clear unless version == expected_version
 
     @session[:visited_pages] ||= []
     @session[:job_profile_skills] ||= {}

--- a/spec/features/user_sign_in_spec.rb
+++ b/spec/features/user_sign_in_spec.rb
@@ -344,4 +344,39 @@ RSpec.feature 'User sign in' do
 
     expect(page).not_to have_text(/Enter a job title/)
   end
+
+  scenario 'user does not lose session if the session version changes' do
+    disable_feature!(:skills_builder_v2)
+    enable_feature!(:user_authentication)
+
+    register_user
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    uncheck('Baldness', allow_label_click: true)
+    click_on('Select these skills')
+    sign_in_user
+
+    enable_feature!(:skills_builder_v2, :user_authentication)
+    visit(check_your_skills_path)
+    Capybara.reset_sessions!
+
+    sign_in_user
+    visit(skills_path)
+
+    expect(page).not_to have_selector('tbody tr', count: 2)
+  end
+
+  xscenario 'user remains signed in if version changes' do
+    pending('Added to show what would happen if we keep the session clear option, which we /
+    should get rid of after releasing skills builder v2')
+    disable_feature!(:skills_builder_v2)
+    enable_feature!(:user_authentication)
+
+    register_user
+    sign_in_user
+
+    enable_feature!(:skills_builder_v2, :user_authentication)
+    visit(check_your_skills_path)
+
+    expect(page).not_to have_text('Return to saved results')
+  end
 end

--- a/spec/support/session_helper.rb
+++ b/spec/support/session_helper.rb
@@ -6,10 +6,6 @@ class SessionKlass < SimpleDelegator
   def id
     self[:id]
   end
-
-  def destroy
-    clear
-  end
 end
 
 module SessionHelper


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-538

When users were hitting the page for the first time we were deleting
the session from the database as they didn't have a version in the data.
This was causing unnecessary read/write to the database also causing the
database to seem like it was "skipping" ids, which were records created and
deleted unnecessarily.

This also caused an issue with authenticated users linked to sessions. If a user was signed
in with a session and the version changed, which caused their session to be deleted they could
not log in again, but rather see an error where we were trying to access a non existing session.

Now we "clear" the session instead of deleting it, only if the session has data, meaning there are no
unnecessary writes to the db, and we don't risk deleting a session linked to a user.

However I am unhappy with this versioning solution, as after we persist sessions this
fix seems more of a pain than a solution. We now have control over sessions, and can make
sure to be backward compatible when releasing different versions. I propose after going live
with phase 3 we get rid of versioning, as it is needed for this release only. I added a commented
out test that shows another failure this causes and as a reminder for us to remove after the release.
