### PR TITLE
Refractor deployment into a template for re-use

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -1,0 +1,65 @@
+parameters:
+  debug: false
+  subscriptionServiceConnection:
+  resourceGroupName:
+  environment:
+  containerImageReference:
+  supportEmailAddresses: '[{"name":"GHtR Alerts","email":"ghtr-alerts@digital.education.gov.uk"}]'
+
+jobs:
+  - deployment: deploy_${{parameters.environment}}
+    displayName: 'Deploy App to ${{parameters.environment}}'
+    environment: '${{parameters.environment}}'
+
+    pool:
+      vmImage: 'vs2017-win2016'
+
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - task: AzureResourceGroupDeployment@2
+              displayName: 'Azure Deployment:Create Or Update Resource Group action on $(resourceEnvironmentName)-$(serviceName)'
+              inputs:
+                action: 'Create Or Update Resource Group'
+                location: 'West Europe'
+                azureSubscription: '${{parameters.subscriptionServiceConnection}}'
+                resourceGroupName: '${{parameters.resourceGroupName}}'
+                csmFile: '$(Pipeline.Workspace)\ARMTemplates\azure\template.json'
+                csmParametersFile: '$(Pipeline.Workspace)\ARMTemplates\azure\config\${{parameters.environment}}.parameters.json'
+                overrideParameters: '-containerImageReference "${{parameters.containerImageReference}}" -supportEmailAddresses ${{parameters.supportEmailAddresses}}'
+                deploymentOutputs: DeploymentOutput
+
+            - task: RasmusWatjen.ARMOutputParserExtension.ARMOutputConverter.ARMOutputParserExtension@1
+              displayName: 'Parse ARM Deployment Outputs into variables'
+              inputs:
+                armOutput: $(DeploymentOutput)
+                variablePrefix: arm_
+
+            - task: AzureAppServiceManage@0
+              displayName: 'Start Azure App Service: ${{parameters.environment}}'
+              inputs:
+                azureSubscription: '${{parameters.subscriptionServiceConnection}}'
+                Action: 'Start Azure App Service'
+                WebAppName: $(arm_appServiceName)
+                SpecifySlotOrASE: true
+                resourceGroupName: '${{parameters.resourceGroupName}}'
+                Slot: staging
+
+            - task: AzureAppServiceManage@0
+              displayName: 'Swap Slots: ${{parameters.environment}}'
+              inputs:
+                azureSubscription: '${{parameters.subscriptionServiceConnection}}'
+                WebAppName: $(arm_appServiceName)
+                resourceGroupName: '${{parameters.resourceGroupName}}'
+                SourceSlot: staging
+
+            - task: AzureAppServiceManage@0
+              displayName: 'Stop Azure App Service: ${{parameters.environment}}'
+              inputs:
+                azureSubscription: '${{parameters.subscriptionServiceConnection}}'
+                Action: 'Stop Azure App Service'
+                WebAppName: $(arm_appServiceName)
+                SpecifySlotOrASE: true
+                resourceGroupName: '${{parameters.resourceGroupName}}'
+                Slot: staging

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -185,72 +185,21 @@ stages:
           TargetFolder: '$(build.artifactstagingdirectory)'
           OverWrite: true
 
-      - task: PublishBuildArtifacts@1
+      - task: PublishPipelineArtifact@1
         displayName: 'Publish Artifact'
         inputs:
-          PathtoPublish: '$(build.artifactstagingdirectory)'
+          path: '$(build.artifactstagingdirectory)'
           ArtifactName: 'ARMTemplates'
 
 - stage: Deployment
-  displayName: Deployment
+  displayName: Deployment to QA
+  dependsOn: Build
   condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/master'))
 
   jobs:
-    - job: QA
-      displayName: Deploy to QA
-      pool:
-        vmImage: 'vs2017-win2016'
-
-      variables:
-        - group: 'Release Common'
-
-      steps:
-        - task: AzureResourceGroupDeployment@2
-          displayName: 'Azure Deployment:Create Or Update Resource Group action on $(resourceEnvironmentName)-$(serviceName)'
-          inputs:
-            action: 'Create Or Update Resource Group'
-            location: 'West Europe'
-            azureSubscription: azdo.pipelines.cip.S108T.arm282af598-0480-4a28-ab29-efa10624365a
-            resourceGroupName: s108t01-qa
-            csmFile: './azure/template.json'
-            csmParametersFile: './azure/config/qa.parameters.json'
-            overrideParameters: '-containerImageReference $(IMAGE_NAME):$(Build.BuildNumber) -supportEmailAddresses $(supportEmailAddresses)'
-            deploymentOutputs: DeploymentOutput
-
-        - task: RasmusWatjen.ARMOutputParserExtension.ARMOutputConverter.ARMOutputParserExtension@1
-          displayName: 'Parse ARM Deployment Outputs into variables'
-          inputs:
-            armOutput: $(DeploymentOutput)
-            variablePrefix: arm_
-
-        - script: |
-            env
-          displayName: 'debug'
-
-        - task: AzureAppServiceManage@0
-          displayName: 'Start Azure App Service: QA'
-          inputs:
-            azureSubscription: azdo.pipelines.cip.S108T.arm282af598-0480-4a28-ab29-efa10624365a
-            Action: 'Start Azure App Service'
-            WebAppName: $(arm_appServiceName)
-            SpecifySlotOrASE: true
-            resourceGroupName: s108t01-qa
-            Slot: staging
-
-        - task: AzureAppServiceManage@0
-          displayName: 'Swap Slots: QA'
-          inputs:
-            azureSubscription: azdo.pipelines.cip.S108T.arm282af598-0480-4a28-ab29-efa10624365a
-            WebAppName: $(arm_appServiceName)
-            resourceGroupName: 's108t01-qa'
-            SourceSlot: staging
-
-        - task: AzureAppServiceManage@0
-          displayName: 'Stop Azure App Service: QA'
-          inputs:
-            azureSubscription: azdo.pipelines.cip.S108T.arm282af598-0480-4a28-ab29-efa10624365a
-            Action: 'Stop Azure App Service'
-            WebAppName: $(arm_appServiceName)
-            SpecifySlotOrASE: true
-            resourceGroupName: s108t01-qa
-            Slot: staging
+  - template: azure-pipelines-deploy-template.yml
+    parameters:
+      resourceGroupName: 's108t01-qa'
+      environment: 'qa'
+      containerImageReference: $(IMAGE_NAME):$(Build.BuildNumber)
+      subscriptionServiceConnection: azdo.pipelines.cip.S108T.arm282af598-0480-4a28-ab29-efa10624365a


### PR DESCRIPTION
### Context

Refractor deployment into a template for re-use

### Changes proposed in this pull request

This PR just moves the deployment logic into a template, so that it DRYs the deployment to multiple environments when needed. 

Some code cleaning before adding the test stages. 


### Guidance to review

