### PR TITLE
Add links styling to privacy policy

### DIFF
--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -19,7 +19,7 @@
       <li>remember who you are if you return to your saved results so we can show you your information and information relevant to you</li>
     </ul>
     <p class="govuk-body">‘Get help to retrain’ cookies aren’t used to identify you personally. We record tracking information anonymously, so cookies do not track your personal data, only your activity on the site.</p>
-    <p class="govuk-body">Find out more about cookies on <%= link_to('GOV.UK', 'https://www.gov.uk/help/cookie-details', target: '_blank') %>.</p>
+    <p class="govuk-body">Find out more about cookies on <%= link_to('GOV.UK', 'https://www.gov.uk/help/cookie-details', target: '_blank', class: 'govuk-link') %>.</p>
 
     <h2 class="govuk-heading-m">How we use cookies</h2>
     <p class="govuk-body">We use Google Analytics and Azure Application Insights software as well as service-specific cookies to collect information about how you use ‘Get help to retrain’. We do this to help make sure the service is meeting the needs of its users and to help us make improvements.</p>
@@ -110,7 +110,7 @@
     </table>
 
     <p class="govuk-body">They always need to be on.</p>
-    <p class="govuk-body">You can find more information about <%= link_to('Azure Application Insights', 'https://azure.microsoft.com/en-gb/services/monitor/',  target: '_blank') %>‎.</p>
+    <p class="govuk-body">You can find more information about <%= link_to('Azure Application Insights', 'https://azure.microsoft.com/en-gb/services/monitor/',  target: '_blank', class: 'govuk-link') %>‎.</p>
 
     <h3 class="govuk-heading-s">Measuring website usage using Google Analytics</h3>
     <p class="govuk-body">This software stores information about:</p>
@@ -144,6 +144,6 @@
       </tbody>
     </table>
 
-    <p class="govuk-body">You can opt out of <%= link_to('Google Analytics', 'https://tools.google.com/dlpage/gaoptout', target: '_blank') %>.</p>
+    <p class="govuk-body">You can opt out of <%= link_to('Google Analytics', 'https://tools.google.com/dlpage/gaoptout', target: '_blank', class: 'govuk-link') %>.</p>
   </div>
 </div>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -41,19 +41,19 @@
       <li>to object to direct marketing (including profiling) and processing for the purposes of scientific/historical research and statistics</li>
       <li>not to be subject to decisions based purely on automated processing where it produces a legal or similarly significant effect on you</li>
     </ul>
-    <p class="govuk-body">You can <%= link_to('find out more about your data protection rights', 'https://ico.org.uk/global/privacy-notice/your-data-protection-rights', target: '_blank') %> on the Information Commissioner’s website.</p>
+    <p class="govuk-body">You can <%= link_to('find out more about your data protection rights', 'https://ico.org.uk/global/privacy-notice/your-data-protection-rights', target: '_blank', class: 'govuk-link') %> on the Information Commissioner’s website.</p>
     <h2 class="govuk-heading-m">The right to lodge a complaint</h2>
-    <p class="govuk-body">You have the right to raise any concerns with the Information Commissioner’s Office (ICO) via their website at <%= link_to('https://ico.org.uk/concerns/', 'https://ico.org.uk/concerns/', target: '_blank') %>.<p>
+    <p class="govuk-body">You have the right to raise any concerns with the Information Commissioner’s Office (ICO) via their website at <%= link_to('https://ico.org.uk/concerns/', 'https://ico.org.uk/concerns/', target: '_blank', class: 'govuk-link') %>.<p>
     <h2 class="govuk-heading-m">Last updated</h2>
     <p class="govuk-body">This version was last updated on 04 October 2019.</p>
     <h2 class="govuk-heading-m">Contact us</h2>
     <p class="govuk-body">If you have any questions about how your personal information will be processed, contact the Data Protection Officer (DPO) by:</p>
     <ul>
-      <li>Email at <%= mail_to('advice.dpo@education.gov.uk') %></li>
+      <li>Email at <%= mail_to('advice.dpo@education.gov.uk', 'advice.dpo@education.gov.uk', class: 'govuk-link') %></li>
       <li>Or by post at Emma Wharram, Departmental Data Protection Officer, 2 Rivergate, Bristol, BS1 6EW</li>
     </ul>
     <h2 class="govuk-heading-m govuk-!-margin-top-6">How to find out what personal information we hold about you</h2>
-    <p class="govuk-body">To find out what personal information we hold about you, or to exercise any of your rights you can contact us using the question option on our <%= link_to('Contact Form', 'https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen', target: '_blank') %> and select ‘something else’.</p>
+    <p class="govuk-body">To find out what personal information we hold about you, or to exercise any of your rights you can contact us using the question option on our <%= link_to('Contact Form', 'https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen', target: '_blank', class: 'govuk-link') %> and select ‘something else’.</p>
     <p class="govuk-body">Please be as specific as you can about the personal information that you are asking us about. If possible, state which part of the department is holding the information and why they hold it.</p>
     <p class="govuk-body">If we cannot satisfactorily confirm or establish your identity, we will request for proof of your identity so we can check your right to access the information and to ensure that we only disclose your personal information to the right person(s).</p>
     <p class="govuk-body">We should respond to your request within one month of receiving it. If your request is complex, we may extend the period by a further two months. In those circumstances, we will let you know of the extended time within one month of receiving your request and explain to you why the extension is necessary.</p>


### PR DESCRIPTION
* note: in the `mail_to` helper it needs the content before the class
* *For the future we should look into moving this rule to all links, unless there are any exceptions*