### PR TITLE
Rescue from standard error rather than response errors

### DIFF
--- a/app/services/health_check/find_a_job_check.rb
+++ b/app/services/health_check/find_a_job_check.rb
@@ -6,7 +6,7 @@ module HealthCheck
 
     def value
       @value ||= FindAJobService.new.health_check
-    rescue FindAJobService::ResponseError => e
+    rescue StandardError => e
       @output = "Find A Job API error: #{e.message}"
       ''
     end

--- a/spec/services/health_check/find_a_job_check_spec.rb
+++ b/spec/services/health_check/find_a_job_check_spec.rb
@@ -7,12 +7,24 @@ RSpec.describe HealthCheck::FindAJobCheck do
 
   describe '#status' do
     context 'with failed Find a Job API call' do
-      before do
+      it 'returns warn on api error' do
         stub_request(:get, /ping/)
           .to_return(status: 500)
+
+        expect(check.status).to eq :warn
       end
 
-      it 'returns warn' do
+      it 'returns warn on socket error' do
+        stub_request(:get, /ping/)
+          .to_raise(SocketError)
+
+        expect(check.status).to eq :warn
+      end
+
+      it 'returns warn on read timeout' do
+        stub_request(:get, /ping/)
+          .to_raise(Net::ReadTimeout)
+
         expect(check.status).to eq :warn
       end
     end


### PR DESCRIPTION
In Sentry we are getting different errors from the DWP API like socket errors
and read timeouts. We were initially only rescuing from bad responses from the API
but we should also account for those, so now we rescue from Standard error instead