### PR TITLE
Add support for target job in user session

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,4 +23,8 @@ module ApplicationHelper
   def user_not_authenticated?
     !current_user
   end
+
+  def target_job
+    @target_job ||= JobProfile.find_by(id: user_session.target_job_id)
+  end
 end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -5,6 +5,7 @@ class UserSession
     job_profile_skills
     job_profile_ids
     postcode
+    target_job_id
   ].freeze
 
   def self.merge_sessions(new_session:, previous_session_data:)
@@ -24,6 +25,14 @@ class UserSession
 
   def postcode=(value)
     session[:postcode] = value
+  end
+
+  def target_job_id
+    session[:target_job_id]
+  end
+
+  def target_job_id=(value)
+    session[:target_job_id] = value
   end
 
   def registered?

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -77,4 +77,35 @@ RSpec.describe ApplicationHelper do
       expect(helper).not_to be_user_not_authenticated
     end
   end
+
+  describe '.target_job' do
+    before do
+      helper.singleton_class.class_eval do
+        def user_session
+          UserSession.new(session)
+        end
+      end
+    end
+
+    it 'returns JobProfile instance if target job id is set in session' do
+      job_profile = create(:job_profile)
+      user_session = UserSession.new(session)
+      user_session.target_job_id = job_profile.id
+
+      expect(helper.target_job).to eq(job_profile)
+    end
+
+    it 'returns nil if target job id no longer exists' do
+      job_profile = create(:job_profile)
+      user_session = UserSession.new(session)
+      user_session.target_job_id = job_profile.id
+      job_profile.destroy
+
+      expect(helper.target_job).to be_nil
+    end
+
+    it 'returns nil if target job id not set in session' do
+      expect(helper.target_job).to be_nil
+    end
+  end
 end

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -9,12 +9,13 @@ RSpec.describe UserSession do
     it 'merges old data into new session for selected keys' do
       old_session = {
         'postcode' => 'NW118QE',
+        'target_job_id' => 100,
         'session_id' => 2
       }
       new_session = { 'session_id' => 1 }
       described_class.merge_sessions(new_session: new_session, previous_session_data: old_session)
 
-      expect(new_session).to eq('postcode' => 'NW118QE', 'session_id' => 1)
+      expect(new_session).to eq('postcode' => 'NW118QE', 'target_job_id' => 100, 'session_id' => 1)
     end
 
     it 'overrides set values in current session with old ones' do
@@ -39,6 +40,18 @@ RSpec.describe UserSession do
 
     it 'returns nil if no postcode set' do
       expect(user_session.postcode).to be_nil
+    end
+  end
+
+  describe '#target_job_id' do
+    it 'returns targetted job id if set' do
+      user_session.target_job_id = 100
+
+      expect(user_session.target_job_id).to eq(100)
+    end
+
+    it 'returns nil if no targetted job id set' do
+      expect(user_session.target_job_id).to be_nil
     end
   end
 


### PR DESCRIPTION
### Context
We have a few stories that depend on having a 'target job profile' being selected.

### Changes proposed in this pull request
This PR simply adds a new key for `target_job_id` to the `UserSession` and a helper method that will return either the relevant `JobProfile` instance or nil; this can be used as needed in various controllers.

Also renamed user_sessions_spec to have correct name.

### Guidance to review
