### PR TITLE
Reset UAT environnet customHostname to uat.

### DIFF
--- a/azure/config/uat.parameters.json
+++ b/azure/config/uat.parameters.json
@@ -97,7 +97,7 @@
       }
     },
     "customHostName": {
-      "value": "beta.nrs-ghtr.org.uk"
+      "value": "uat.nrs-ghtr.org.uk"
     },
     "certificateName": {
       "value": "nrs-ghtr-org-uk"


### PR DESCRIPTION
### Context

The UAT environment was being used as the live environment until Phase3 so it was under the beta.nrs-ghtr.org.uk FQDN.

### Changes proposed in this pull request

This PR changes this back to uat.nrs-ghtr.org.uk

### Guidance to review

