### PR TITLE
Simplify breadcrumbs on Your Skills page

### DIFF
--- a/app/views/skills/index.html.erb
+++ b/app/views/skills/index.html.erb
@@ -3,10 +3,7 @@
     generate_breadcrumbs(
       t('breadcrumb.your_skills'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path],
-        [t('breadcrumb.check_your_skills'), check_your_skills_path],
-        [t('breadcrumb.search_results'), results_check_your_skills_path(search: params[:search])],
-        [t('breadcrumb.current_job_skills'), job_profile_skills_path(job_profile_id: params[:job_profile_id] || @job_profiles_with_skills.last[:profile_slug], search: params[:search])]
+        [t('breadcrumb.task_list_home'), task_list_path]
       ]
     )
   end

--- a/spec/features/skills_builder_spec.rb
+++ b/spec/features/skills_builder_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Build your skills', type: :feature do
     expect(page).to have_css('nav.govuk-breadcrumbs a', count: 1)
   end
 
-  scenario 'Breadcrumbs - user can click on \'Home: Get help to retrain\' link' do
+  scenario 'Breadcrumbs - user can click on \'Home: Get help to retrain\' nav item' do
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     click_on('Select these skills')
     click_on('Home: Get help to retrain')
@@ -51,11 +51,11 @@ RSpec.feature 'Build your skills', type: :feature do
     expect(page).to have_current_path(task_list_path)
   end
 
-  scenario 'Breadcrumbs - \'Your skills\' item is present' do
+  scenario 'Breadcrumbs - \'Your skills\' nav item is present' do
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     click_on('Select these skills')
 
-    expect(page).to have_text('Your skills')
+    expect(page).to have_css('nav.govuk-breadcrumbs', text: 'Your skills')
   end
 
   scenario 'User sees a list of skills when checking their Job skills' do

--- a/spec/features/skills_builder_spec.rb
+++ b/spec/features/skills_builder_spec.rb
@@ -36,6 +36,28 @@ RSpec.feature 'Build your skills', type: :feature do
     click_on('Select these skills')
   end
 
+  scenario 'Breadcrumbs: user only sees 1 clickable item in the navigation' do
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    click_on('Select these skills')
+
+    expect(page).to have_css('nav.govuk-breadcrumbs a', count: 1)
+  end
+
+  scenario 'Breadcrumbs - user can click on \'Home: Get help to retrain\' link' do
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    click_on('Select these skills')
+    click_on('Home: Get help to retrain')
+
+    expect(page).to have_current_path(task_list_path)
+  end
+
+  scenario 'Breadcrumbs - \'Your skills\' item is present' do
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    click_on('Select these skills')
+
+    expect(page).to have_text('Your skills')
+  end
+
   scenario 'User sees a list of skills when checking their Job skills' do
     visit(check_your_skills_path)
     fill_in('search', with: 'Hitman')
@@ -212,17 +234,7 @@ RSpec.feature 'Build your skills', type: :feature do
   scenario 'User can not search for job profiles anymore when one has 5 profiles persisted on the session' do
     build_max_job_profiles
 
-    click_on('Check your existing skills')
-
-    expect(page).to have_current_path(skills_path)
-  end
-
-  scenario 'Breadcrumbs: Search results redirects to Your Skills when one has 5 profiles persisted on the session' do
-    build_max_job_profiles
-
-    visit(skills_path)
-
-    click_on('Search results')
+    visit(check_your_skills_path)
 
     expect(page).to have_current_path(skills_path)
   end
@@ -256,30 +268,6 @@ RSpec.feature 'Build your skills', type: :feature do
     expect(page).to have_selector('input[checked="checked"]', count: 1)
   end
 
-  scenario 'User selects skills but goes back to different job profile sees all skills selected' do
-    create(
-      :job_profile,
-      name: 'Assassin',
-      skills: [
-        create(:skill, name: 'Chameleon-like blend in tactics'),
-        create(:skill, name: 'Mastery of unarmed combat skill'),
-        create(:skill, name: 'License to kill')
-      ]
-    )
-
-    visit(check_your_skills_path)
-    fill_in('search', with: 'Hitman assassin')
-    find('.search-button').click
-    click_on('Hitman')
-    uncheck('Baldness', allow_label_click: true)
-    uncheck('License to kill', allow_label_click: true)
-    click_on('Select these skills')
-    click_on('Search results')
-    click_on('Assassin')
-
-    expect(page).to have_selector('input[checked="checked"]', count: 3)
-  end
-
   scenario 'skill builder requires at least one skill selected' do
     unselect_all_skills_for(job_profile)
 
@@ -291,16 +279,6 @@ RSpec.feature 'Build your skills', type: :feature do
     visit(skills_path)
 
     expect(page).to have_current_path(task_list_path)
-  end
-
-  scenario 'User navigates to the last added job profile skills page from breadcrumbs' do
-    build_max_job_profiles
-
-    visit(skills_path)
-
-    click_on('Job skills')
-
-    expect(page).to have_text('Hitman4')
   end
 
   scenario 'redirected to task list path if no job profile selected' do
@@ -414,49 +392,6 @@ RSpec.feature 'Build your skills', type: :feature do
     click_on('Check my skills')
     fill_in('search', with: job_profile.name)
     find('.search-button').click
-
-    expect(page).to have_text(job_profile.name)
-  end
-
-  scenario 'user can navigate back to search if they removed their last job' do
-    visit(check_your_skills_path)
-    fill_in('search', with: job_profile.name)
-    find('.search-button').click
-    click_on(job_profile.name)
-    click_on('Select these skills')
-
-    click_on('remove this role')
-    click_on('Search results')
-
-    expect(page).to have_text(job_profile.name)
-  end
-
-  scenario 'user can navigate back to their last job if they removed their last job' do
-    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
-    click_on('Select these skills')
-
-    click_on('remove this role')
-    click_on('Job skills')
-
-    expect(page).to have_text(job_profile.name)
-  end
-
-  scenario 'user can navigate back to their last job if they removed another job' do
-    assassin = create(
-      :job_profile,
-      :with_html_content,
-      name: 'Assasin',
-      skills: [
-        create(:skill, name: 'Classic')
-      ]
-    )
-    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
-    click_on('Select these skills')
-    visit(job_profile_skills_path(job_profile_id: assassin.slug))
-    click_on('Select these skills')
-
-    all('a', text: 'remove this role')[1].click
-    click_on('Job skills')
 
     expect(page).to have_text(job_profile.name)
   end


### PR DESCRIPTION
User can only see the following breadcrumbs items:

Home: Get help to retrain
Your skills

![Screen Shot 2019-10-18 at 13 24 41](https://user-images.githubusercontent.com/1955084/67093978-b1216180-f1aa-11e9-831d-771e043418a3.png)

https://dfedigital.atlassian.net/browse/GET-531