### PR TITLE
Amend breadcrumb and sidebar content for courses page

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,13 +1,23 @@
 <% page_title :courses_index %>
 
 <% content_for :breadcrumb do
-    generate_breadcrumbs(
-      t('breadcrumb.training_courses_near_you'),
-      [
-        [t('breadcrumb.task_list_home'), task_list_path],
-        [t('breadcrumb.training_hub'), training_hub_path]
-      ]
-    )
+    if Flipflop.action_plan?
+      generate_breadcrumbs(
+        t('breadcrumb.training_courses_near_you'),
+        [
+          [t('breadcrumb.task_list_home'), task_list_path],
+          [t('breadcrumb.action_plan'), action_plan_path]
+        ]
+      )
+    else
+      generate_breadcrumbs(
+        t('breadcrumb.training_courses_near_you'),
+        [
+          [t('breadcrumb.task_list_home'), task_list_path],
+          [t('breadcrumb.training_hub'), training_hub_path]
+        ]
+      )
+    end
   end
 %>
 
@@ -52,7 +62,7 @@
   <div class="govuk-grid-column-one-third">
     <%= render 'shared/contact_us' %>
     <%= render 'shared/save_or_return_to_your_results' %>
-    <%= render 'shared/what_you_can_do_next' %>
+    <%= render 'shared/what_you_can_do_next' unless Flipflop.action_plan? %>
     <%= render 'shared/help_improve_this_service' %>
   </div>
 </div>

--- a/spec/features/find_training_courses_spec.rb
+++ b/spec/features/find_training_courses_spec.rb
@@ -141,6 +141,44 @@ RSpec.feature 'Find training courses', type: :feature do
     expect(TrackingService).to have_received(:track_event).with('Courses near me - Postcode search', search: 'NW6 8ET')
   end
 
+  context 'with action plan feature enabled' do
+    background do
+      enable_feature! :action_plan
+    end
+
+    scenario 'Breadcrumb links back to action plan' do
+      visit(courses_path(topic_id: 'maths'))
+
+      expect(page).to have_css('nav.govuk-breadcrumbs', text: 'Action plan')
+    end
+
+    scenario 'Further help to find work section is hidden' do
+      visit(courses_path(topic_id: 'maths'))
+
+      expect(page).not_to have_link('Get help changing jobs')
+    end
+  end
+
+  context 'with action plan feature disabled' do
+    background do
+      disable_feature! :action_plan
+    end
+
+    scenario 'Breadcrumb links back to training hub' do
+      visit(courses_path(topic_id: 'maths'))
+
+      expect(page).to have_css('nav.govuk-breadcrumbs', text: 'Find training')
+    end
+
+    scenario 'Further help to find work section is shown' do
+      visit(courses_path(topic_id: 'maths'))
+
+      expect(page).to have_link('Get help changing jobs', href: next_steps_path)
+    end
+  end
+
+  private
+
   def capture_user_location(postcode)
     visit(your_information_path)
     fill_in('user_personal_data[first_name]', with: 'John')


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-618

### Changes proposed in this pull request
This only applies when the action plan feature is enabled - the breadcrumb trail links back to the action plan rather than the training hub. Also the sidebar partial for next steps is hidden as the next steps page will ultimately be completely replaced by the action plan.

### Guidance to review
The updated breadcrumbs are slightly repetitive but this approach makes it simpler to remove the legacy behaviour once the feature is promoted, so I didn't attempt to DRY things up at this stage. Added some basic feature level coverage to accompany change.

Only affects courses page - see `/courses/maths` and `/courses/english` - needs to be tested both with and without `action_plan` feature enabled.



