### PR TITLE
GET-490 Avoid session creation on homepage

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,15 @@
 class HomeController < ApplicationController
   def index
-    @pid_or_task_list_path = user_session.postcode.present? ? task_list_path : your_information_path
+    @pid_or_task_list_path = pid_or_task_list_path
+  end
+
+  private
+
+  def pid_or_task_list_path
+    if cookies['_get_help_to_retrain_session'].blank? || user_session.postcode.blank?
+      your_information_path
+    else
+      task_list_path
+    end
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -21,6 +21,10 @@
     <p class="govuk-body-s muted-text"><%= t('contact_us.telephone_times') %></p>
   </div>
   <div class="govuk-grid-column-one-third">
-    <%= render 'shared/save_or_return_to_your_results' %>
+    <% if cookies['_get_help_to_retrain_session'].blank? %>
+      <%= render 'shared/return_to_saved_results' %>
+    <% else %>
+      <%= render 'shared/save_or_return_to_your_results' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template ">
   <head>
     <title><%= content_for?(:page_title) ? yield(:page_title) : t('page_titles.default') %></title>
-    <%= csrf_meta_tags %>
+    <%= csrf_meta_tags unless current_page?(root_path) %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
@@ -61,7 +61,7 @@
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 class="govuk-visually-hidden">Support links</h2>
-          
+
             <ul class="govuk-footer__inline-list">
                 <li class="govuk-footer__inline-list-item">
                   <%= link_to 'Cookies', cookies_policy_path, class: 'govuk-footer__link' %>

--- a/app/views/shared/_return_to_saved_results.html.erb
+++ b/app/views/shared/_return_to_saved_results.html.erb
@@ -1,4 +1,3 @@
-<% return unless user_not_authenticated? %>
 <div class="govuk-related-items govuk-!-padding-bottom-4 top-border__container" id="sign-in">
   <h2 class="govuk-heading-m"><%= t('return_to_saved_results.title') %></h2>
   <p class="govuk-body"><%= t('return_to_saved_results.sub_title') %></p>

--- a/app/views/shared/_save_or_return_to_your_results.html.erb
+++ b/app/views/shared/_save_or_return_to_your_results.html.erb
@@ -1,5 +1,6 @@
 <% if user_session.job_profile_skills? %>
   <%= render 'shared/save_your_results'  %>
 <% else %>
+  <% return unless user_not_authenticated? %>
   <%= render 'shared/return_to_saved_results' %>
 <% end %>

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -58,4 +58,10 @@ RSpec.feature 'Navigation from home page' do
 
     expect(page).to have_text('Privacy policy')
   end
+
+  scenario 'Sessions not created when user has no previous session' do
+    visit(root_path)
+
+    expect(Session.count).to be_zero
+  end
 end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-490

Sessions are lazy loaded. If we don't touch teh session on
the homepage we can avoid creating it unnecessarily.
The three places the session is created and avoided are:
1) csrf token: skip this tag if its the homepage
2) start link: render the information page if the cookie
  is missing. The cookie is created when we have a session.
  Default to normal behaviour if the cookie exists
3) authentication partial: default to return to saved results
  unless there is a cookie, where then we default to previous
  behaviour