### PR TITLE
Get 650 fieldset legend dob gender

### DIFF
--- a/app/views/user_personal_data/_form.html.erb
+++ b/app/views/user_personal_data/_form.html.erb
@@ -16,53 +16,63 @@
   <% end %>
   <div class="govuk-form-group">
     <%= form_group_tag @user_personal_data, :dob do %>
-      <h3 class="govuk-heading-m govuk-!-margin-bottom-0">
-        Date of birth
-      </h3>
-      <span id="passport-issued-hint" class="govuk-hint">
-        For example, 12 11 1980
-      </span>
-      <%= errors_tag @user_personal_data, :dob %>
-      <div class="govuk-date-input">
-        <div class="govuk-date-input__item">
-          <div class="govuk-form-group">
-            <%= f.label :birth_day, 'Day', class: 'govuk-label' %>
-            <%= f.number_field :birth_day, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-2'), data: { cy: 'pid-dob-day-field' } %>
+      <%= field_set_tag nil, class: 'govuk-fieldset', role: 'group', aria: { describedby: 'date-of-birth-hint' } do %>
+        <legend class='govuk-fieldset__legend govuk-fieldset__legend--xl'>
+          <h3 class="govuk-heading-m govuk-!-margin-bottom-0">
+            Date of birth
+          </h3>
+        </legend>
+        <span id="date-of-birth-hint" class="govuk-hint">
+          For example, 12 11 1980
+        </span>
+        <%= errors_tag @user_personal_data, :dob %>
+        <div class="govuk-date-input">
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <%= f.label :birth_day, 'Day', class: 'govuk-label' %>
+              <%= f.number_field :birth_day, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-2'), data: { cy: 'pid-dob-day-field' } %>
+            </div>
+          </div>
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <%= f.label :birth_month, 'Month', class: 'govuk-label' %>
+              <%= f.number_field :birth_month, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-2'), data: { cy: 'pid-dob-month-field' } %>
+            </div>
+          </div>
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <%= f.label :birth_year, 'Year', class: 'govuk-label' %>
+              <%= f.number_field :birth_year, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-4'), data: { cy: 'pid-dob-year-field' } %>
+            </div>
           </div>
         </div>
-        <div class="govuk-date-input__item">
-          <div class="govuk-form-group">
-            <%= f.label :birth_month, 'Month', class: 'govuk-label' %>
-            <%= f.number_field :birth_month, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-2'), data: { cy: 'pid-dob-month-field' } %>
-          </div>
-        </div>
-        <div class="govuk-date-input__item">
-          <div class="govuk-form-group">
-            <%= f.label :birth_year, 'Year', class: 'govuk-label' %>
-            <%= f.number_field :birth_year, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-4'), data: { cy: 'pid-dob-year-field' } %>
-          </div>
-        </div>
-      </div>
+      <% end %>
     <% end %>
   </div>
   <div class="govuk-radios">
     <%= form_group_tag @user_personal_data, :gender do %>
-      <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
-        Gender
-      </h3>
-      <%= errors_tag @user_personal_data, :gender %>
-      <div class="govuk-radios__item">
-        <%= f.radio_button :gender, :female, class: 'govuk-radios__input', data: { cy: 'pid-gender-female-radio-btn' } %>
-        <%= f.label :gender_female, 'Female', class: 'govuk-label govuk-radios__label' %>
-      </div>
-      <div class="govuk-radios__item">
-        <%= f.radio_button :gender, :male, class: 'govuk-radios__input', data: { cy: 'pid-gender-male-radio-btn' } %>
-        <%= f.label :gender_male, 'Male', class: 'govuk-label govuk-radios__label' %>
-      </div>
-      <div class="govuk-radios__item">
-        <%= f.radio_button :gender, :not_mentioned, class: 'govuk-radios__input', data: { cy: 'pid-gender-refuse-radio-btn' } %>
-        <%= f.label :gender_not_mentioned, 'Prefer not to say', class: 'govuk-label govuk-radios__label' %>
-      </div>
+      <%= field_set_tag nil, class: 'govuk-fieldset', role: 'group' do %>
+        <legend class='govuk-fieldset__legend govuk-fieldset__legend--xl'>
+          <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
+            Gender
+          </h3>
+        </legend>
+        <div class="govuk-radios">
+          <%= errors_tag @user_personal_data, :gender %>
+          <div class="govuk-radios__item">
+            <%= f.radio_button :gender, :female, class: 'govuk-radios__input', data: { cy: 'pid-gender-female-radio-btn' } %>
+            <%= f.label :gender_female, 'Female', class: 'govuk-label govuk-radios__label' %>
+          </div>
+          <div class="govuk-radios__item">
+            <%= f.radio_button :gender, :male, class: 'govuk-radios__input', data: { cy: 'pid-gender-male-radio-btn' } %>
+            <%= f.label :gender_male, 'Male', class: 'govuk-label govuk-radios__label' %>
+          </div>
+          <div class="govuk-radios__item">
+            <%= f.radio_button :gender, :not_mentioned, class: 'govuk-radios__input', data: { cy: 'pid-gender-refuse-radio-btn' } %>
+            <%= f.label :gender_not_mentioned, 'Prefer not to say', class: 'govuk-label govuk-radios__label' %>
+          </div>
+        </div>
+      <% end %>
     <% end %>
   </div>
   <p class="govuk-body govuk-!-margin-top-8">By continuing you agree to allow us to use your information as explained in our <%= link_to 'privacy policy', privacy_policy_path, class: 'govuk-link'  %>.</p>

--- a/app/views/user_personal_data/_form.html.erb
+++ b/app/views/user_personal_data/_form.html.erb
@@ -53,7 +53,7 @@
     <%= form_group_tag @user_personal_data, :gender do %>
       <%= field_set_tag nil, class: 'govuk-fieldset', role: 'group' do %>
         <legend class='govuk-fieldset__legend govuk-fieldset__legend--xl'>
-          <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
+          <h3 class="govuk-heading-m govuk-!-margin-bottom-0">
             Gender
           </h3>
         </legend>


### PR DESCRIPTION
## Context
DAC suggested the following fixes:

1. Add a fieldset/legend for date of birth
2. Add a fieldset/legend for gender

Resources
https://design-system.service.gov.uk/components/date-input/

## Notes

`field_set_tag :name` will create a markup like this:

```ruby
<%= field_set_tag do %>
  <p><%= text_field_tag 'name' %></p>
<% end %>
# => <fieldset><p><input id="name" name="name" type="text" /></p></fieldset>

<%= field_set_tag 'Your details' do %>
  <p><%= text_field_tag 'name' %></p>
<% end %>
# => <fieldset><legend>Your details</legend><p><input id="name" name="name" type="text" /></p></fieldset>
```

However, we want a different nesting as per GDS design system e.g:

```ruby
<div class="govuk-form-group">
  <fieldset class="govuk-fieldset" role="group" aria-describedby="passport-issued-hint">
    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
      <h1 class="govuk-fieldset__heading">
        When was your passport issued?
      </h1>
    </legend>
    <span id="passport-issued-hint" class="govuk-hint">
      For example, 12 11 2007
    </span>
```

The legend tag needs to wrap around as follows:

```ruby
<legend class='govuk-fieldset__legend govuk-fieldset__legend--xl'>
   <h3 class="govuk-heading-m govuk-!-margin-bottom-0">
       Date of birth
    </h3>
</legend>
```

Hence, why we pass `nil` to the `<%= field_set_tag nil, ...`

## Ticket
https://dfedigital.atlassian.net/browse/GET-650