### PR TITLE
GET-654 Add aria label to courses visit page button

### DIFF
--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -4,6 +4,6 @@
   <p class="govuk-body govuk-!-margin-bottom-0">Distance: <b><%= course.distance.round(1) %> miles</b></p>
   <p class="govuk-body-s"><%= course.full_address %></p>
   <p class="govuk-body-s">Tel:<%= link_to(course.phone_number, "tel:#{course.phone_number}", class: 'govuk-!-padding-left-1 govuk-link' ) %></p>
-  <%= link_to 'Visit website', course.url, class: 'govuk-!-margin-bottom-6 govuk-button', target: '_blank', data: { module: 'govuk-button', tracked_event: 'Courses - Clicked course link', tracked_event_props: { url: course.url } } %>
+  <%= link_to 'Visit website', course.url, class: 'govuk-!-margin-bottom-6 govuk-button', target: '_blank', aria: { label: "Visit website of #{course.provider}" }, data: { module: 'govuk-button', tracked_event: 'Courses - Clicked course link', tracked_event_props: { url: course.url } } %>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-top-0">
 </li>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,76 +1,15 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "0d65275a6b9e56ab756db50e4ad75a7394a308992823937c716d8807ee4c8848",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/controllers/pages_controller.rb",
-      "line": 3,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(template => \"pages/#{params[:page]}\", {})",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "PagesController",
-        "method": "show"
-      },
-      "user_input": "params[:page]",
-      "confidence": "Medium",
-      "note": "This is not a real security threat as rails escapes params"
-    },
-    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
-      "fingerprint": "365fd9ea8cee0c69534a037daf9ffb9a53443fce909bcbf94046dc52347fc842",
+      "fingerprint": "c7d3557a0330aa983694942103ea896d4f99430adb262089403d57987432d856",
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/courses/_course.html.erb",
       "line": 7,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"Visit website\", Course.new.url, :class => \"govuk-!-margin-bottom-6 govuk-button\", :target => \"_blank\", :data => ({ :tracked_event => (\"Courses - Clicked course link: #{Course.new.url}\") }))",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "CoursesController",
-          "method": "index",
-          "line": 6,
-          "file": "app/controllers/courses_controller.rb",
-          "rendered": {
-            "name": "courses/index",
-            "file": "app/views/courses/index.html.erb"
-          }
-        },
-        {
-          "type": "template",
-          "name": "courses/index",
-          "line": 40,
-          "file": "app/views/courses/index.html.erb",
-          "rendered": {
-            "name": "courses/_course",
-            "file": "app/views/courses/_course.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "courses/_course"
-      },
-      "user_input": "Course.new.url",
-      "confidence": "Weak",
-      "note": "This is a known false positive from brakeman. We trust our data."
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "5d9238626ad413e9e81f43dce95601e74ecfe447d59c68120edf86a867c20d1b",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/courses/_course.html.erb",
-      "line": 7,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"Visit website\", (Unresolved Model).new.url, :class => \"govuk-!-margin-bottom-6 govuk-button\", :target => \"_blank\", :data => ({ :module => \"govuk-button\", :tracked_event => \"Courses - Clicked course link\", :tracked_event_props => ({ :url => (Unresolved Model).new.url }) }))",
+      "code": "link_to(\"Visit website\", (Unresolved Model).new.url, :class => \"govuk-!-margin-bottom-6 govuk-button\", :target => \"_blank\", :aria => ({ :label => (\"Visit website of #{(Unresolved Model).new.provider}\") }), :data => ({ :module => \"govuk-button\", :tracked_event => \"Courses - Clicked course link\", :tracked_event_props => ({ :url => (Unresolved Model).new.url }) }))",
       "render_path": [
         {
           "type": "template",
@@ -90,66 +29,6 @@
       "user_input": "(Unresolved Model).new.url",
       "confidence": "Weak",
       "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "b8e15875bbcc098cff1cf2ff4198ff34b18219248b801328a6fea8d054106e0e",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/courses/_course.html.erb",
-      "line": 7,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"Visit website\", (Unresolved Model).new.url, :class => \"govuk-!-margin-bottom-6 govuk-button\", :target => \"_blank\", :data => ({ :tracked_event => \"Courses - Clicked course link\", :tracked_event_props => ({ :url => (Unresolved Model).new.url }) }))",
-      "render_path": [
-        {
-          "type": "template",
-          "name": "courses/index",
-          "line": 43,
-          "file": "app/views/courses/index.html.erb",
-          "rendered": {
-            "name": "courses/_course",
-            "file": "app/views/courses/_course.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "courses/_course"
-      },
-      "user_input": "(Unresolved Model).new.url",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "ebb71a6ea809f271551663c77d050194229ee6d7f84e683cb7c36550890d2393",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/courses/_course.html.erb",
-      "line": 7,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"Visit website\", (Unresolved Model).new.url, :class => \"govuk-!-margin-bottom-6 govuk-button\", :target => \"_blank\", :data => ({ :tracked_event => (\"Courses - Clicked course link: #{(Unresolved Model).new.url}\") }))",
-      "render_path": [
-        {
-          "type": "template",
-          "name": "courses/index",
-          "line": 40,
-          "file": "app/views/courses/index.html.erb",
-          "rendered": {
-            "name": "courses/_course",
-            "file": "app/views/courses/_course.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "courses/_course"
-      },
-      "user_input": "(Unresolved Model).new.url",
-      "confidence": "Weak",
-      "note": "This is a known false positive from brakeman. We trust our data."
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -182,6 +61,6 @@
       "note": ""
     }
   ],
-  "updated": "2019-10-29 20:59:51 +0000",
+  "updated": "2019-10-31 10:08:44 +0000",
   "brakeman_version": "4.5.1"
 }


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-654

The link on the courses search page has many visit page buttons,
add aria label to describe where the link is going to be DAC
compliant

