### PR TITLE
Add context for Send Link button

### DIFF
--- a/app/views/users/return_to_saved_results.html.erb
+++ b/app/views/users/return_to_saved_results.html.erb
@@ -20,7 +20,7 @@
         <%= errors_tag @user, :email %>
         <%= text_field_tag(:email, params.fetch(:email, nil), class: css_classes_for_input(@user, :email, "govuk-input govuk-!-width-two-thirds")) %>
       <% end %>
-      <%= button_tag('Send link', class: 'govuk-button', data: { module: 'govuk-button' }) %>
+      <%= button_tag('Send link', class: 'govuk-button', data: { module: 'govuk-button' }, aria: { label: 'Send a link to my Email address to access my saved results' }) %>
     <% end %>
   </div>
   <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
Return to saved results page should have more
context around Send Link button and what it does.

https://dfedigital.atlassian.net/browse/GET-657

