### PR TITLE
GET-656 Add autocomplete to all forms across app

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -32,7 +32,7 @@
             Postcode
           </label>
           <%= errors_tag @search, :postcode %>
-          <%= text_field_tag(:postcode, @postcode, class: css_classes_for_input(@search, :postcode, "course-search-input govuk-input govuk-!-width-one-half")) %>
+          <%= text_field_tag(:postcode, @postcode, class: css_classes_for_input(@search, :postcode, "course-search-input govuk-input govuk-!-width-one-half"), autocomplete: 'postal-code') %>
           <%= button_tag('', class: 'search-button-results', name: nil, aria: { label: 'Search button' }, data: { module: 'govuk-button' }) %>
         <% end %>
       <% end %>

--- a/app/views/job_vacancies/index.html.erb
+++ b/app/views/job_vacancies/index.html.erb
@@ -21,7 +21,7 @@
         <%= form_group_tag @job_vacancy_search, :postcode do %>
           <%= form.label :postcode, class: 'govuk-label' %>
           <%= errors_tag @job_vacancy_search, :postcode %>
-          <%= text_field_tag(:postcode, @postcode, class: css_classes_for_input(@job_vacancy_search, :postcode, "course-search-input govuk-input govuk-!-width-one-half")) %>
+          <%= text_field_tag(:postcode, @postcode, class: css_classes_for_input(@job_vacancy_search, :postcode, "course-search-input govuk-input govuk-!-width-one-half"), autocomplete: 'postal-code') %>
           <%= button_tag('', class: 'search-button-results', name: nil, aria: { label: 'Search button' }, data: { module: 'govuk-button' }) %>
         <% end %>
       <% end %>

--- a/app/views/user_personal_data/_form.html.erb
+++ b/app/views/user_personal_data/_form.html.erb
@@ -2,17 +2,17 @@
   <%= form_group_tag @user_personal_data, :first_name do %>
     <%= f.label :first_name, class: 'govuk-label' %>
     <%= errors_tag @user_personal_data, :first_name %>
-    <%= f.text_field :first_name, maxlength: 250, class: css_classes_for_input(@user_personal_data, :first_name, 'govuk-input govuk-!-width-two-thirds'), data: { cy: 'pid-first-name-field' } %>
+    <%= f.text_field :first_name, maxlength: 250, class: css_classes_for_input(@user_personal_data, :first_name, 'govuk-input govuk-!-width-two-thirds'), autocomplete: 'given-name', data: { cy: 'pid-first-name-field' } %>
   <% end %>
   <%= form_group_tag @user_personal_data, :last_name do %>
     <%= f.label :last_name, class: 'govuk-label' %>
     <%= errors_tag @user_personal_data, :last_name %>
-    <%= f.text_field :last_name, maxlength: 250, class: css_classes_for_input(@user_personal_data, :last_name, 'govuk-input govuk-!-width-two-thirds'), data: { cy: 'pid-surname-field' } %>
+    <%= f.text_field :last_name, maxlength: 250, class: css_classes_for_input(@user_personal_data, :last_name, 'govuk-input govuk-!-width-two-thirds'), autocomplete: 'family-name', data: { cy: 'pid-surname-field' } %>
   <% end %>
   <%= form_group_tag @user_personal_data, :postcode do %>
     <%= f.label :postcode, class: 'govuk-label' %>
     <%= errors_tag @user_personal_data, :postcode %>
-    <%= f.text_field :postcode, class: css_classes_for_input(@user_personal_data, :postcode, 'govuk-input govuk-input--width-10'), data: { cy: 'pid-postcode-field' } %>
+    <%= f.text_field :postcode, class: css_classes_for_input(@user_personal_data, :postcode, 'govuk-input govuk-input--width-10'), autocomplete: 'postal-code', data: { cy: 'pid-postcode-field' } %>
   <% end %>
   <div class="govuk-form-group">
     <%= form_group_tag @user_personal_data, :dob do %>
@@ -30,19 +30,19 @@
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= f.label :birth_day, 'Day', class: 'govuk-label' %>
-              <%= f.number_field :birth_day, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-2'), data: { cy: 'pid-dob-day-field' } %>
+              <%= f.number_field :birth_day, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-2'), autocomplete: 'bday-day', data: { cy: 'pid-dob-day-field' } %>
             </div>
           </div>
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= f.label :birth_month, 'Month', class: 'govuk-label' %>
-              <%= f.number_field :birth_month, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-2'), data: { cy: 'pid-dob-month-field' } %>
+              <%= f.number_field :birth_month, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-2'), autocomplete: 'bday-month', data: { cy: 'pid-dob-month-field' } %>
             </div>
           </div>
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= f.label :birth_year, 'Year', class: 'govuk-label' %>
-              <%= f.number_field :birth_year, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-4'), data: { cy: 'pid-dob-year-field' } %>
+              <%= f.number_field :birth_year, class: css_classes_for_input(@user_personal_data, :dob, 'govuk-input--width-4'), autocomplete: 'bday-year', data: { cy: 'pid-dob-year-field' } %>
             </div>
           </div>
         </div>
@@ -60,15 +60,15 @@
         <div class="govuk-radios">
           <%= errors_tag @user_personal_data, :gender %>
           <div class="govuk-radios__item">
-            <%= f.radio_button :gender, :female, class: 'govuk-radios__input', data: { cy: 'pid-gender-female-radio-btn' } %>
+            <%= f.radio_button :gender, :female, class: 'govuk-radios__input', autocomplete: 'sex', data: { cy: 'pid-gender-female-radio-btn' } %>
             <%= f.label :gender_female, 'Female', class: 'govuk-label govuk-radios__label' %>
           </div>
           <div class="govuk-radios__item">
-            <%= f.radio_button :gender, :male, class: 'govuk-radios__input', data: { cy: 'pid-gender-male-radio-btn' } %>
+            <%= f.radio_button :gender, :male, class: 'govuk-radios__input', autocomplete: 'sex', data: { cy: 'pid-gender-male-radio-btn' } %>
             <%= f.label :gender_male, 'Male', class: 'govuk-label govuk-radios__label' %>
           </div>
           <div class="govuk-radios__item">
-            <%= f.radio_button :gender, :not_mentioned, class: 'govuk-radios__input', data: { cy: 'pid-gender-refuse-radio-btn' } %>
+            <%= f.radio_button :gender, :not_mentioned, class: 'govuk-radios__input', autocomplete: 'sex', data: { cy: 'pid-gender-refuse-radio-btn' } %>
             <%= f.label :gender_not_mentioned, 'Prefer not to say', class: 'govuk-label govuk-radios__label' %>
           </div>
         </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -17,7 +17,7 @@
       <%= form_group_tag @user, :email do %>
         <%= form.label :email, class: 'govuk-label' %>
         <%= errors_tag @user, :email %>
-        <%= text_field_tag(:email, params.fetch(:email, nil), class: css_classes_for_input(@user, :email, "govuk-input govuk-!-width-two-thirds")) %>
+        <%= text_field_tag(:email, params.fetch(:email, nil), class: css_classes_for_input(@user, :email, "govuk-input govuk-!-width-two-thirds"), autocomplete: 'email') %>
       <% end %>
       <p class="govuk-body">We'll send you a confirmation email to this email address.</p>
       <%= button_tag('Save your results', class: 'govuk-button', data: { module: 'govuk-button' }) %>

--- a/app/views/users/return_to_saved_results.html.erb
+++ b/app/views/users/return_to_saved_results.html.erb
@@ -18,7 +18,7 @@
       <%= form_group_tag @user, :email do %>
         <%= form.label :email, class: 'govuk-label' %>
         <%= errors_tag @user, :email %>
-        <%= text_field_tag(:email, params.fetch(:email, nil), class: css_classes_for_input(@user, :email, "govuk-input govuk-!-width-two-thirds")) %>
+        <%= text_field_tag(:email, params.fetch(:email, nil), class: css_classes_for_input(@user, :email, "govuk-input govuk-!-width-two-thirds"), autocomplete: 'email') %>
       <% end %>
       <%= button_tag('Send link', class: 'govuk-button', data: { module: 'govuk-button' }, aria: { label: 'Send a link to my Email address to access my saved results' }) %>
     <% end %>


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-656

To coform to WCAG guidelines add autcomplete attribute to all inputs
in forms.

The value of attributes has been taken from:
https://www.w3.org/TR/html52/sec-forms.html#sec-autofill
with a table explaining the what the expected values map to
Other good links include:
https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html
and the gov uk example:
https://design-system.service.gov.uk/components/text-input/

