### PR TITLE
Content updates to jobs matches page

### DIFF
--- a/app/views/skills_matcher/_job_matches.html.erb
+++ b/app/views/skills_matcher/_job_matches.html.erb
@@ -9,17 +9,14 @@
         <p class="govuk-body-s govuk-!-margin-bottom-2 muted-text"><%= job_profile.alternative_titles %></p>
       <% end %>
       <p class="govuk-!-margin-0 govuk-!-margin-bottom-3"><%= job_profile.description %></p>
-      <p class="govuk-body-s govuk-!-margin-bottom-1">Salary: <span class="strong"><%= job_profile.salary_range %></span></p>
-      <p class="govuk-body-s govuk-!-margin-bottom-1">Skills match: <span class="strong"><%= job_profile.skills_match(@scores[job_profile.id]) %></span></p>
+      <p class="govuk-body govuk-!-margin-bottom-1">Skills match: <span class="strong"><%= job_profile.skills_match(@scores[job_profile.id]) %></span></p>
       <% if job_profile.growth.present? %>
-        <p class="govuk-body-s govuk-!-margin-bottom-1">Recent job growth: <span class="strong"><%= job_profile.growth_type %></span></p>
-        <details class="govuk-details govuk-details-custom" data-module="govuk-details">
-          <summary class="govuk-details__summary govuk-details__summary-custom">
-            <span class="underlined-text">
-              What does this mean?
-            </span>
+        <p class="govuk-body govuk-!-margin-bottom-1">Recent job growth: <span class="strong"><%= job_profile.growth_type %></span></p>
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary" aria-controls="recent-growth-details" aria-expanded="true" role="button">
+            <span class="govuk-details__summary-text">What does <%= job_profile.growth_type.downcase %> mean?</span>
           </summary>
-          <div class="govuk-details__text govuk-body-m">
+          <div class="govuk-details__text govuk-body-m" aria-hidden="false" id="recent-growth-details">
             <%= job_profile.growth_explanation %>
           </div>
         </details>

--- a/app/views/skills_matcher/index.html.erb
+++ b/app/views/skills_matcher/index.html.erb
@@ -13,8 +13,8 @@
   <div class="govuk-grid-column-two-thirds">
     <% if @results.present? %>
       <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
-      <p class="govuk-body-l">You may already have many of the skills to do these types of job. Click into each job title to understand what additional training you might need.</p>
-      <p class="govuk-body">You’ll see information about whether job numbers have been growing or falling in recent years. If job numbers are growing it may mean you’re more likely to find work doing this job and it’s more likely to be secure.</p>
+      <p class="govuk-body-l">You may already have many of the skills for these types of work. Select a job title to find out if you need to do more training.</p>
+      <p class="govuk-body">You'll see information on whether job numbers for this type of work have grown or fallen in recent years. If job numbers have grown it may mean you're more likely to find jobs in this type of work and it's more likely to be secure.</p>
       <%= render "job_matches", job_profiles: @job_profiles %>
       <div class="govuk-grid-column-full govuk-!-padding-top-6 govuk-!-margin-bottom-4 govuk-!-margin-top-6 pagination__section">
         <%= paginate @results %>

--- a/app/webpacker/styles/_job-profile.scss
+++ b/app/webpacker/styles/_job-profile.scss
@@ -197,27 +197,3 @@
     margin-bottom: 62px;
   }
 }
-
-.govuk-details__summary-custom {
-  color: $govuk-link-colour;
-  padding-left: 0;
-  font-size: 1rem;
-  line-height: 1.2;
-  margin-bottom: 25px;
-}
-
-.govuk-details-custom {
-  margin-bottom: 0;
-}
-
-.govuk-details__summary-custom:before {
-  display: none;
-}
-
-.govuk-details[open] > .govuk-details__summary-custom:before {
-  display: none;
-}
-
-.underlined-text {
-  text-decoration: underline;
-}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,10 +165,10 @@ en-GB:
       disabled: 'off'
 
   job_growth_explanation:
-    falling: In the last few years, there hasn't been as much work available for people doing this job. You might find it hard to get work.
-    stable: In the last few years, employers haven't really changed how many people they hire to do jobs like this. This could mean you’ve got an average chance of finding work.
-    growing: In the last few years, employers have been hiring more people to do jobs like this. If this continues it could mean you’re likely to find work.
-    growing_strongly: In the last few years, employers have been hiring a lot more people to do jobs like this. If this continues it could mean you’re likely to find work.
+    falling: In the last few years, there hasn't been as much work available for people doing this type of work. You might find it hard to get work.
+    stable: In the last few years, employers haven't really changed how many people they hire to do types of work like this. This could mean you’ve got an average chance of finding work.
+    growing: In the last few years, employers have been hiring more people to do types of work like this. If this continues it could mean you’re likely to find work.
+    growing_strongly: In the last few years, employers have been hiring a lot more people to do types of work like this. If this continues it could mean you’re likely to find work.
 
   activerecord:
     errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,10 +165,10 @@ en-GB:
       disabled: 'off'
 
   job_growth_explanation:
-    falling: In the last few years, there hasn't been as much work available for people doing this type of work. You might find it hard to get work.
-    stable: In the last few years, employers haven't really changed how many people they hire to do types of work like this. This could mean you’ve got an average chance of finding work.
-    growing: In the last few years, employers have been hiring more people to do types of work like this. If this continues it could mean you’re likely to find work.
-    growing_strongly: In the last few years, employers have been hiring a lot more people to do types of work like this. If this continues it could mean you’re likely to find work.
+    falling: In the last few years, there has not been as much of this type of work available. You might find it hard to get into this type of work.
+    stable: In the last few years, employers have not really changed how many people they hire to do this type of work. This could mean you have got an average chance of finding work.
+    growing: In the last few years, employers have been hiring more people to do this type of work. If this continues it could mean you are likely to find work.
+    growing_strongly: In the last few years, employers have been hiring a lot more people to do this type of work. If this continues it could mean you are likely to find work.
 
   activerecord:
     errors:

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature 'Skills matcher', type: :feature do
 
     visit '/job-matches'
 
-    find('.underlined-text').click
+    find('.govuk-details__summary-text').click
 
     expect(page).to have_content(I18n.t(:growing, scope: :job_growth_explanation))
   end

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature 'Skills matcher', type: :feature do
 
     visit '/job-matches'
 
-    expect(page).to have_content('What does this mean?')
+    expect(page).to have_content('What does growing mean?')
   end
 
   scenario 'When clicking on What does this mean? link user gets the explanation for that score', :js do


### PR DESCRIPTION
Update paragraph 1 and 2

Remove salary

Update link label change text

Update the job growth details

Use the propper GDS accordion component

Update the font size for Skills match, Recent job growth:

Fix DAC accessibility fail Non-descriptive buttons/details component
issue (page 31 on the report) by updating aria label.

James Cutt from a team using the same Details component has shwon a nice
solution:

```ruby
<details class="govuk-details" role="group" open="">
    <summary class="govuk-details__summary" aria-controls="details-content-92" aria-expanded="true" role="button" tabindex="0">
        <span class="govuk-details__summary-text" data-testid="Expand Details Section Download data files">Download data files</span>
    </summary>
    <div class="govuk-details__text" aria-hidden="false" id="details-content-92">
        <ul class="govuk-list govuk-list--bullet">
            .....
        </ul>
    </div>
</details>
```

<img width="1017" alt="Screen Shot 2019-11-04 at 11 07 13" src="https://user-images.githubusercontent.com/1955084/68116672-5189bc80-fef3-11e9-8a8c-a1aa8a9f888e.png">

https://dfedigital.atlassian.net/browse/GET-645