### PR TITLE
Amendments to skills builder page

### DIFF
--- a/app/views/skills/_job_profiles_with_skills.html.erb
+++ b/app/views/skills/_job_profiles_with_skills.html.erb
@@ -1,31 +1,29 @@
-  <table class="govuk-table">
-    <thead class="govuk-table__head">
-      <hr class="govuk-section-break govuk-section-break--visible">
-      <% job_profiles_with_skills.each do |job_profile_hash| %>
-      <tr class="govuk-table__row">
-        <th class="govuk-table__header govuk-section-break__l govuk-!-padding-0" scope="col">
-          <div class="govuk-grid-row govuk-!-margin-top-3">
-            <div class="govuk-grid-column-one-third govuk-!-padding-right-0">
-              <h2 class="govuk-heading-m govuk-!-margin-bottom-3"><%= job_profile_hash[:name] %></h2>
-            </div>
-            <div class="govuk-grid-column-one-third govuk-!-padding-right-0">
-              <%= link_to('edit these skills', job_profile_skills_path(job_profile_id: job_profile_hash[:profile_slug], search: params[:search]), class:'govuk-link govuk-body', aria: { label: "Edit #{job_profile_hash[:name]} skills" }) %>
-            </div>
-            <div class="govuk-grid-column-one-third govuk-!-padding-right-0">
-              <%= link_to('remove this role', job_profile_path(job_profile_hash[:profile_slug], job_profile_id: job_profiles_with_skills.last[:profile_slug], search: params[:search]), method: :delete, class:'govuk-link govuk-body', aria: { label: "Remove #{job_profile_hash[:name]} role" }) %>
-            </div>
-          </div>
-          <p class="govuk-body">
-            <%= "#{pluralize(job_profile_hash[:skills].values.count, 'skill', 'skills')} selected" %>
-          </p>
-        </th>
-      </tr>
-      <% end %>
-    </thead>
-  </table>
+<hr class="govuk-section-break govuk-section-break--visible">
+
+<% job_profiles_with_skills.each do |job_profile_hash| %>
+  <div class="govuk-grid-row govuk-!-margin-top-3">
+    <div class="govuk-grid-column-one-third govuk-!-padding-right-0">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-3"><%= job_profile_hash[:name] %></h2>
+    </div>
+    <div class="govuk-grid-column-one-third govuk-!-padding-right-0">
+      <%= link_to('edit these skills', job_profile_skills_path(job_profile_id: job_profile_hash[:profile_slug], search: params[:search]), class:'govuk-link govuk-body', aria: { label: "Edit #{job_profile_hash[:name]} skills" }) %>
+    </div>
+    <div class="govuk-grid-column-one-third govuk-!-padding-right-0">
+      <%= link_to('remove this role', job_profile_path(job_profile_hash[:profile_slug], job_profile_id: job_profiles_with_skills.last[:profile_slug], search: params[:search]), method: :delete, class:'govuk-link govuk-body', aria: { label: "Remove #{job_profile_hash[:name]} role" }) %>
+    </div>
+    <div class="govuk-grid-column-full">
+      <p class="govuk-body">
+        <%= "#{pluralize(job_profile_hash[:skills].values.count, 'skill', 'skills')} selected" %>
+      </p>
+    </div>
+  </div>
+  <hr class="govuk-section-break govuk-section-break--visible">
+<% end %>
+
 <% unless user_session.job_profiles_cap_reached? %>
   <div class='govuk-!-margin-top-7 govuk-!-margin-bottom-3'>
     <%= link_to('Add more skills from another role', check_your_skills_path, class: 'govuk-link') %>
   </div>
 <% end %>
+
 <%= link_to('Find out what you can do with these skills', skills_matcher_index_path, class: 'govuk-button', data: { cy: 'find-out-what-you-can-do-btn', module: 'govuk-button' }) %>

--- a/app/views/skills/_job_profiles_with_skills.html.erb
+++ b/app/views/skills/_job_profiles_with_skills.html.erb
@@ -6,10 +6,10 @@
       <h2 class="govuk-heading-m govuk-!-margin-bottom-3"><%= job_profile_hash[:name] %></h2>
     </div>
     <div class="govuk-grid-column-one-third govuk-!-padding-right-0">
-      <%= link_to('edit these skills', job_profile_skills_path(job_profile_id: job_profile_hash[:profile_slug], search: params[:search]), class:'govuk-link govuk-body', aria: { label: "Edit #{job_profile_hash[:name]} skills" }) %>
+      <%= link_to('edit these skills', job_profile_skills_path(job_profile_id: job_profile_hash[:profile_slug], search: params[:search]), class:'govuk-link job-profile-action', aria: { label: "Edit #{job_profile_hash[:name]} skills" }) %>
     </div>
     <div class="govuk-grid-column-one-third govuk-!-padding-right-0">
-      <%= link_to('remove this role', job_profile_path(job_profile_hash[:profile_slug], job_profile_id: job_profiles_with_skills.last[:profile_slug], search: params[:search]), method: :delete, class:'govuk-link govuk-body', aria: { label: "Remove #{job_profile_hash[:name]} role" }) %>
+      <%= link_to('remove this role', job_profile_path(job_profile_hash[:profile_slug], job_profile_id: job_profiles_with_skills.last[:profile_slug], search: params[:search]), method: :delete, class:'govuk-link job-profile-action', aria: { label: "Remove #{job_profile_hash[:name]} role" }) %>
     </div>
     <div class="govuk-grid-column-full">
       <p class="govuk-body">

--- a/app/views/skills/_job_profiles_with_skills.html.erb
+++ b/app/views/skills/_job_profiles_with_skills.html.erb
@@ -1,28 +1,28 @@
-<% job_profiles_with_skills.each do |job_profile_hash| %>
   <table class="govuk-table">
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-1 govuk-!-margin-top-8"><%= job_profile_hash[:name] %></h2>
     <thead class="govuk-table__head">
+      <hr class="govuk-section-break govuk-section-break--visible">
+      <% job_profiles_with_skills.each do |job_profile_hash| %>
       <tr class="govuk-table__row">
-        <th class="govuk-table__header govuk-section-break__xl govuk-!-padding-0" scope="col">
-          <p class="govuk-body-l govuk-!-margin-bottom-2">You gained these skills from working as a <%= job_profile_hash[:name] %></p>
-          <span class='edit-skills govuk-!-margin-bottom-2'>
-            <%= link_to('edit these skills', job_profile_skills_path(job_profile_id: job_profile_hash[:profile_slug], search: params[:search]), class:'govuk-link govuk-body', aria: { label: "Edit #{job_profile_hash[:name]} skills" }) %>
-          </span>
-          <span class='remove-role govuk-!-margin-bottom-2'>
-            <%= link_to('remove this role', job_profile_path(job_profile_hash[:profile_slug], job_profile_id: job_profiles_with_skills.last[:profile_slug], search: params[:search]), method: :delete, class:'govuk-link govuk-body', aria: { label: "Remove #{job_profile_hash[:name]} role" }) %>
-          </span>
+        <th class="govuk-table__header govuk-section-break__l govuk-!-padding-0" scope="col">
+          <div class="govuk-grid-row govuk-!-margin-top-3">
+            <div class="govuk-grid-column-one-third govuk-!-padding-right-0">
+              <h2 class="govuk-heading-m govuk-!-margin-bottom-3"><%= job_profile_hash[:name] %></h2>
+            </div>
+            <div class="govuk-grid-column-one-third govuk-!-padding-right-0">
+              <%= link_to('edit these skills', job_profile_skills_path(job_profile_id: job_profile_hash[:profile_slug], search: params[:search]), class:'govuk-link govuk-body', aria: { label: "Edit #{job_profile_hash[:name]} skills" }) %>
+            </div>
+            <div class="govuk-grid-column-one-third govuk-!-padding-right-0">
+              <%= link_to('remove this role', job_profile_path(job_profile_hash[:profile_slug], job_profile_id: job_profiles_with_skills.last[:profile_slug], search: params[:search]), method: :delete, class:'govuk-link govuk-body', aria: { label: "Remove #{job_profile_hash[:name]} role" }) %>
+            </div>
+          </div>
+          <p class="govuk-body">
+            <%= "#{pluralize(job_profile_hash[:skills].values.count, 'skill', 'skills')} selected" %>
+          </p>
         </th>
       </tr>
-    </thead>
-    <tbody class="govuk-table__body govuk-table__body-skills">
-      <% job_profile_hash[:skills].values.each do |skill_name| %>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-!-padding-bottom-4 govuk-!-padding-top-4"><%= skill_name %></th>
-        </tr>
       <% end %>
-    </tbody>
+    </thead>
   </table>
-<% end %>
 <% unless user_session.job_profiles_cap_reached? %>
   <div class='govuk-!-margin-top-7 govuk-!-margin-bottom-3'>
     <%= link_to('Add more skills from another role', check_your_skills_path, class: 'govuk-link') %>

--- a/app/views/skills/index.html.erb
+++ b/app/views/skills/index.html.erb
@@ -12,7 +12,7 @@
 <div class="govuk-grid-row govuk-!-margin-top-7 govuk-body">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-grid-column-full govuk-!-padding-0">
-      <h1 class="govuk-heading-xl">Your skills</h1>
+      <h1 class="govuk-heading-xl">You’ve selected skills from the following jobs</h1>
       <% if flash[:notice].present? %>
         <div role="alert" class="banner-info">
           <p class="banner-info-message"><%= flash[:notice] %></p>

--- a/app/webpacker/styles/_skills-builder.scss
+++ b/app/webpacker/styles/_skills-builder.scss
@@ -11,11 +11,3 @@
     }
   }
 }
-
-.edit-skills {
-  float: left;
-}
-
-.remove-role {
-  float: right;
-}

--- a/app/webpacker/styles/_skills-builder.scss
+++ b/app/webpacker/styles/_skills-builder.scss
@@ -11,3 +11,14 @@
     }
   }
 }
+
+.job-profile-action {
+  display: block;
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(2);
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}

--- a/spec/features/skills_builder_spec.rb
+++ b/spec/features/skills_builder_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature 'Build your skills', type: :feature do
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     click_on('Select these skills')
 
-    expect(page).to have_selector('tbody tr', count: 3)
+    expect(page).to have_text('3 skills selected')
   end
 
   scenario 'User selects the skills for the first job profile and can see the current job title' do
@@ -130,7 +130,7 @@ RSpec.feature 'Build your skills', type: :feature do
     uncheck('Baldness', allow_label_click: true)
     click_on('Select these skills')
 
-    expect(page).to have_selector('tbody tr', count: 2)
+    expect(page).to have_text('2 skills selected')
   end
 
   scenario 'User can search for other job profiles' do
@@ -168,8 +168,6 @@ RSpec.feature 'Build your skills', type: :feature do
       :with_html_content,
       name: 'Classic-hitman',
       skills: [
-        create(:skill, name: 'Classic'),
-        create(:skill, name: 'James Bond like'),
         create(:skill, name: 'Martini lover')
       ]
     )
@@ -182,9 +180,7 @@ RSpec.feature 'Build your skills', type: :feature do
     click_on('Classic-hitman')
     click_on('Select these skills')
 
-    ['Classic-hitman', 'Classic', 'James Bond like', 'Martini lover', 'Hitman', 'Chameleon-like blend in tactics', 'License to kill', 'Baldness'].each do |title|
-      expect(page).to have_text(title)
-    end
+    expect(page).to have_text('1 skill selected')
   end
 
   scenario 'User jobs ordered correctly on skills page' do

--- a/spec/features/user_sign_in_spec.rb
+++ b/spec/features/user_sign_in_spec.rb
@@ -140,7 +140,7 @@ RSpec.feature 'User sign in' do
     sign_in_user
     visit(skills_path)
 
-    expect(page).to have_selector('tbody tr', count: 2)
+    expect(page).to have_text('2 skills selected')
   end
 
   scenario 'if user registers, continues journey then signs in, their session is restored' do
@@ -151,7 +151,7 @@ RSpec.feature 'User sign in' do
     sign_in_user
     visit(skills_path)
 
-    expect(page).to have_selector('tbody tr', count: 2)
+    expect(page).to have_text('2 skills selected')
   end
 
   scenario 'if user signs in, continues journey then signs in again, their session is restored' do
@@ -164,7 +164,7 @@ RSpec.feature 'User sign in' do
     sign_in_user
     visit(skills_path)
 
-    expect(page).to have_selector('tbody tr', count: 2)
+    expect(page).to have_text('2 skills selected')
   end
 
   scenario 'user restores their session after signing in with same session' do
@@ -175,7 +175,7 @@ RSpec.feature 'User sign in' do
     sign_in_user(reset_sessions: false)
     visit(skills_path)
 
-    expect(page).to have_selector('tbody tr', count: 2)
+    expect(page).to have_text('2 skills selected')
   end
 
   scenario 'if user registers, continues journey then signs in, their session is restored with same session' do
@@ -186,7 +186,7 @@ RSpec.feature 'User sign in' do
     sign_in_user(reset_sessions: false)
     visit(skills_path)
 
-    expect(page).to have_selector('tbody tr', count: 2)
+    expect(page).to have_text('2 skills selected')
   end
 
   scenario 'if user signs in, continues journey then signs in again, their session is restored with same session' do
@@ -199,7 +199,7 @@ RSpec.feature 'User sign in' do
     sign_in_user
     visit(skills_path)
 
-    expect(page).to have_selector('tbody tr', count: 2)
+    expect(page).to have_text('2 skills selected')
   end
 
   scenario 'if user signs in, they should be redirected to task list page' do

--- a/spec/features/user_sign_in_through_registration_spec.rb
+++ b/spec/features/user_sign_in_through_registration_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'User sign in through registration' do
     sign_in_user
     visit(skills_path)
 
-    expect(page).to have_selector('tbody tr', count: 2)
+    expect(page).to have_text('2 skills selected')
   end
 
   scenario 'if user registers, continues journey then signs in, their session is restored' do
@@ -56,7 +56,7 @@ RSpec.feature 'User sign in through registration' do
     sign_in_user
     visit(skills_path)
 
-    expect(page).to have_selector('tbody tr', count: 2)
+    expect(page).to have_text('2 skills selected')
   end
 
   scenario 'if user signs in, continues journey then signs in again, their session is restored' do
@@ -67,6 +67,6 @@ RSpec.feature 'User sign in through registration' do
     sign_in_user
     visit(skills_path)
 
-    expect(page).to have_selector('tbody tr', count: 2)
+    expect(page).to have_text('2 skills selected')
   end
 end


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-649

### Changes proposed in this pull request
Now instead of listing individual skills, summarises as "3 skills selected" for each job profile. This is less repetitive for screen readers. Cleaned up existing markup slightly and removed redundant styles. Updated feature specs to reflect.

### Guidance to review
I left out the centre align styles from the prototype markup - this looks really weird at narrow device widths. As a result the links to 'edit' and 'remove' are not in quite the same horizontal position as the prototype but responsiveness is improved.
