### PR TITLE
GET-683 Hide postcode in pagination and update Postcodes in Jobs near me and Courses page

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -7,6 +7,8 @@ class CoursesController < ApplicationController
       topic: courses_params[:topic_id]
     )
 
+    user_session.postcode = postcode if postcode && @search.valid?
+
     @courses = Kaminari.paginate_array(course_search).page(params[:page])
   rescue CourseGeospatialSearch::GeocoderAPIError
     redirect_to course_postcode_search_error_path

--- a/app/controllers/job_vacancies_controller.rb
+++ b/app/controllers/job_vacancies_controller.rb
@@ -8,6 +8,8 @@ class JobVacanciesController < ApplicationController
       page: job_vacancies_params[:page]
     )
 
+    user_session.postcode = postcode if postcode && @job_vacancy_search.valid?
+
     @job_vacancies = job_vacancies
   end
 

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -53,7 +53,7 @@
           <%= render partial: 'course', collection: @courses %>
         </ul>
         <div class="govuk-grid-column-full govuk-!-margin-bottom-4">
-          <%= paginate @courses %>
+          <%= paginate @courses, params: { postcode: nil } %>
         </div>
       <% end %>
     </div>

--- a/app/views/job_vacancies/index.html.erb
+++ b/app/views/job_vacancies/index.html.erb
@@ -41,7 +41,7 @@
           <%= render partial: 'job_vacancy', collection: @job_vacancies %>
         </ul>
         <div class="govuk-grid-column-full govuk-!-margin-bottom-4">
-          <%= paginate @job_vacancies %>
+          <%= paginate @job_vacancies, params: { postcode: nil } %>
         </div>
       <% end %>
     </div>

--- a/spec/features/find_training_courses_spec.rb
+++ b/spec/features/find_training_courses_spec.rb
@@ -59,6 +59,25 @@ RSpec.feature 'Find training courses', type: :feature do
     expect(page).to have_selector('ul.govuk-list li', count: 1)
   end
 
+  scenario 'Users can update their session postcode if there was none there' do
+    visit(courses_path(topic_id: 'maths'))
+    fill_in('postcode', with: 'NW6 8ET')
+    find('.search-button-results').click
+    visit(courses_path(topic_id: 'maths'))
+
+    expect(find_field('postcode').value).to eq 'NW6 8ET'
+  end
+
+  scenario 'Users can update their session postcode if it already existed' do
+    capture_user_location('NW6 1JF')
+    visit(courses_path(topic_id: 'maths'))
+    fill_in('postcode', with: 'NW6 8ET')
+    find('.search-button-results').click
+    visit(courses_path(topic_id: 'maths'))
+
+    expect(find_field('postcode').value).to eq 'NW6 8ET'
+  end
+
   scenario 'Pagination not visible if results number < 10' do
     Geocoder::Lookup::Test.add_stub(
       'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]

--- a/spec/features/jobs_near_me_spec.rb
+++ b/spec/features/jobs_near_me_spec.rb
@@ -32,6 +32,41 @@ RSpec.feature 'Jobs near me', type: :feature do
     expect(find_field('postcode').value).to eq 'NW6 8ET'
   end
 
+  scenario 'Users can update their session postcode if there was none there' do
+    find_a_job_service = instance_double(
+      FindAJobService,
+      job_vacancies: {
+        'pager' => { 'total_entries' => 1 },
+        'jobs' => [{}]
+      }
+    )
+    allow(FindAJobService).to receive(:new).and_return(find_a_job_service)
+    user_targets_a_job
+    fill_in('postcode', with: 'NW6 1JF')
+    find('.search-button-results').click
+    visit(jobs_near_me_path)
+
+    expect(find_field('postcode').value).to eq('NW6 1JF')
+  end
+
+  scenario 'Users can update their session postcode if it already existed' do
+    fill_in_postcode
+    find_a_job_service = instance_double(
+      FindAJobService,
+      job_vacancies: {
+        'pager' => { 'total_entries' => 1 },
+        'jobs' => [{}]
+      }
+    )
+    allow(FindAJobService).to receive(:new).and_return(find_a_job_service)
+    user_targets_a_job
+    fill_in('postcode', with: 'NW6 1JF')
+    find('.search-button-results').click
+    visit(jobs_near_me_path)
+
+    expect(find_field('postcode').value).to eq('NW6 1JF')
+  end
+
   scenario 'User can see jobs for their targeted job' do
     find_a_job_service = instance_double(
       FindAJobService,


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/GET-683

* Hide postcode params in pagination by setting it to nil on both pages
* Update postcode in session on both pages if user updates it in the form