### PR TITLE
Inform users if the Notify Service is not working

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -61,8 +61,7 @@ class UsersController < ApplicationController
       render(:return_to_saved_results)
     end
   rescue NotifyService::NotifyAPIError
-    # TODO: show user an error page, for now render link sent page
-    render(partial)
+    redirect_to return_to_saved_results_error_path
   end
 
   def register_with(partial:)

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -17,7 +17,7 @@ class NotifyService
       template_id: template_id,
       personalisation: options
     )
-  rescue Notifications::Client::RequestError, RuntimeError => e
+  rescue Notifications::Client::RequestError, RuntimeError, ArgumentError => e
     Rails.logger.error("Notify API error: #{e.message}")
     raise NotifyAPIError
   end
@@ -33,9 +33,6 @@ class NotifyService
 
   def client
     @client ||= Notifications::Client.new(api_key)
-  rescue ArgumentError => e
-    Rails.logger.error("Notify API error: #{e.message}")
-    raise NotifyAPIError
   end
 
   def api_key

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -33,6 +33,9 @@ class NotifyService
 
   def client
     @client ||= Notifications::Client.new(api_key)
+  rescue ArgumentError => e
+    Rails.logger.error("Notify API error: #{e.message}")
+    raise NotifyAPIError
   end
 
   def api_key

--- a/app/views/errors/return_to_saved_results_error.html.erb
+++ b/app/views/errors/return_to_saved_results_error.html.erb
@@ -1,0 +1,25 @@
+<% page_title :errors_return_to_saved_results_error %>
+
+<% content_for :breadcrumb do
+    generate_breadcrumbs(
+      t('breadcrumb.link_not_sent'),
+      [
+        [t('breadcrumb.task_list_home'), task_list_path]
+      ]
+    )
+  end
+%>
+
+<main role="main" class="govuk-main-wrapper" id="main-content">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+       <p class="govuk-body">Unfortunately we weren’t able to send you a link to your saved results at this time.</p>
+      <p class="govuk-body">You could try again later.</p>
+      <%= link_to 'Return to previous page', return_to_saved_results_path, class: 'govuk-link govuk-body', data: { module: 'govuk-button' } %>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <%= render 'shared/contact_us' %>
+    </div>
+  </div>
+</main>

--- a/app/views/errors/return_to_saved_results_error.html.erb
+++ b/app/views/errors/return_to_saved_results_error.html.erb
@@ -1,25 +1,13 @@
 <% page_title :errors_return_to_saved_results_error %>
 
-<% content_for :breadcrumb do
-    generate_breadcrumbs(
-      t('breadcrumb.link_not_sent'),
-      [
-        [t('breadcrumb.task_list_home'), task_list_path]
-      ]
-    )
-  end
-%>
-
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+      <h1 class="govuk-heading-xl">Sorry, there is a problem with this service</h1>
        <p class="govuk-body">Unfortunately we weren’t able to send you a link to your saved results at this time.</p>
-      <p class="govuk-body">You could try again later.</p>
-      <%= link_to 'Return to previous page', return_to_saved_results_path, class: 'govuk-link govuk-body', data: { module: 'govuk-button' } %>
-    </div>
-    <div class="govuk-grid-column-one-third">
-      <%= render 'shared/contact_us' %>
+       <p class="govuk-body">You could try again later.</p>
+       <p class="govuk-body">You can still use this service to check the skills you already have and explore the types of jobs you could apply to do.</p>
+      <%= link_to 'Return to previous page', return_to_saved_results_path, class: 'govuk-link govuk-body' %>
     </div>
   </div>
 </main>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@ en-GB:
     save_your_results: Save your results
     return_to_saved_results: Return to saved results
     link_sent: Link sent
+    link_not_sent: Link not sent
     results_saved: Results saved
     email_sent_again: Email sent again
     link_sent_again: Link sent again
@@ -56,6 +57,7 @@ en-GB:
     errors_internal_server_error: Get help to retrain - Internal server error
     errors_postcode_search_error: Get help to retrain - Postcode search error
     errors_jobs_near_me_error: Get help to retrain - Jobs near me error
+    errors_return_to_saved_results_error: Get help to retrain - Return to saved results error
     save_your_results: Get help to retrain - Save your results
     return_to_saved_results: Get help to retrain - Return to saved results
     link_sent: Get help to retrain - Link sent

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,7 +22,6 @@ en-GB:
     save_your_results: Save your results
     return_to_saved_results: Return to saved results
     link_sent: Link sent
-    link_not_sent: Link not sent
     results_saved: Results saved
     email_sent_again: Email sent again
     link_sent_again: Link sent again

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
   get 'training-hub', to: 'pages#training_hub'
   get 'offers-near-me', to: 'pages#offers_near_me', constraints: ->(_req) { Flipflop.action_plan? }
   get 'course-postcode-search-error', to: 'errors#course_postcode_search_error'
+  get 'return-to-saved-results-error', to: 'errors#return_to_saved_results_error'
 
   get 'location-ineligible', to: 'pages#location_ineligible'
   get 'postcode-search-error', to: 'errors#postcode_search_error'

--- a/spec/features/user_sign_in_spec.rb
+++ b/spec/features/user_sign_in_spec.rb
@@ -86,6 +86,20 @@ RSpec.feature 'User sign in' do
     expect(page).to have_current_path(return_to_saved_results_error_path)
   end
 
+  scenario 'User redirected to error page if there is the Notify Service is using an invalid API KEY' do
+    allow(Notifications::Client).to receive(:new).with('test').and_raise(ArgumentError)
+
+    register_user
+
+    visit(return_to_saved_results_path)
+
+    fill_in('email', with: 'test@test.test')
+
+    click_on('Send link')
+
+    expect(page).to have_current_path(return_to_saved_results_error_path)
+  end
+
   scenario 'User redirected to link sent page if email is valid and user does not exists' do
     send_sign_in_email
 

--- a/spec/features/user_sign_in_spec.rb
+++ b/spec/features/user_sign_in_spec.rb
@@ -70,6 +70,22 @@ RSpec.feature 'User sign in' do
     expect(page).to have_text('Link sent')
   end
 
+  scenario 'User redirected to error page if there is an issue with the Notify Service' do
+    api_response = instance_double(Net::HTTPResponse, code: 500, body: 'FUBAR')
+
+    allow(client).to receive(:send_email).and_raise(Notifications::Client::RequestError, api_response)
+
+    register_user
+
+    visit(return_to_saved_results_path)
+
+    fill_in('email', with: 'test@test.test')
+
+    click_on('Send link')
+
+    expect(page).to have_current_path(return_to_saved_results_error_path)
+  end
+
   scenario 'User redirected to link sent page if email is valid and user does not exists' do
     send_sign_in_email
 

--- a/spec/features/user_sign_in_spec.rb
+++ b/spec/features/user_sign_in_spec.rb
@@ -86,20 +86,6 @@ RSpec.feature 'User sign in' do
     expect(page).to have_current_path(return_to_saved_results_error_path)
   end
 
-  scenario 'User redirected to error page if there is the Notify Service is using an invalid API KEY' do
-    allow(Notifications::Client).to receive(:new).with('test').and_raise(ArgumentError)
-
-    register_user
-
-    visit(return_to_saved_results_path)
-
-    fill_in('email', with: 'test@test.test')
-
-    click_on('Send link')
-
-    expect(page).to have_current_path(return_to_saved_results_error_path)
-  end
-
   scenario 'User redirected to link sent page if email is valid and user does not exists' do
     send_sign_in_email
 

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe NotifyService do
-  subject(:service) { described_class.new(api_key: 'SOME VALID KEY') }
+  subject(:service) { described_class.new(api_key: 'SOME KEY') }
 
   let(:template_id) { '5f06ec42-a1e2-44b7-a8d0-239f2b893fe9' }
   let(:email) { 'test@test.com' }
@@ -17,7 +17,17 @@ RSpec.describe NotifyService do
     context 'when the NOTIFY_API_KEY is missing' do
       subject(:service) { described_class.new(api_key: nil) }
 
-      it 'returns the error message accordingly' do
+      it 'raises NotifyAPIError' do
+        expect {
+          service.send_email(email_address: email, template_id: template_id)
+        }.to raise_error(described_class::NotifyAPIError)
+      end
+    end
+
+    context 'when the NOTIFY_API_KEY is wrong' do
+      it 'raises NotifyAPIError' do
+        allow(Notifications::Client).to receive(:new).and_raise(ArgumentError)
+
         expect {
           service.send_email(email_address: email, template_id: template_id)
         }.to raise_error(described_class::NotifyAPIError)


### PR DESCRIPTION
### Description

Add a Return to results: Error page
when notify fails to send magic link email

<img width="985" alt="Screen Shot 2019-11-07 at 17 06 55" src="https://user-images.githubusercontent.com/1955084/68410703-16042200-0181-11ea-8c82-a76c023a0be6.png">

https://dfedigital.atlassian.net/browse/GET-496

### Testing
Try altering the API key on HEROKU to get to this page naturally.