### PR TITLE
Fix flakey courses test

### DIFF
--- a/spec/features/find_training_courses_spec.rb
+++ b/spec/features/find_training_courses_spec.rb
@@ -60,6 +60,9 @@ RSpec.feature 'Find training courses', type: :feature do
   end
 
   scenario 'Users can update their session postcode if there was none there' do
+    Geocoder::Lookup::Test.add_stub(
+      'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+    )
     visit(courses_path(topic_id: 'maths'))
     fill_in('postcode', with: 'NW6 8ET')
     find('.search-button-results').click
@@ -69,6 +72,9 @@ RSpec.feature 'Find training courses', type: :feature do
   end
 
   scenario 'Users can update their session postcode if it already existed' do
+    Geocoder::Lookup::Test.add_stub(
+      'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+    )
     capture_user_location('NW6 1JF')
     visit(courses_path(topic_id: 'maths'))
     fill_in('postcode', with: 'NW6 8ET')


### PR DESCRIPTION
Replicate test failure using:
`be rspec ./spec/features/find_training_courses_spec.rb[1:8,1:9,1:13] --seed 33797`

Postcode is seen as not real if no geocode is defined for it and thus will be invalid
and not saved into the session. Make sure to define it's geocoding to make sure it's valid.