### PR TITLE
GET-682: Fix IE11 compatibility issue 

### DIFF
--- a/app/webpacker/packs/track-events.js
+++ b/app/webpacker/packs/track-events.js
@@ -1,9 +1,11 @@
 function TrackEvents () {
   this.start = function () {
     if (typeof(appInsights) !== 'undefined') {
-      document.querySelectorAll('[data-tracked-event]').forEach(function (element) {
-        trackComponentOnClick(element);
-      });
+      var elements = document.querySelectorAll('[data-tracked-event]')
+
+      for (let i = 0; i < elements.length; ++i) {
+        trackComponentOnClick(elements[i]);
+      }
     }
   };
 

--- a/app/webpacker/packs/track-events.js
+++ b/app/webpacker/packs/track-events.js
@@ -1,7 +1,7 @@
 function TrackEvents () {
   this.start = function () {
     if (typeof(appInsights) !== 'undefined') {
-      var elements = document.querySelectorAll('[data-tracked-event]')
+      var elements = document.querySelectorAll('[data-tracked-event]');
 
       for (let i = 0; i < elements.length; ++i) {
         trackComponentOnClick(elements[i]);


### PR DESCRIPTION
### Context

Fix IE11 compatibility issue

We currently have for event tracking that is using
forEach function. However, IE11 throws the following
error:

Object doesn't support property or method 'forEach'

Because of this the behaviour our accordion component
is broken on IE11 giving bad user experience.

Decided to go with the simplest solution of using the
classic for loop.

<img width="1131" alt="Screen Shot 2019-11-06 at 12 25 29" src="https://user-images.githubusercontent.com/1955084/68302430-f219e100-0099-11ea-8315-fef46d17d321.png">

### Test

Please use: https://dev1.nrs-ghtr.org.uk/task-list
And browserling.com