### PR TITLE
GET-621 Show error page if Find a Job API is down and cleanup exceptions for service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ restricted_erd.pdf
 *.log
 coverage
 **/local-parameters.json
+.DS_Store

--- a/app/controllers/job_profiles_controller.rb
+++ b/app/controllers/job_profiles_controller.rb
@@ -41,5 +41,7 @@ class JobProfilesController < ApplicationController
       name: resource.name,
       postcode: user_session.postcode
     ).count
+  rescue FindAJobService::APIError
+    nil
   end
 end

--- a/app/controllers/job_vacancies_controller.rb
+++ b/app/controllers/job_vacancies_controller.rb
@@ -11,6 +11,8 @@ class JobVacanciesController < ApplicationController
     user_session.postcode = postcode if postcode && @job_vacancy_search.valid?
 
     @job_vacancies = job_vacancies
+  rescue FindAJobService::ResponseError
+    redirect_to jobs_near_me_error_path
   end
 
   private

--- a/app/controllers/job_vacancies_controller.rb
+++ b/app/controllers/job_vacancies_controller.rb
@@ -11,7 +11,7 @@ class JobVacanciesController < ApplicationController
     user_session.postcode = postcode if postcode && @job_vacancy_search.valid?
 
     @job_vacancies = job_vacancies
-  rescue FindAJobService::ResponseError
+  rescue FindAJobService::APIError
     redirect_to jobs_near_me_error_path
   end
 

--- a/app/services/find_a_job_service.rb
+++ b/app/services/find_a_job_service.rb
@@ -38,7 +38,7 @@ class FindAJobService
     end
   rescue StandardError => e
     Rails.logger.error("Find a Job Service API error: #{e.inspect}")
-    raise APIError
+    raise APIError, e
   end
 
   def build_uri(path:, options: {})

--- a/app/services/find_a_job_service.rb
+++ b/app/services/find_a_job_service.rb
@@ -3,6 +3,7 @@ class FindAJobService
 
   BASE_URL = 'https://findajob.dwp.gov.uk/api/'.freeze
   ResponseError = Class.new(StandardError)
+  APIError = Class.new(StandardError)
 
   def initialize(
     api_id: Rails.configuration.find_a_job_api_id,
@@ -18,10 +19,6 @@ class FindAJobService
     uri = build_uri(path: 'search', options: options)
 
     JSON.parse(response_body(uri))
-  rescue ResponseError => e
-    Rails.logger.error("Find a Job Service API error: #{e.inspect}")
-
-    {}
   end
 
   def health_check
@@ -39,6 +36,9 @@ class FindAJobService
 
       response.body
     end
+  rescue StandardError => e
+    Rails.logger.error("Find a Job Service API error: #{e.inspect}")
+    raise APIError
   end
 
   def build_uri(path:, options: {})

--- a/app/services/health_check/find_a_job_check.rb
+++ b/app/services/health_check/find_a_job_check.rb
@@ -8,7 +8,7 @@ module HealthCheck
 
     def value
       @value ||= FindAJobService.new.health_check
-    rescue StandardError => e
+    rescue FindAJobService::APIError => e
       @output = "Find A Job API error: #{e.message}"
       ''
     end

--- a/app/views/errors/jobs_near_me_error.html.erb
+++ b/app/views/errors/jobs_near_me_error.html.erb
@@ -1,0 +1,12 @@
+<% page_title :errors_jobs_near_me_error %>
+
+<main role="main" class="govuk-main-wrapper" id="main-content">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Sorry, there is a problem with this service</h1>
+      <p class="govuk-body">The <%= link_to 'Find a job', 'https://www.gov.uk/find-a-job', class: 'govuk-link' %> service is not working right now.</p>
+      <p class="govuk-body-m">You can continue using this service to check your existing skills and explore the types of jobs you could apply to do.</p>
+      <%= link_to 'Continue', action_plan_path, class: 'govuk-button', data: { module: 'govuk-button' } %>
+    </div>
+  </div>
+</main>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,7 @@ en-GB:
     errors_unprocessable_entity: Get help to retrain - Unprocessable entity
     errors_internal_server_error: Get help to retrain - Internal server error
     errors_postcode_search_error: Get help to retrain - Postcode search error
+    errors_jobs_near_me_error: Get help to retrain - Jobs near me error
     save_your_results: Get help to retrain - Save your results
     return_to_saved_results: Get help to retrain - Return to saved results
     link_sent: Get help to retrain - Link sent

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
 
   get 'location-ineligible', to: 'pages#location_ineligible'
   get 'postcode-search-error', to: 'errors#postcode_search_error'
+  get 'jobs-near-me-error', to: 'errors#jobs_near_me_error', constraints: ->(_req) { Flipflop.action_plan? }
 
   match(
     'courses/:topic_id',

--- a/spec/features/job_profile_spec.rb
+++ b/spec/features/job_profile_spec.rb
@@ -107,8 +107,10 @@ RSpec.feature 'Job profile spec' do
   end
 
   scenario 'User does not see job vacancies if API is down' do
-    job_vacancy_search = instance_double(JobVacancySearch, count: nil)
+    job_vacancy_search = instance_double(JobVacancySearch)
     allow(JobVacancySearch).to receive(:new).and_return(job_vacancy_search)
+    allow(job_vacancy_search).to receive(:count).and_raise(FindAJobService::APIError)
+
     job_profile = create(:job_profile, :with_html_content)
 
     user_enters_location
@@ -118,8 +120,10 @@ RSpec.feature 'Job profile spec' do
   end
 
   scenario 'User does not see job vacancies if no postcode supplied' do
-    job_vacancy_search = instance_double(JobVacancySearch, count: nil)
+    job_vacancy_search = instance_double(JobVacancySearch)
     allow(JobVacancySearch).to receive(:new).and_return(job_vacancy_search)
+    allow(job_vacancy_search).to receive(:count).and_raise(FindAJobService::APIError)
+
     job_profile = create(:job_profile, :with_html_content)
 
     visit(job_profile_path(job_profile.slug))

--- a/spec/features/jobs_near_me_spec.rb
+++ b/spec/features/jobs_near_me_spec.rb
@@ -159,7 +159,7 @@ RSpec.feature 'Jobs near me', type: :feature do
   scenario 'User gets relevant messaging if there is an API error' do
     find_a_job_service = instance_double(FindAJobService)
     allow(FindAJobService).to receive(:new).and_return(find_a_job_service)
-    allow(find_a_job_service).to receive(:job_vacancies).and_raise(FindAJobService::ResponseError)
+    allow(find_a_job_service).to receive(:job_vacancies).and_raise(FindAJobService::APIError)
 
     user_targets_a_job
     fill_in('postcode', with: 'NW6 9ET')

--- a/spec/features/jobs_near_me_spec.rb
+++ b/spec/features/jobs_near_me_spec.rb
@@ -157,8 +157,10 @@ RSpec.feature 'Jobs near me', type: :feature do
   end
 
   scenario 'User gets relevant messaging if there is an API error' do
-    # TODO: Render error page for Find a Job API error
-    pending
+    find_a_job_service = instance_double(FindAJobService)
+    allow(FindAJobService).to receive(:new).and_return(find_a_job_service)
+    allow(find_a_job_service).to receive(:job_vacancies).and_raise(FindAJobService::ResponseError)
+
     user_targets_a_job
     fill_in('postcode', with: 'NW6 9ET')
     find('.search-button-results').click

--- a/spec/routing/action_plan_spec.rb
+++ b/spec/routing/action_plan_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe 'routes for action plan', type: :routing do
     it 'successfully routes to pages#offers_near_me' do
       expect(get('/offers-near-me')).to route_to(controller: 'pages', action: 'offers_near_me')
     end
+
+    it 'successfully routes to errors#jobs_near_me_error' do
+      expect(get('/jobs-near-me-error')).to route_to(controller: 'errors', action: 'jobs_near_me_error')
+    end
   end
 
   context 'with action_plan feature disabled' do
@@ -26,6 +30,10 @@ RSpec.describe 'routes for action plan', type: :routing do
 
     it 'does not root to pages#offers_near_me' do
       expect(get('/offers-near-me')).not_to be_routable
+    end
+
+    it 'does not root to errors#jobs_near_me_error' do
+      expect(get('/jobs-near-me-error')).not_to be_routable
     end
   end
 end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-621

The errors for find a job service were a bit of a mess, so now made them
consistent to the following:

1) If there is an internal API response error we raise a Response Error
  which we catch and for outside services this is seen as an API error
2) If there is a NET::HTTP error, the best way is to save it through standard
   error see: https://stackoverflow.com/questions/5370697/what-s-the-best-way-to-handle-exceptions-from-nethttp
   rescue that and raise also API error for outside services. Since we are
   now doing that in the find a job service itself, remove the need to
  do that from the healthcheck service and rescue from API error instead
3) For job vacancies on the search page, show error page and rescue from
   new API error
4) For job vacancy count on job profiles page, rescue from API error but return
   nil to hide that section. This has been moved to the controller instead now


For testing purposes, I went with the following scenarios locally:
1) Job vacancy search: shows error if `Net::HTTP` exception or `Response` exception are thrown
2) Job profile count: shows nothing if `Net::HTTP` exception or `Response` exception are thrown. Shows nothing if no postcode entered, shows number over 0, and a different text for 0 otherwise
3) Health check: shows error if `Net::HTTP` exception or `Response` exception are thrown with **correct** message, show pass otherwise
