### PR TITLE
Fix flaky specs caused by strange quantum tunnelling effect

### DIFF
--- a/app/scrapers/job_profile_scraper.rb
+++ b/app/scrapers/job_profile_scraper.rb
@@ -18,7 +18,14 @@ class JobProfileScraper
 
   content 'css=body', :html
 
-  # rubocop:disable Metrics/LineLength
-  skills "xpath=//section[@id='Skills']//section[contains(@class, 'job-profile-subsection') and not(contains(@id, 'restrictions'))]//li", :list
-  # rubocop:enable Metrics/LineLength
+  skills "xpath=//section[@id='Skills']//section[contains(@class, 'job-profile-subsection') and not(contains(@id, 'restrictions'))]//li", :list # rubocop:disable Metrics/LineLength
+
+  def reparse(content, &block)
+    metadata[:page] = Mechanize::Page.new(nil, nil, content, 200, mechanize)
+    begin
+      block.call
+    ensure
+      metadata[:page] = nil
+    end
+  end
 end

--- a/lib/tasks/data_import/refresh_job_profiles.rake
+++ b/lib/tasks/data_import/refresh_job_profiles.rake
@@ -6,10 +6,10 @@ namespace :data_import do
     if JobProfile.any?
       JobProfile.all.each do |job_profile|
         scraper = JobProfileScraper.new
-        cached_page = Mechanize::Page.new(nil, nil, job_profile.content, 200, scraper.mechanize)
-        scraper.metadata.page cached_page
-        print "Refreshing job profile #{job_profile.slug}"
-        job_profile.scrape(scraper)
+        scraper.reparse(job_profile.content) do
+          print "Refreshing job profile #{job_profile.slug}"
+          job_profile.scrape(scraper)
+        end
       end
 
       Skill.without_job_profiles.delete_all


### PR DESCRIPTION
Well, actually it turns out that the Wombat gem makes use of class level instance variables, and writing directly to the `metadata` class causes pollution across other instances of the same `Crawler` class. `JobProfileScraper` derives from this class:

```ruby
module Wombat
  module Crawler
    include Processing::Parser
    extend ActiveSupport::Concern

    included do
      class << self
        attr_accessor :metadata
      end
      self.metadata = DSL::Metadata.new
    end
```

The fix for this took a while to resolve, (tried many approaches) but turns out to just require clearing the parsed page (setting it to `nil`) which forces the next scraped page to be parsed correctly. This is the magic line:

```ruby
      metadata[:page] = nil
```

Also took the opportunity to clean up the rake task implementation by offloading some of the messy details to the `JobProfileScraper` class. Tests now pass using the same seed and minimal set of specs that was previously failing:

```bash
rspec "./spec/models/job_profile_spec.rb[1:4:1:1,1:4:1:2,1:4:1:3,1:4:1:4,1:4:1:5,1:4:1:6,1:4:2:1]" "./spec/tasks/refresh_job_profiles_spec.rb[1:1]" "./spec/tasks/scrape_job_profiles_spec.rb[1:1,1:2]" --seed 4240
```

![quantum-leap](https://i.imgflip.com/3fo826.jpg)