### PR TITLE
Add service error page for user registration

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,4 @@
-class ErrorsController < ActionController::Base
+class ErrorsController < ApplicationController
   layout 'application'
 
   def not_found

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -72,8 +72,7 @@ class UsersController < ApplicationController
       render(:new)
     end
   rescue NotifyService::NotifyAPIError
-    # TODO: show user an error page, for now render link sent page
-    render(partial)
+    redirect_to save_results_error_path
   end
 
   def user

--- a/app/views/errors/save_results_error.html.erb
+++ b/app/views/errors/save_results_error.html.erb
@@ -1,0 +1,24 @@
+<% page_title :errors_save_results_error %>
+
+<% content_for :breadcrumb do
+    generate_breadcrumbs(
+      t('breadcrumb.results_saved'),
+      [
+        [t('breadcrumb.task_list_home'), task_list_path]
+      ]
+    )
+  end
+%>
+
+<div class="govuk-grid-row govuk-!-margin-top-7">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Your results have been saved</h1>
+    <p class="govuk-body">We have saved your results using the email address you have provided.</p>
+    <p class="govuk-body">We cannot send you a confirmation email right now because of an error with our system. Your results are still saved.</p>
+    <p class="govuk-body">To see your saved skills and job matches in future, just return to the service and enter your email address. You will then be sent a link so you can return to your saved results.</p>
+    <%= link_to 'Continue', user_session.registration_triggered_path || task_list_path, class: 'govuk-button', data: { module: 'govuk-button' } %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render "shared/contact_us" %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,7 @@ en-GB:
     errors_postcode_search_error: Get help to retrain - Postcode search error
     errors_jobs_near_me_error: Get help to retrain - Jobs near me error
     errors_return_to_saved_results_error: Get help to retrain - Return to saved results error
+    errors_save_results_error: Get help to retrain - Save your results error
     save_your_results: Get help to retrain - Save your results
     return_to_saved_results: Get help to retrain - Return to saved results
     link_sent: Get help to retrain - Link sent

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
   get 'offers-near-me', to: 'pages#offers_near_me', constraints: ->(_req) { Flipflop.action_plan? }
   get 'course-postcode-search-error', to: 'errors#course_postcode_search_error'
   get 'return-to-saved-results-error', to: 'errors#return_to_saved_results_error'
+  get 'save-results-error', to: 'errors#save_results_error'
 
   get 'location-ineligible', to: 'pages#location_ineligible'
   get 'postcode-search-error', to: 'errors#postcode_search_error'

--- a/spec/features/user_registration_spec.rb
+++ b/spec/features/user_registration_spec.rb
@@ -120,7 +120,19 @@ RSpec.feature 'User registration' do
     expect(page).to have_current_path(next_steps_path)
   end
 
-  scenario 'User can resume the journey from the point one saves results but gets the error page (NotifyService is down)' do
+  scenario 'When NotifyService is down, the user sees the correct error page when one tries to save results' do
+    allow(Notifications::Client).to receive(:new).and_raise(ArgumentError)
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    click_on('Select these skills')
+    click_on('Save my results')
+    fill_in('email', with: 'test@test.test')
+    click_on('Save your results')
+
+    expect(page).to have_current_path(save_results_error_path)
+  end
+
+  scenario 'When NotifyService is down, user can resume the journey from the point one tries saving the results' do
     allow(Notifications::Client).to receive(:new).and_raise(ArgumentError)
 
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
@@ -133,18 +145,6 @@ RSpec.feature 'User registration' do
     click_on('Continue')
 
     expect(page).to have_current_path(training_hub_path)
-  end
-
-  scenario 'User sees the error page when one tries to save results NotifyService is down' do
-    allow(Notifications::Client).to receive(:new).and_raise(ArgumentError)
-
-    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
-    click_on('Select these skills')
-    click_on('Save my results')
-    fill_in('email', with: 'test@test.test')
-    click_on('Save your results')
-
-    expect(page).to have_current_path(save_results_error_path)
   end
 
   scenario 'User can resume their journey to where they first clicked save my results' do

--- a/spec/features/user_registration_spec.rb
+++ b/spec/features/user_registration_spec.rb
@@ -120,6 +120,33 @@ RSpec.feature 'User registration' do
     expect(page).to have_current_path(next_steps_path)
   end
 
+  scenario 'User can resume the journey from the point one saves results but gets the error page (NotifyService is down)' do
+    allow(Notifications::Client).to receive(:new).and_raise(ArgumentError)
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    click_on('Select these skills')
+    visit(training_hub_path)
+    click_on('Save my results')
+    fill_in('email', with: 'test@test.test')
+    click_on('Save your results')
+
+    click_on('Continue')
+
+    expect(page).to have_current_path(training_hub_path)
+  end
+
+  scenario 'User sees the error page when one tries to save results NotifyService is down' do
+    allow(Notifications::Client).to receive(:new).and_raise(ArgumentError)
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    click_on('Select these skills')
+    click_on('Save my results')
+    fill_in('email', with: 'test@test.test')
+    click_on('Save your results')
+
+    expect(page).to have_current_path(save_results_error_path)
+  end
+
   scenario 'User can resume their journey to where they first clicked save my results' do
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     click_on('Select these skills')


### PR DESCRIPTION
### Context

If notify service is down, users will get an error
page explaining what is happening.

Users can still resume their journey.

<img width="996" alt="Screen Shot 2019-11-11 at 15 59 41" src="https://user-images.githubusercontent.com/1955084/68601503-583ca480-049c-11ea-81df-cfe41a250fb0.png">

### Testing

1. Please check you can resume the journey (try saving results at different stages)
2. Deeplinking to the error page should redirect to task-list page.

https://dfedigital.atlassian.net/browse/GET-526