### PR TITLE
Revert the temporaty database in qa

### DIFF
--- a/azure/config/qa.parameters.json
+++ b/azure/config/qa.parameters.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "domainDatabaseName": {
-      "value": "domaintemp"
+      "value": "domain"
     },
     "domainDatabaseUsername": {
       "reference": {


### PR DESCRIPTION
### Context

We introduced a temporary domain database in the qa environment to respond to a MS Azure service failure.  We don't need it anymore

### Changes proposed in this pull request

This reverts to the original database instance.

### Guidance to review

