### PR TITLE
GET-661 Enable GA tracking for outbound urls

### DIFF
--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,6 +1,7 @@
 import '../styles/application.scss';
 import CookiesBanner from './cookies-banner';
 import TrackEvents from './track-events';
+import OutboundLinkTracking from './outbound-link-tracking';
 import UserFeedback from './user-feedback';
 import Rails from 'rails-ujs';
 import { initAll } from 'govuk-frontend';
@@ -8,5 +9,6 @@ import { initAll } from 'govuk-frontend';
 CookiesBanner.start();
 TrackEvents.start();
 UserFeedback.start();
+OutboundLinkTracking.start();
 Rails.start();
 initAll();

--- a/app/webpacker/packs/outbound-link-tracking.js
+++ b/app/webpacker/packs/outbound-link-tracking.js
@@ -1,22 +1,29 @@
 function OutboundLinkTracking () {
   this.start = function () {
+    if (typeof(gtag) !== 'undefined') {
+      trackOutboundLinks();
+    }
+  }
+
+
+  function trackOutboundLinks () {
     if (document.getElementsByTagName) {
       var el = document.getElementsByTagName('a');
       var getDomain = document.domain.split('.').reverse()[1] + '.' + document.domain.split('.').reverse()[0];
 
-      // Look thru each a element
+      // Look through each a element
       for (var i = 0; i < el.length; i++) {
-        // Extract it's href attribute
+        // Extract its href attribute
         var href = (typeof(el[i].getAttribute('href')) == 'string' ) ? el[i].getAttribute('href') : '';
 
         // Query the href for the top level domain (xxxxx.com)
         var myDomain = href.match(getDomain);
 
         // If link is outbound and is not to this domain
-        if (typeof gtag === 'function' && (href.match(/^(https?:|\/\/)/i)  && !myDomain) || href.match(/^mailto\:/i)) {
+        if ((href.match(/^(https?:|\/\/)/i)  && !myDomain) || href.match(/^mailto\:/i)) {
 
           // Add an event to click
-          addEvent(el[i],'click', function(e) {
+          addEvent(el[i], 'click', function(e) {
             var url = this.getAttribute('href');
             var win = (typeof(this.getAttribute('target')) == 'string') ? this.getAttribute('target') : '';
 

--- a/app/webpacker/packs/outbound-link-tracking.js
+++ b/app/webpacker/packs/outbound-link-tracking.js
@@ -1,0 +1,57 @@
+function OutboundLinkTracking () {
+  this.start = function () {
+    if (document.getElementsByTagName) {
+      var el = document.getElementsByTagName('a');
+      var getDomain = document.domain.split('.').reverse()[1] + '.' + document.domain.split('.').reverse()[0];
+
+      // Look thru each a element
+      for (var i = 0; i < el.length; i++) {
+        // Extract it's href attribute
+        var href = (typeof(el[i].getAttribute('href')) == 'string' ) ? el[i].getAttribute('href') : '';
+
+        // Query the href for the top level domain (xxxxx.com)
+        var myDomain = href.match(getDomain);
+
+        // If link is outbound and is not to this domain
+        if ((href.match(/^(https?:|\/\/)/i)  && !myDomain) || href.match(/^mailto\:/i)) {
+
+          // Add an event to click
+          addEvent(el[i],'click', function(e) {
+            var url = this.getAttribute('href');
+            var win = (typeof(this.getAttribute('target')) == 'string') ? this.getAttribute('target') : '';
+
+            // Log event to Analytics, once done, go to the link
+            gtag('event', 'click', {
+              'event_category': 'outbound',
+              'event_label': url,
+              'transport_type': 'beacon',
+              'event_callback': hitCallbackHandler(url, win)
+            });
+
+            e.preventDefault();
+          });
+        }
+      }
+    }
+  }
+
+  function hitCallbackHandler (url, win) {
+    if (win) {
+      window.open(url, win);
+    } else {
+      window.location.href = url;
+    }
+  }
+
+  function addEvent (el, eventName, handler) {
+    if (el.addEventListener) {
+      el.addEventListener(eventName, handler);
+    } else {
+      el.attachEvent('on' + eventName, function(){
+        handler.call(el);
+      });
+    }
+  }
+}
+
+export default new OutboundLinkTracking();

--- a/app/webpacker/packs/outbound-link-tracking.js
+++ b/app/webpacker/packs/outbound-link-tracking.js
@@ -13,7 +13,7 @@ function OutboundLinkTracking () {
         var myDomain = href.match(getDomain);
 
         // If link is outbound and is not to this domain
-        if ((href.match(/^(https?:|\/\/)/i)  && !myDomain) || href.match(/^mailto\:/i)) {
+        if (typeof gtag === 'function' && (href.match(/^(https?:|\/\/)/i)  && !myDomain) || href.match(/^mailto\:/i)) {
 
           // Add an event to click
           addEvent(el[i],'click', function(e) {

--- a/app/webpacker/packs/outbound-link-tracking.js
+++ b/app/webpacker/packs/outbound-link-tracking.js
@@ -5,27 +5,26 @@ function OutboundLinkTracking () {
     }
   }
 
-
   function trackOutboundLinks () {
     if (document.getElementsByTagName) {
-      var el = document.getElementsByTagName('a');
-      var getDomain = document.domain.split('.').reverse()[1] + '.' + document.domain.split('.').reverse()[0];
+      var links = document.getElementsByTagName('a');
+      var getDomain = document.domain;
 
       // Look through each a element
-      for (var i = 0; i < el.length; i++) {
+      for (var i = 0; i < links.length; i++) {
         // Extract its href attribute
-        var href = (typeof(el[i].getAttribute('href')) == 'string' ) ? el[i].getAttribute('href') : '';
+        var href = (typeof(links[i].getAttribute('href')) == 'string' ) ? links[i].getAttribute('href') : '';
 
         // Query the href for the top level domain (xxxxx.com)
         var myDomain = href.match(getDomain);
 
-        // If link is outbound and is not to this domain
+        // If linking to another domain (except via email)
         if ((href.match(/^(https?:|\/\/)/i)  && !myDomain) || href.match(/^mailto\:/i)) {
 
           // Add an event to click
-          addEvent(el[i], 'click', function(e) {
+          addEvent(links[i], 'click', function(e) {
             var url = this.getAttribute('href');
-            var win = (typeof(this.getAttribute('target')) == 'string') ? this.getAttribute('target') : '';
+            var win = this.getAttribute('target');
 
             // Log event to Analytics, once done, go to the link
             gtag('event', 'click', {


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-661

We need to track clicks that send users to outbound urls, either through
the same window or through the a new tab. Add JS which does the following
taken from:
http://www.joehessert.com/seo/google-analytics-external-link-tracking
https://support.google.com/analytics/answer/7478520?hl=en

1) gets all links (our buttons that link to outside are just button styled
  links)
2) check the domain, and make sure its not a mailto/call link
3) Get the url target (same tab/different tab)
4) Log the click if its an outbound url using gtag event

Testing:
Use the heroku app to navigate to outside urls and look for events on realtime 
Tested on IE11 and seems reasonably ok, will confirm with Mak after his crossbrowser testing
https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon
