### PR TITLE
Fix caching in Health status endpoint

### DIFF
--- a/app/services/health_check/check_base.rb
+++ b/app/services/health_check/check_base.rb
@@ -10,6 +10,10 @@ module HealthCheck
       raise NotImplementedError
     end
 
+    def cached_status
+      detail[:status]
+    end
+
     def time
       Time.now.iso8601
     end

--- a/app/services/health_check/features_check.rb
+++ b/app/services/health_check/features_check.rb
@@ -7,10 +7,7 @@ module HealthCheck
     end
 
     def value
-      @value ||= Flipflop.health_check?
-    rescue StandardError => e
-      @output = "SplitIO error: #{e.inspect}"
-      false
+      @value ||= fetch_value
     end
 
     def unit
@@ -19,6 +16,15 @@ module HealthCheck
 
     def status
       value ? :pass : :fail
+    end
+
+    private
+
+    def fetch_value
+      Flipflop.health_check?
+    rescue StandardError => e
+      @output = "SplitIO error: #{e.inspect}"
+      false
     end
   end
 end

--- a/app/services/health_check/find_a_job_check.rb
+++ b/app/services/health_check/find_a_job_check.rb
@@ -7,10 +7,7 @@ module HealthCheck
     end
 
     def value
-      @value ||= FindAJobService.new.health_check
-    rescue FindAJobService::APIError => e
-      @output = "Find A Job API error: #{e.message}"
-      ''
+      @value ||= fetch_value
     end
 
     def unit
@@ -19,6 +16,15 @@ module HealthCheck
 
     def status
       value.present? ? :pass : :warn
+    end
+
+    private
+
+    def fetch_value
+      FindAJobService.new.health_check
+    rescue FindAJobService::APIError => e
+      @output = "Find A Job API error: #{e.message}"
+      ''
     end
   end
 end

--- a/app/services/health_check/notify_check.rb
+++ b/app/services/health_check/notify_check.rb
@@ -7,10 +7,7 @@ module HealthCheck
     end
 
     def value
-      @value ||= NotifyService.new.health_check
-    rescue Notifications::Client::RequestError, RuntimeError, ArgumentError => e
-      @output = "Notify API error: #{e.message}"
-      nil
+      @value ||= fetch_value
     end
 
     def unit
@@ -19,6 +16,15 @@ module HealthCheck
 
     def status
       value.present? ? :pass : :warn
+    end
+
+    private
+
+    def fetch_value
+      NotifyService.new.health_check
+    rescue Notifications::Client::RequestError, RuntimeError, ArgumentError => e
+      @output = "Notify API error: #{e.message}"
+      nil
     end
   end
 end

--- a/app/services/health_check/postcodes_check.rb
+++ b/app/services/health_check/postcodes_check.rb
@@ -7,10 +7,7 @@ module HealthCheck
     end
 
     def value
-      @value ||= Geocoder.coordinates('B1 2JP')
-    rescue SocketError, Timeout::Error, Geocoder::Error => e
-      @output = "Geocoder API error: #{e.message}"
-      []
+      @value ||= fetch_value
     end
 
     def unit
@@ -19,6 +16,15 @@ module HealthCheck
 
     def status
       value.present? ? :pass : :warn
+    end
+
+    private
+
+    def fetch_value
+      Geocoder.coordinates('B1 2JP')
+    rescue SocketError, Timeout::Error, Geocoder::Error => e
+      @output = "Geocoder API error: #{e.message}"
+      []
     end
   end
 end

--- a/app/services/health_check/report_service.rb
+++ b/app/services/health_check/report_service.rb
@@ -29,7 +29,7 @@ module HealthCheck
     private
 
     def statuses
-      @statuses ||= checks.map(&:status)
+      @statuses ||= checks.map(&:cached_status)
     end
 
     def checks

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'User personal data', type: :request do
+RSpec.describe 'Health check', type: :request do
   describe 'GET status#index' do
     let(:report) { { foo: 'bar' } }
     let(:health_check) { instance_double(HealthCheck::ReportService, report: report, status: status) }


### PR DESCRIPTION
We are currently caching details, but not the status, which makes internal calls to all endpoints again. Cache the status as well.

Also if an API is down, we are not memoizing the method result `value` as we are rescuing from exceptions, this causes the API to be called multiple times every time we invoke the method `value`. Change that so we only call it once