### PR TITLE
Update content as follows:

### DIFF
--- a/app/views/check_your_skills/_results_list.html.erb
+++ b/app/views/check_your_skills/_results_list.html.erb
@@ -2,7 +2,7 @@
   <% job_profiles.each do |job_profile| %>
     <li class="govuk-!-padding-bottom-3 govuk-!-padding-top-4">
       <h3 class="govuk-!-margin-0">
-        <%= link_to job_profile.name, job_profile_skills_path(job_profile.slug, search: params[:search]), class: 'govuk-link no-text-decoration' %>
+        <%= link_to job_profile.name, job_profile_skills_path(job_profile.slug, search: params[:search]), class: 'govuk-link' %>
       </h3>
       <% if job_profile.alternative_titles.present? %>
         <span class="govuk-visually-hidden">Alternative titles for this job include:</span>

--- a/app/views/check_your_skills/_search_form.html.erb
+++ b/app/views/check_your_skills/_search_form.html.erb
@@ -1,0 +1,3 @@
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-7"><%= t(:title, scope: scope) %></h1>
+<%= render "shared/search/results_form", search_path: results_check_your_skills_path, scope: 'check_your_skills.results' %>
+<p class="govuk-body-l govuk-!-margin-bottom-2"><%= t(:body, scope: scope) %></p>

--- a/app/views/check_your_skills/results.html.erb
+++ b/app/views/check_your_skills/results.html.erb
@@ -15,13 +15,7 @@
     <% if @job_profiles.blank? %>
       <%= render '/shared/search/no_results' %>
     <% else %>
-      <% if user_session.job_profile_skills? %>
-        <h1 class="govuk-heading-xl govuk-!-margin-bottom-7"><%= t(:title, scope: 'check_your_skills.results.additional_skills') %></h1>
-      <% else %>
-        <h1 class="govuk-heading-xl govuk-!-margin-bottom-7"><%= t('.title') %></h1>
-      <% end %>
-      <%= render "shared/search/results_form", search_path: results_check_your_skills_path, scope: 'check_your_skills.results' %>
-      <p class="govuk-body-l govuk-!-margin-bottom-2"><%= t('.body') %></p>
+      <%= render "search_form", scope: user_session.job_profile_skills? ? 'check_your_skills.results.additional_skills' : 'check_your_skills.results' %> 
       <%= render "results_list", job_profiles: @job_profiles %>
       <div class="govuk-grid-column-full govuk-!-padding-top-6 govuk-!-margin-bottom-4 govuk-!-margin-top-6 pagination__section">
         <%= paginate @job_profiles %>

--- a/app/views/check_your_skills/results.html.erb
+++ b/app/views/check_your_skills/results.html.erb
@@ -15,7 +15,11 @@
     <% if @job_profiles.blank? %>
       <%= render '/shared/search/no_results' %>
     <% else %>
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-7"><%= t('.title') %></h1>
+      <% if user_session.job_profile_skills? %>
+        <h1 class="govuk-heading-xl govuk-!-margin-bottom-7"><%= t(:title, scope: 'check_your_skills.results.additional_skills') %></h1>
+      <% else %>
+        <h1 class="govuk-heading-xl govuk-!-margin-bottom-7"><%= t('.title') %></h1>
+      <% end %>
       <%= render "shared/search/results_form", search_path: results_check_your_skills_path, scope: 'check_your_skills.results' %>
       <p class="govuk-body-l govuk-!-margin-bottom-2"><%= t('.body') %></p>
       <%= render "results_list", job_profiles: @job_profiles %>

--- a/app/views/shared/search/_form.html.erb
+++ b/app/views/shared/search/_form.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-xl"><%= t('title', scope: scope) %></h1>
 <p class="govuk-body-l"><%= t('body', scope: scope) %></p>
 <%= form_tag search_path, method: 'get' do %>
-  <%= form_group_tag @job_profile_search, :term, tag_class: ['job-search-form-group-tag'] do %>
+  <%= form_group_tag @job_profile_search, :term do %>
     <%= errors_tag @job_profile_search, :term %>
     <%= text_field(nil, :search, class: 'govuk-input search-input govuk-!-width-one-half', placeholder: t('placeholder', scope: scope), aria: { label: 'Search' }, data: { cy: 'search-field'}) %>
     <%= button_tag('Search', class: 'govuk-button search-button', aria: { label: 'Search button' }, data: { cy: 'search-field-submit-btn', module: 'govuk-button' }) %>

--- a/app/views/shared/search/_results_form.html.erb
+++ b/app/views/shared/search/_results_form.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-column-full govuk-!-padding-0">
   <%= form_tag search_path, method: 'get' do %>
-    <%= form_group_tag @job_profile_search, :term, tag_class: ['job-search-form-group-tag'] do %>
+    <%= form_group_tag @job_profile_search, :term do %>
       <%= errors_tag @job_profile_search, :term %>
       <%= text_field(nil, :search, value: params[:search], class: 'search-input govuk-input govuk-!-width-one-half', placeholder: t('placeholder', scope: scope), aria: { label: 'Search' }) %>
       <%= button_tag('Search', class: 'govuk-button search-button', aria: { label: 'Search button' }, data: { module: 'govuk-button' }) %>

--- a/app/webpacker/styles/_job-profile.scss
+++ b/app/webpacker/styles/_job-profile.scss
@@ -173,11 +173,3 @@
     padding-right: 0;
   }
 }
-
-.job-search-form-group-tag {
-  margin-bottom: 40px;
-
-  @include govuk-media-query($from: tablet) {
-    margin-bottom: 62px;
-  }
-}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,11 +98,12 @@ en-GB:
 
     results:
       title: Your current job
+      body: Select the job title that best matches what you do now. If you can’t see your job title, try searching with different words - for example, checkout operator instead of cashier.
       additional_skills:
         title: Your previous job
+        body: Select the job title that best matches your previous role. If you can’t see your job title, try searching with different words - for example, checkout operator instead of cashier.
       placeholder: Enter your current job title
       no_results: 0 results found - try again using a different job title
-      body: Select the job title that best matches what you do now. If you can’t see your job title, try searching with different words - for example, checkout operator instead of cashier.
   job_profiles_search:
     no_term_error: Enter a job title
   skills_matcher:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,9 +98,11 @@ en-GB:
 
     results:
       title: Your current job
+      additional_skills:
+        title: Your previous job
       placeholder: Enter your current job title
       no_results: 0 results found - try again using a different job title
-      body: Click the job title that best matches what you do now.
+      body: Select the job title that best matches what you do now. If you can’t see your job title, try searching with different words - for example, checkout operator instead of cashier.
   job_profiles_search:
     no_term_error: Enter a job title
   skills_matcher:

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -32,6 +32,32 @@ RSpec.feature 'Check your skills', type: :feature do
     expect(page).to have_text('Patience and the ability to remain calm in stressful situations')
   end
 
+  scenario 'When user adds the first job the results page should reflect that' do
+    visit(check_your_skills_path)
+    fill_in('search', with: 'Bodyguard')
+    find('.search-button').click
+
+    expect(page).to have_text('Your current job')
+  end
+
+  scenario 'When user adds previous job titles the results page should reflect that' do
+    hitman = create(
+      :job_profile,
+      :with_html_content,
+      name: 'Hitman5',
+      skills: [
+        create(:skill)
+      ]
+    )
+    visit(job_profile_skills_path(job_profile_id: hitman.slug))
+    click_on('Select these skills')
+    visit(check_your_skills_path)
+    fill_in('search', with: 'Bodyguard')
+    find('.search-button').click
+
+    expect(page).to have_text('Your previous job')
+  end
+
   scenario 'User enters an incorrect word but no api key is available' do
     visit(check_your_skills_path)
     fill_in('search', with: 'Gatas')


### PR DESCRIPTION
1. All job results titles are underlined now
2. New subtitle paragraph
3. When a user has already input a job, when adding new ones
one should see Your previous job title on results page
4. Remove job-search-form-group-tag tag class from the form as
it doesn't seem to be needed anymore.

![Screen Shot 2019-11-15 at 16 55 03](https://user-images.githubusercontent.com/1955084/68960748-baf9ad00-07c8-11ea-947f-b49d3577e312.png)

https://dfedigital.atlassian.net/browse/GET-642