### PR TITLE
All outbound links open in the same tab

### DIFF
--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -4,6 +4,6 @@
   <p class="govuk-body govuk-!-margin-bottom-0">Distance: <b><%= course.distance.round(1) %> miles</b></p>
   <p class="govuk-body-s"><%= course.full_address %></p>
   <p class="govuk-body-s">Tel:<%= link_to(course.phone_number, "tel:#{course.phone_number}", class: 'govuk-!-padding-left-1 govuk-link' ) %></p>
-  <%= link_to 'Visit website', course.url, class: 'govuk-!-margin-bottom-6 govuk-button', target: '_blank', aria: { label: "Visit website of #{course.provider}" }, data: { module: 'govuk-button', tracked_event: 'Courses - Clicked course link', tracked_event_props: { url: course.url } } %>
+  <%= link_to 'Visit website', course.url, class: 'govuk-!-margin-bottom-6 govuk-button', aria: { label: "Visit website of #{course.provider}" }, data: { module: 'govuk-button' } %>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-top-0">
 </li>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -31,7 +31,7 @@
       <% if @courses.empty? %>
         <p class="govuk-body-m">0 courses found</p>
         <p class="govuk-body-m">Get help to retrain isn't offering courses in your local area yet.</p>
-        <p class="govuk-body-m">Find training in your local area using the <%= link_to('Find a course service', 'https://nationalcareers.service.gov.uk/find-a-course', class: 'govuk-link', target: '_blank', data: { tracked_event: "Courses - Clicked 'Find a course service': https://nationalcareers.service.gov.uk/find-a-course" }) %> from the National Careers Service.</p>
+        <p class="govuk-body-m">Find training in your local area using the <%= link_to('Find a course service', 'https://nationalcareers.service.gov.uk/find-a-course', class: 'govuk-link') %> from the National Careers Service.</p>
         <h2 class="govuk-heading-s">Try again using a different postcode.</h2>
         <p class="govuk-body">You could try:</p>
         <ul class="govuk-list govuk-list--bullet">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -11,7 +11,7 @@
       <li>you're aged 24 or over</li>
       <li>and you're earning below £35,000 a year</li>
     </ul>
-    <p class="govuk-body">If these don’t all apply to you, try visiting the <%= link_to 'National Careers Service', 'https://nationalcareers.service.gov.uk/', class: 'govuk-link', target: '_blank' %> or your local <%= link_to 'Jobcentre Plus', 'https://find-your-nearest-jobcentre.dwp.gov.uk/', class: 'govuk-link', target: '_blank' %> instead.</p>
+    <p class="govuk-body">If these don’t all apply to you, try visiting the <%= link_to('National Careers Service', 'https://nationalcareers.service.gov.uk/', class: 'govuk-link') %> or your local <%= link_to('Jobcentre Plus', 'https://find-your-nearest-jobcentre.dwp.gov.uk/', class: 'govuk-link') %> instead.</p>
     <%= link_to @pid_or_task_list_path, class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8', role: 'button', data: { cy: 'start-now-btn', module: 'govuk-button' } do %>
       Start now
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">

--- a/app/views/job_vacancies/_job_vacancy.html.erb
+++ b/app/views/job_vacancies/_job_vacancy.html.erb
@@ -1,5 +1,5 @@
 <li>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><%= link_to job_vacancy.title, job_vacancy.url, class: 'govuk-link', target: '_blank', data: { tracked_event: "Jobs near me - Clicked '#{job_vacancy.title}'", tracked_event_props: { url: job_vacancy.url } } %></h2>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><%= link_to job_vacancy.title, job_vacancy.url, class: 'govuk-link' %></h2>
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><span class="govuk-visually-hidden">Date posted:</span><%= job_vacancy.formatted_date_posted %></h3>
   <p class="govuk-body govuk-!-margin-bottom-0"><span class="govuk-visually-hidden">Company and location:</span><%= job_vacancy.company_and_location %></p>
   <p class="govuk-body govuk-!-margin-bottom-1"><span class="govuk-visually-hidden">Salary:</span><b><%= job_vacancy.salary %></b></p>

--- a/app/views/job_vacancies/index.html.erb
+++ b/app/views/job_vacancies/index.html.erb
@@ -14,7 +14,7 @@
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= target_job.name %> jobs near me</h1>
-    <p class="govuk-body">These jobs within 20 miles of your postcode are currently being advertised in the <%= link_to('Find a job', 'https://findajob.dwp.gov.uk/', class: 'govuk-link', target: '_blank', data: { tracked_event: "Jobs near me - Clicked 'Find a job'", tracked_event_props: { url: 'https://findajob.dwp.gov.uk/' } }) %> service from the Department for Work and Pensions.</p>
+    <p class="govuk-body">These jobs within 20 miles of your postcode are currently being advertised in the <%= link_to('Find a job', 'https://findajob.dwp.gov.uk/', class: 'govuk-link') %> service from the Department for Work and Pensions.</p>
     <div class="govuk-grid-column-full govuk-!-padding-0">
       <%= form_with model: @job_vacancy_search, local: true, url: jobs_near_me_path do |form| %>
         <%= form_group_tag @job_vacancy_search, :postcode do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
           <p class="govuk-phase-banner__content">
             <strong class="govuk-tag govuk-phase-banner__content__tag">beta</strong>
             <span class="govuk-phase-banner__text">
-              This is a new service – your <%= link_to 'feedback', 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link', target: '_blank', data: { tracked_event: 'Banner - User Exit Survey Link', tracked_event_props: { url: 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/' } }%> will help us to improve it.
+              This is a new service – your <%= link_to('feedback', 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', class: 'govuk-link') %> will help us to improve it.
             </span>
           </p>
         </div>

--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -19,7 +19,7 @@
       <li>remember who you are if you return to your saved results so we can show you your information and information relevant to you</li>
     </ul>
     <p class="govuk-body">‘Get help to retrain’ cookies aren’t used to identify you personally. We record tracking information anonymously, so cookies do not track your personal data, only your activity on the site.</p>
-    <p class="govuk-body">Find out more about cookies on <%= link_to('GOV.UK', 'https://www.gov.uk/help/cookie-details', target: '_blank', class: 'govuk-link') %>.</p>
+    <p class="govuk-body">Find out more about cookies on <%= link_to('GOV.UK', 'https://www.gov.uk/help/cookie-details', class: 'govuk-link') %>.</p>
 
     <h2 class="govuk-heading-m">How we use cookies</h2>
     <p class="govuk-body">We use Google Analytics and Azure Application Insights software as well as service-specific cookies to collect information about how you use ‘Get help to retrain’. We do this to help make sure the service is meeting the needs of its users and to help us make improvements.</p>
@@ -110,7 +110,7 @@
     </table>
 
     <p class="govuk-body">They always need to be on.</p>
-    <p class="govuk-body">You can find more information about <%= link_to('Azure Application Insights', 'https://azure.microsoft.com/en-gb/services/monitor/',  target: '_blank', class: 'govuk-link') %>‎.</p>
+    <p class="govuk-body">You can find more information about <%= link_to('Azure Application Insights', 'https://azure.microsoft.com/en-gb/services/monitor/', class: 'govuk-link') %>‎.</p>
 
     <h3 class="govuk-heading-s">Measuring website usage using Google Analytics</h3>
     <p class="govuk-body">This software stores information about:</p>
@@ -144,6 +144,6 @@
       </tbody>
     </table>
 
-    <p class="govuk-body">You can opt out of <%= link_to('Google Analytics', 'https://tools.google.com/dlpage/gaoptout', target: '_blank', class: 'govuk-link') %>.</p>
+    <p class="govuk-body">You can opt out of <%= link_to('Google Analytics', 'https://tools.google.com/dlpage/gaoptout', class: 'govuk-link') %>.</p>
   </div>
 </div>

--- a/app/views/pages/location_ineligible.html.erb
+++ b/app/views/pages/location_ineligible.html.erb
@@ -13,7 +13,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
     <p class="govuk-body-m">The service will be rolled out across England during 2020. In the meantime you can use it to check your existing skills and explore the types of jobs you could apply for.</p>
-    <p class="govuk-body-m">Find more training and careers advice for your area through the <%= link_to 'National Careers Service', 'https://nationalcareers.service.gov.uk/', class: 'govuk-link', target: '_blank' %>.</p>
+    <p class="govuk-body-m">Find more training and careers advice for your area through the <%= link_to('National Careers Service', 'https://nationalcareers.service.gov.uk/', class: 'govuk-link') %>.</p>
     <%= link_to 'Continue', task_list_path, class: 'govuk-button', data: { module: 'govuk-button' } %>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -41,9 +41,9 @@
       <li>to object to direct marketing (including profiling) and processing for the purposes of scientific/historical research and statistics</li>
       <li>not to be subject to decisions based purely on automated processing where it produces a legal or similarly significant effect on you</li>
     </ul>
-    <p class="govuk-body">You can <%= link_to('find out more about your data protection rights', 'https://ico.org.uk/global/privacy-notice/your-data-protection-rights', target: '_blank', class: 'govuk-link') %> on the Information Commissioner’s website.</p>
+    <p class="govuk-body">You can <%= link_to('find out more about your data protection rights', 'https://ico.org.uk/global/privacy-notice/your-data-protection-rights', class: 'govuk-link') %> on the Information Commissioner’s website.</p>
     <h2 class="govuk-heading-m">The right to lodge a complaint</h2>
-    <p class="govuk-body">You have the right to raise any concerns with the Information Commissioner’s Office (ICO) via their website at <%= link_to('https://ico.org.uk/concerns/', 'https://ico.org.uk/concerns/', target: '_blank', class: 'govuk-link') %>.<p>
+    <p class="govuk-body">You have the right to raise any concerns with the Information Commissioner’s Office (ICO) via their website at <%= link_to('https://ico.org.uk/concerns/', 'https://ico.org.uk/concerns/', class: 'govuk-link') %>.<p>
     <h2 class="govuk-heading-m">Last updated</h2>
     <p class="govuk-body">This version was last updated on 04 October 2019.</p>
     <h2 class="govuk-heading-m">Contact us</h2>
@@ -53,7 +53,7 @@
       <li>Or by post at Emma Wharram, Departmental Data Protection Officer, 2 Rivergate, Bristol, BS1 6EW</li>
     </ul>
     <h2 class="govuk-heading-m govuk-!-margin-top-6">How to find out what personal information we hold about you</h2>
-    <p class="govuk-body">To find out what personal information we hold about you, or to exercise any of your rights you can contact us using the question option on our <%= link_to('Contact Form', 'https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen', target: '_blank', class: 'govuk-link') %> and select ‘something else’.</p>
+    <p class="govuk-body">To find out what personal information we hold about you, or to exercise any of your rights you can contact us using the question option on our <%= link_to('Contact Form', 'https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen', class: 'govuk-link') %> and select ‘something else’.</p>
     <p class="govuk-body">Please be as specific as you can about the personal information that you are asking us about. If possible, state which part of the department is holding the information and why they hold it.</p>
     <p class="govuk-body">If we cannot satisfactorily confirm or establish your identity, we will request for proof of your identity so we can check your right to access the information and to ensure that we only disclose your personal information to the right person(s).</p>
     <p class="govuk-body">We should respond to your request within one month of receiving it. If your request is complex, we may extend the period by a further two months. In those circumstances, we will let you know of the extended time within one month of receiving your request and explain to you why the extension is necessary.</p>

--- a/app/views/pages/task_list_items/_item_4.html.erb
+++ b/app/views/pages/task_list_items/_item_4.html.erb
@@ -5,7 +5,7 @@
   <ul class="app-task-list__items">
     <li class="app-task-list__item">
       <div class="app-task-list__task-name">
-        <%= link_or_blocked(path: 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', enabled:  user_session.job_profile_skills? && user_session.target_job?, span_id: 4, data: { tracked_event: 'TaskList - User Exit Survey Link' }, target: '_blank') do %>
+        <%= link_or_blocked(path: 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/', enabled:  user_session.job_profile_skills? && user_session.target_job?, span_id: 4) do %>
           Take a quick survey
         <% end %>
         <p class="govuk-body govuk-!-margin-bottom-0">Tell us about your experience using Get help to retrain.</p>

--- a/app/views/shared/_help_improve_this_service.html.erb
+++ b/app/views/shared/_help_improve_this_service.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-related-items govuk-!-padding-bottom-4 top-border__container">
   <h2 class="govuk-heading-m"><%= t('help_improve_this_service.title') %></h2>
   <p class="govuk-body-m">
-    <%= link_to t('help_improve_this_service.body'), 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/' , class: 'govuk-link', target: '_blank', data: { tracked_event: 'Courses - Help improve this service survey link', tracked_event_props: { url: 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/' } } %>
+    <%= link_to(t('help_improve_this_service.body'), 'https://www.smartsurvey.co.uk/s/get-help-to-retrain/' , class: 'govuk-link') %>
   </p>
 </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -14,7 +14,7 @@
         {
           "type": "template",
           "name": "courses/index",
-          "line": 53,
+          "line": 43,
           "file": "app/views/courses/index.html.erb",
           "rendered": {
             "name": "courses/_course",
@@ -59,38 +59,8 @@
       "user_input": "(Unresolved Model).new.url",
       "confidence": "Weak",
       "note": "The attribute value is escaped at storage level as part of ActiveRecord behaviour. There is no danger."
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "fac0e5ac35ed48cc22ccb7d506848bd6589458e07ed263582f7a9c4b79467794",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/job_vacancies/_job_vacancy.html.erb",
-      "line": 2,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to((Unresolved Model).new.title, (Unresolved Model).new.url, :class => \"govuk-link\", :target => \"_blank\", :data => ({ :tracked_event => (\"Jobs near me - Clicked '#{(Unresolved Model).new.title}'\"), :tracked_event_props => ({ :url => (Unresolved Model).new.url }) }))",
-      "render_path": [
-        {
-          "type": "template",
-          "name": "job_vacancies/index",
-          "line": 41,
-          "file": "app/views/job_vacancies/index.html.erb",
-          "rendered": {
-            "name": "job_vacancies/_job_vacancy",
-            "file": "app/views/job_vacancies/_job_vacancy.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "job_vacancies/_job_vacancy"
-      },
-      "user_input": "(Unresolved Model).new.url",
-      "confidence": "Weak",
-      "note": ""
     }
   ],
-  "updated": "2019-11-18 15:24:49 +0000",
+  "updated": "2019-11-18 16:45:08 +0000",
   "brakeman_version": "4.7.1"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -33,36 +33,6 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
-      "fingerprint": "c7d3557a0330aa983694942103ea896d4f99430adb262089403d57987432d856",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/courses/_course.html.erb",
-      "line": 7,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"Visit website\", (Unresolved Model).new.url, :class => \"govuk-!-margin-bottom-6 govuk-button\", :target => \"_blank\", :aria => ({ :label => (\"Visit website of #{(Unresolved Model).new.provider}\") }), :data => ({ :module => \"govuk-button\", :tracked_event => \"Courses - Clicked course link\", :tracked_event_props => ({ :url => (Unresolved Model).new.url }) }))",
-      "render_path": [
-        {
-          "type": "template",
-          "name": "courses/index",
-          "line": 53,
-          "file": "app/views/courses/index.html.erb",
-          "rendered": {
-            "name": "courses/_course",
-            "file": "app/views/courses/_course.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "courses/_course"
-      },
-      "user_input": "(Unresolved Model).new.url",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
       "fingerprint": "f69515401ea52a993411003a30274e78738e810e45dd181d84d235e504cc51de",
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,6 +3,36 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
+      "fingerprint": "94ee8acee565270826d7c0d23287a262ebb719194e83207a83de31cd19cdf3a2",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/courses/_course.html.erb",
+      "line": 7,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(\"Visit website\", (Unresolved Model).new.url, :class => \"govuk-!-margin-bottom-6 govuk-button\", :aria => ({ :label => (\"Visit website of #{(Unresolved Model).new.provider}\") }), :data => ({ :module => \"govuk-button\" }))",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "courses/index",
+          "line": 53,
+          "file": "app/views/courses/index.html.erb",
+          "rendered": {
+            "name": "courses/_course",
+            "file": "app/views/courses/_course.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "courses/_course"
+      },
+      "user_input": "(Unresolved Model).new.url",
+      "confidence": "Weak",
+      "note": "The attribute value is escaped at storage level as part of ActiveRecord behaviour. There is no danger."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
       "fingerprint": "c7d3557a0330aa983694942103ea896d4f99430adb262089403d57987432d856",
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
@@ -29,6 +59,36 @@
       "user_input": "(Unresolved Model).new.url",
       "confidence": "Weak",
       "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "f69515401ea52a993411003a30274e78738e810e45dd181d84d235e504cc51de",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/job_vacancies/_job_vacancy.html.erb",
+      "line": 2,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to((Unresolved Model).new.title, (Unresolved Model).new.url, :class => \"govuk-link\")",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "job_vacancies/index",
+          "line": 42,
+          "file": "app/views/job_vacancies/index.html.erb",
+          "rendered": {
+            "name": "job_vacancies/_job_vacancy",
+            "file": "app/views/job_vacancies/_job_vacancy.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "job_vacancies/_job_vacancy"
+      },
+      "user_input": "(Unresolved Model).new.url",
+      "confidence": "Weak",
+      "note": "The attribute value is escaped at storage level as part of ActiveRecord behaviour. There is no danger."
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -61,6 +121,6 @@
       "note": ""
     }
   ],
-  "updated": "2019-10-31 10:08:44 +0000",
-  "brakeman_version": "4.5.1"
+  "updated": "2019-11-18 15:24:49 +0000",
+  "brakeman_version": "4.7.1"
 }

--- a/spec/features/task_list_spec.rb
+++ b/spec/features/task_list_spec.rb
@@ -41,12 +41,7 @@ RSpec.feature 'Task list', type: :feature do
 
     link = find_link('feedback')
 
-    expect([link[:href], link[:target]]).to eq(
-      [
-        'https://www.smartsurvey.co.uk/s/get-help-to-retrain/',
-        '_blank'
-      ]
-    )
+    expect(link[:href]).to eq('https://www.smartsurvey.co.uk/s/get-help-to-retrain/')
   end
 
   scenario 'With a clean new session the user will see sections 2,3,4 locked' do
@@ -158,11 +153,6 @@ RSpec.feature 'Task list', type: :feature do
 
     link = find_link('Take a quick survey')
 
-    expect([link[:href], link[:target]]).to eq(
-      [
-        'https://www.smartsurvey.co.uk/s/get-help-to-retrain/',
-        '_blank'
-      ]
-    )
+    expect(link[:href]).to eq('https://www.smartsurvey.co.uk/s/get-help-to-retrain/')
   end
 end

--- a/spec/helpers/task_list_helper_spec.rb
+++ b/spec/helpers/task_list_helper_spec.rb
@@ -20,13 +20,11 @@ RSpec.describe TaskListHelper do
         helper.link_or_blocked(
           path: 'some-path',
           enabled: true,
-          span_id: 1,
-          data: { tracked_event: 'task' },
-          target: '_blank'
+          span_id: 1
         ) { 'some text' }
       ).to eq(
         <<~HTML.strip
-          <a class="#{expected_classes}" data-tracked-event="task" target="_blank" href="some-path">some text</a>
+          <a class="#{expected_classes}" href="some-path">some text</a>
         HTML
       )
     end


### PR DESCRIPTION
Now that we have these links tracked in GA, we can drop
the tracked-event data attribute as we don't need to track
them in AppInsights.

NOTE:

We can not yet get rid of TrackEvents() JS function as
we still need to track the interraction on our inpage
smart survey(`shared/feedback/_survey.html.erb`) Once we implement GA backend tracking,
we can drop this script.

![Screen Shot 2019-11-18 at 14 38 48](https://user-images.githubusercontent.com/1955084/69062945-89285680-0a13-11ea-9b21-b59bbfd92f5b.png)

### Testing

Set GOOGLE_ANALYTICS_TRACKING_ID to the workspace you want to use (I used QA) and see the outbound events coming though in real-time.
