### PR TITLE
GET-637 Do not redirect from skills page when no skills available, also params cleanup

### DIFF
--- a/app/controllers/job_profiles_controller.rb
+++ b/app/controllers/job_profiles_controller.rb
@@ -13,7 +13,7 @@ class JobProfilesController < ApplicationController
     user_session.remove_job_profile(resource.id)
 
     redirect_to(
-      skills_path(query_params), notice: t('.notice', name: resource.name.downcase)
+      skills_path, notice: t('.notice', name: resource.name.downcase)
     )
   end
 
@@ -24,15 +24,7 @@ class JobProfilesController < ApplicationController
   end
 
   def job_profile_params
-    params.permit(:job_profile_id, :search, :id)
-  end
-
-  def query_params
-    # TODO: this is to support skills removal. Revisit after fixing navigation
-    query = { search: job_profile_params[:search] }
-    query[:job_profile_id] = job_profile_params[:job_profile_id] unless user_session.job_profile_skills?
-
-    query
+    params.permit(:search, :id)
   end
 
   def job_vacancy_count

--- a/app/controllers/job_profiles_skills_controller.rb
+++ b/app/controllers/job_profiles_skills_controller.rb
@@ -1,11 +1,11 @@
 class JobProfilesSkillsController < ApplicationController
   def index
     if profile_skills_not_editable? && user_session.job_profiles_cap_reached?
-      redirect_to_profile_skills_page
+      redirect_to skills_path
     else
       skills_builder.build
 
-      return redirect_to_profile_skills_page if skills_valid?
+      return redirect_to skills_path if skills_valid?
 
       render('job_profiles/skills/index')
     end
@@ -35,11 +35,5 @@ class JobProfilesSkillsController < ApplicationController
 
   def profile_skills_not_editable?
     user_session.job_profile_ids.exclude?(job_profile.id)
-  end
-
-  def redirect_to_profile_skills_page
-    redirect_to(
-      skills_path(job_profile_id: skills_params[:job_profile_id], search: skills_params[:search])
-    )
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,12 +4,6 @@ class PagesController < ApplicationController
   end
 
   def task_list
-    if user_session.job_profile_skills?
-      current_job = JobProfile.find(user_session.job_profile_ids.first)
-
-      @skills_summary_path = skills_path(job_profile_id: current_job.slug)
-    else
-      @skills_summary_path = check_your_skills_path
-    end
+    @skills_summary_path = user_session.job_profile_skills? ? skills_path : check_your_skills_path
   end
 end

--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -1,9 +1,5 @@
 class SkillsController < ApplicationController
   def index
-    return redirect_to task_list_path unless
-      skills_params[:job_profile_id].present? ||
-      (job_profiles.any? && user_session.skill_ids.any?)
-
     @job_profiles_with_skills = job_profiles.map { |job_profile|
       skill_ids_from_session = user_session.skill_ids_for_profile(job_profile.id)
 
@@ -17,9 +13,5 @@ class SkillsController < ApplicationController
 
   def job_profiles
     @job_profiles ||= JobProfile.includes(:skills).find(user_session.job_profile_ids)
-  end
-
-  def skills_params
-    params.permit(:job_profile_id)
   end
 end

--- a/app/views/job_profiles/skills/index.html.erb
+++ b/app/views/job_profiles/skills/index.html.erb
@@ -40,7 +40,7 @@
             </div>
           </fieldset>
         <% end %>
-        <%= button_tag('Select these skills', class: 'govuk-button', aria: { label: 'Select these skills button' }, data: { cy: 'select-skills-btn', module: 'govuk-button' }) %>
+        <%= button_tag('Select these skills', class: 'govuk-button', name: nil, aria: { label: 'Select these skills button' }, data: { cy: 'select-skills-btn', module: 'govuk-button' }) %>
       <% end %>
     </div>
   </div>

--- a/app/views/shared/search/_form.html.erb
+++ b/app/views/shared/search/_form.html.erb
@@ -4,6 +4,6 @@
   <%= form_group_tag @job_profile_search, :term do %>
     <%= errors_tag @job_profile_search, :term %>
     <%= text_field(nil, :search, class: 'govuk-input search-input govuk-!-width-one-half', placeholder: t('placeholder', scope: scope), aria: { label: 'Search' }, data: { cy: 'search-field'}) %>
-    <%= button_tag('Search', class: 'govuk-button search-button', aria: { label: 'Search button' }, data: { cy: 'search-field-submit-btn', module: 'govuk-button' }) %>
+    <%= button_tag('Search', class: 'govuk-button search-button', name: nil, aria: { label: 'Search button' }, data: { cy: 'search-field-submit-btn', module: 'govuk-button' }) %>
   <% end %>
 <% end %>

--- a/app/views/shared/search/_results_form.html.erb
+++ b/app/views/shared/search/_results_form.html.erb
@@ -3,7 +3,7 @@
     <%= form_group_tag @job_profile_search, :term do %>
       <%= errors_tag @job_profile_search, :term %>
       <%= text_field(nil, :search, value: params[:search], class: 'search-input govuk-input govuk-!-width-one-half', placeholder: t('placeholder', scope: scope), aria: { label: 'Search' }) %>
-      <%= button_tag('Search', class: 'govuk-button search-button', aria: { label: 'Search button' }, data: { module: 'govuk-button' }) %>
+      <%= button_tag('Search', class: 'govuk-button search-button', name: nil, aria: { label: 'Search button' }, data: { module: 'govuk-button' }) %>
       <%= render 'shared/search/spell_check' %>
     <% end %>
   <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -20,7 +20,7 @@
         <%= text_field_tag(:email, params.fetch(:email, nil), class: css_classes_for_input(@user, :email, "govuk-input govuk-!-width-two-thirds"), autocomplete: 'email') %>
       <% end %>
       <p class="govuk-body">We'll send you a confirmation email to this email address.</p>
-      <%= button_tag('Save your results', class: 'govuk-button', data: { module: 'govuk-button' }) %>
+      <%= button_tag('Save your results', class: 'govuk-button', name: nil, data: { module: 'govuk-button' }) %>
     <% end %>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/app/views/users/return_to_saved_results.html.erb
+++ b/app/views/users/return_to_saved_results.html.erb
@@ -20,7 +20,7 @@
         <%= errors_tag @user, :email %>
         <%= text_field_tag(:email, params.fetch(:email, nil), class: css_classes_for_input(@user, :email, "govuk-input govuk-!-width-two-thirds"), autocomplete: 'email') %>
       <% end %>
-      <%= button_tag('Send link', class: 'govuk-button', data: { module: 'govuk-button' }, aria: { label: 'Send a link to my Email address to access my saved results' }) %>
+      <%= button_tag('Send link', class: 'govuk-button', name: nil, data: { module: 'govuk-button' }, aria: { label: 'Send a link to my Email address to access my saved results' }) %>
     <% end %>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/spec/features/skills_builder_spec.rb
+++ b/spec/features/skills_builder_spec.rb
@@ -270,17 +270,17 @@ RSpec.feature 'Build your skills', type: :feature do
     expect(page).to have_text(/Select at least one skill/)
   end
 
-  scenario 'redirects from skills page if no skills present on session for a job profile' do
+  scenario 'remains on skills page if no skills present on session for a job profile' do
     unselect_all_skills_for(job_profile)
     visit(skills_path)
 
-    expect(page).to have_current_path(task_list_path)
+    expect(page).to have_current_path(skills_path)
   end
 
-  scenario 'redirected to task list path if no job profile selected' do
+  scenario 'remains on skills path if no job profile selected' do
     visit(skills_path)
 
-    expect(page).to have_current_path(task_list_path)
+    expect(page).to have_current_path(skills_path)
   end
 
   scenario 'shows no skills selected if job profile selected but no skills selected' do

--- a/spec/features/task_list_spec.rb
+++ b/spec/features/task_list_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature 'Task list', type: :feature do
     visit(task_list_path)
     click_on('Check your existing skills')
 
-    expect(page).to have_current_path(skills_path(job_profile_id: job_profile.slug))
+    expect(page).to have_current_path(skills_path)
   end
 
   scenario 'With a clean new session the user will not be able to click sections 2,3,4' do


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-637

* If there are no skills stay on page
* If there is no params remain on page
* Cleanup params for search/job profile id as they are no longer required for breadcrumbs or page logic
* Cleanup button params