### PR TITLE
Update styling for course titles/subtitle

### DIFF
--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -1,6 +1,6 @@
 <li>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-heading-l title"><%= course.title %></h2>
-  <h3 class="govuk-heading-s govuk-!-margin-bottom-0 muted-text"><span class="govuk-visually-hidden">Provider:</span><%= course.provider %></h3>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-heading-l"><%= course.title %></h2>
+  <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><span class="govuk-visually-hidden">Provider:</span><%= course.provider %></h3>
   <p class="govuk-body govuk-!-margin-bottom-0">Distance: <b><%= course.distance.round(1) %> miles</b></p>
   <p class="govuk-body-s"><%= course.full_address %></p>
   <p class="govuk-body-s">Tel:<%= link_to(course.phone_number, "tel:#{course.phone_number}", class: 'govuk-!-padding-left-1 govuk-link' ) %></p>

--- a/app/webpacker/styles/_course.scss
+++ b/app/webpacker/styles/_course.scss
@@ -1,3 +1,0 @@
-.title {
-  color: $govuk-link-colour;
-}

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -3,7 +3,6 @@
 @import "contact-us";
 @import "task-list";
 @import "pagination";
-@import "course";
 @import "user_feedback";
 @import "user";
 @import "skills-builder";


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-703

### Changes proposed in this pull request
Tweaked styles, removed redundant stylesheet for courses as it's now empty - removed class is not used elsewhere.

### Guidance to review
Just check english and maths course results page.
