### PR TITLE
Add batch processing to the TrackingService

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,9 +29,9 @@ class ApplicationController < ActionController::Base
     event_label = I18n.t(event_key, scope: :events)
 
     track_events(
-      event_key,
       [
         {
+          key: event_key,
           label: event_label,
           value: event_value
         }
@@ -39,8 +39,8 @@ class ApplicationController < ActionController::Base
     )
   end
 
-  def track_events(event_key, props = [])
-    TrackingService.new.track_events(key: event_key, props: props)
+  def track_events(props = [])
+    TrackingService.new.track_events(props: props)
   rescue TrackingService::TrackingServiceError
     nil
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include Passwordless::ControllerHelpers
+  include GaTrackingHelper
 
   before_action :set_raven_context
 
@@ -24,10 +25,22 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def track_event(event_key, value = nil)
+  def track_event(event_key, event_value)
     event_label = I18n.t(event_key, scope: :events)
 
-    TrackingService.new.track_event(key: event_key, label: event_label, value: value)
+    track_events(
+      event_key,
+      [
+        {
+          label: event_label,
+          value: event_value
+        }
+      ]
+    )
+  end
+
+  def track_events(event_key, props = [])
+    TrackingService.new.track_events(key: event_key, props: props)
   rescue TrackingService::TrackingServiceError
     nil
   end

--- a/app/controllers/job_profiles_skills_controller.rb
+++ b/app/controllers/job_profiles_skills_controller.rb
@@ -6,7 +6,7 @@ class JobProfilesSkillsController < ApplicationController
       skills_builder.build
 
       if skills_valid?
-        track_selections(:skills_builder, selected: selected_skills, unselected: unselected_skills)
+        track_selections(selected: selected_skills, unselected: unselected_skills)
 
         return redirect_to skills_path
       end
@@ -53,14 +53,16 @@ class JobProfilesSkillsController < ApplicationController
 
   def selected_skills
     {
-      label: "#{job_profile.name} - Ticked",
+      key: :skills_builder_ticked,
+      label: job_profile.name,
       values: available_skills.slice(*user_skill_ids).values
     }
   end
 
   def unselected_skills
     {
-      label: "#{job_profile.name} - Unticked",
+      key: :skills_builder_unticked,
+      label: job_profile.name,
       values: available_skills.except(*user_skill_ids).values
     }
   end

--- a/app/controllers/job_profiles_skills_controller.rb
+++ b/app/controllers/job_profiles_skills_controller.rb
@@ -5,7 +5,11 @@ class JobProfilesSkillsController < ApplicationController
     else
       skills_builder.build
 
-      return redirect_to skills_path if skills_valid?
+      if skills_valid?
+        track_selections(:skills_builder, selected: selected_skills, unselected: unselected_skills)
+
+        return redirect_to skills_path
+      end
 
       render('job_profiles/skills/index')
     end
@@ -35,5 +39,29 @@ class JobProfilesSkillsController < ApplicationController
 
   def profile_skills_not_editable?
     user_session.job_profile_ids.exclude?(job_profile.id)
+  end
+
+  def available_skills
+    @available_skills ||= job_profile.skills.each_with_object({}) do |skill, hash|
+      hash[skill.id.to_s] = skill.name
+    end
+  end
+
+  def user_skill_ids
+    @user_skill_ids ||= skills_params[:skill_ids].reject(&:empty?)
+  end
+
+  def selected_skills
+    {
+      label: "#{job_profile.name} - Ticked",
+      values: available_skills.slice(*user_skill_ids).values
+    }
+  end
+
+  def unselected_skills
+    {
+      label: "#{job_profile.name} - Unticked",
+      values: available_skills.except(*user_skill_ids).values
+    }
   end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -10,9 +10,8 @@ class QuestionsController < ApplicationController
     user_session.training = questions_params[:training] || []
 
     track_selections(
-      :training,
-      selected: selected_options_for(:training),
-      unselected: unselected_options_for(:training)
+      selected: selected_options_for('training'),
+      unselected: unselected_options_for('training')
     )
 
     redirect_to helpers.job_hunting_questions || action_plan_path
@@ -22,9 +21,8 @@ class QuestionsController < ApplicationController
     user_session.job_hunting = questions_params[:job_hunting] || []
 
     track_selections(
-      :job_hunting,
-      selected: selected_options_for(:job_hunting),
-      unselected: unselected_options_for(:job_hunting)
+      selected: selected_options_for('job_hunting'),
+      unselected: unselected_options_for('job_hunting')
     )
 
     redirect_to action_plan_path
@@ -34,15 +32,17 @@ class QuestionsController < ApplicationController
 
   def selected_options_for(section)
     {
-      label: I18n.t(section, action: 'Ticked', scope: 'events'),
-      values: user_answers_for(section)
+      key: "#{section}_ticked".to_sym,
+      label: I18n.t(section, scope: 'events'),
+      values: user_answers_for(section.to_sym)
     }
   end
 
   def unselected_options_for(section)
     {
-      label: I18n.t(section, action: 'Unticked', scope: 'events'),
-      values: AVAILABLE_OPTIONS[section] - user_answers_for(section)
+      key: "#{section}_unticked".to_sym,
+      label: I18n.t(section, scope: 'events'),
+      values: AVAILABLE_OPTIONS[section.to_sym] - user_answers_for(section)
     }
   end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,22 +1,59 @@
 class QuestionsController < ApplicationController
   before_action :redirect_unless_target_job
 
+  AVAILABLE_OPTIONS = {
+    training: %w[english_skills math_skills],
+    job_hunting: %w[cv cover_letter interviews]
+  }.freeze
+
   def training_answers
     user_session.training = questions_params[:training] || []
+
+    track_selections(
+      :training,
+      selected: selected_options_for(:training),
+      unselected: unselected_options_for(:training)
+    )
+
     redirect_to helpers.job_hunting_questions || action_plan_path
   end
 
   def job_hunting_answers
     user_session.job_hunting = questions_params[:job_hunting] || []
+
+    track_selections(
+      :job_hunting,
+      selected: selected_options_for(:job_hunting),
+      unselected: unselected_options_for(:job_hunting)
+    )
+
     redirect_to action_plan_path
   end
 
   private
+
+  def selected_options_for(section)
+    {
+      label: I18n.t(section, action: 'Ticked', scope: 'events'),
+      values: user_answers_for(section)
+    }
+  end
+
+  def unselected_options_for(section)
+    {
+      label: I18n.t(section, action: 'Unticked', scope: 'events'),
+      values: AVAILABLE_OPTIONS[section] - user_answers_for(section)
+    }
+  end
 
   def questions_params
     params.permit(
       training: [],
       job_hunting: []
     )
+  end
+
+  def user_answers_for(section)
+    questions_params[section] || []
   end
 end

--- a/app/helpers/ga_tracking_helper.rb
+++ b/app/helpers/ga_tracking_helper.rb
@@ -1,0 +1,25 @@
+module GaTrackingHelper
+  def track_selections(event_key, selected: {}, unselected: {})
+    return unless selected.present? || unselected.present?
+
+    event_props = [selected, unselected].map { |option|
+      build_event_props(label: option[:label], values: option[:values])
+    }.flatten
+
+    track_events(
+      event_key,
+      event_props
+    )
+  end
+
+  private
+
+  def build_event_props(label:, values:)
+    values.map do |value|
+      {
+        label: label,
+        value: value
+      }
+    end
+  end
+end

--- a/app/helpers/ga_tracking_helper.rb
+++ b/app/helpers/ga_tracking_helper.rb
@@ -1,22 +1,22 @@
 module GaTrackingHelper
-  def track_selections(event_key, selected: {}, unselected: {})
+  def track_selections(selected: {}, unselected: {})
     return unless selected.present? || unselected.present?
 
     event_props = [selected, unselected].map { |option|
-      build_event_props(label: option[:label], values: option[:values])
+      build_event_props(key: option[:key], label: option[:label], values: option[:values])
     }.flatten
 
     track_events(
-      event_key,
       event_props
     )
   end
 
   private
 
-  def build_event_props(label:, values:)
+  def build_event_props(key:, label:, values:)
     values.map do |value|
       {
+        key: key,
         label: label,
         value: value
       }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,8 @@ en-GB:
     courses_index_search: Courses near me - Postcode search
     skills_index_selected: Current job skills - Skills selected
     user_personal_information_skipped: User personal information - Skip this step link clicked
+    job_hunting: Get help with your job hunting skills - %{action}
+    training: Check your maths and English skills - %{action}
 
   contact_us:
     title: Free local advice

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,8 +72,8 @@ en-GB:
     courses_index_search: Courses near me - Postcode search
     skills_index_selected: Current job skills - Skills selected
     user_personal_information_skipped: User personal information - Skip this step link clicked
-    job_hunting: Get help with your job hunting skills - %{action}
-    training: Check your maths and English skills - %{action}
+    job_hunting: Get help with your job hunting skills
+    training: Check your maths and English skills
 
   contact_us:
     title: Free local advice

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -154,10 +154,10 @@ RSpec.feature 'Check your skills', type: :feature do
     find('.search-button').click
 
     expect(tracking_service).to have_received(:track_events).with(
-      key: :check_your_skills_index_search,
       props:
       [
         {
+          key: :check_your_skills_index_search,
           label: 'Check your skills - Job search',
           value: 'Bodyguard'
         }

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -153,17 +153,22 @@ RSpec.feature 'Check your skills', type: :feature do
     fill_in('search', with: 'Bodyguard')
     find('.search-button').click
 
-    expect(tracking_service).to have_received(:track_event).with(
+    expect(tracking_service).to have_received(:track_events).with(
       key: :check_your_skills_index_search,
-      label: 'Check your skills - Job search',
-      value: 'Bodyguard'
+      props:
+      [
+        {
+          label: 'Check your skills - Job search',
+          value: 'Bodyguard'
+        }
+      ]
     )
   end
 
   scenario 'when TrackingService errors, user journey is not affected' do
     tracking_service = instance_double(TrackingService)
     allow(TrackingService).to receive(:new).and_return(tracking_service)
-    allow(tracking_service).to receive(:track_event).and_raise(TrackingService::TrackingServiceError)
+    allow(tracking_service).to receive(:track_events).and_raise(TrackingService::TrackingServiceError)
 
     visit(check_your_skills_path)
     fill_in('search', with: 'Bodyguard')

--- a/spec/features/find_training_courses_spec.rb
+++ b/spec/features/find_training_courses_spec.rb
@@ -136,17 +136,22 @@ RSpec.feature 'Find training courses', type: :feature do
     fill_in('postcode', with: 'NW6 8ET')
     find('.search-button-results').click
 
-    expect(tracking_service).to have_received(:track_event).with(
+    expect(tracking_service).to have_received(:track_events).with(
       key: :courses_index_search,
-      label: 'Courses near me - Postcode search',
-      value: 'NW6 8ET'
+      props:
+      [
+        {
+          label: 'Courses near me - Postcode search',
+          value: 'NW6 8ET'
+        }
+      ]
     )
   end
 
   scenario 'when TrackingService errors, user journey is not affected' do
     tracking_service = instance_double(TrackingService)
     allow(TrackingService).to receive(:new).and_return(tracking_service)
-    allow(tracking_service).to receive(:track_event).and_raise(TrackingService::TrackingServiceError)
+    allow(tracking_service).to receive(:track_events).and_raise(TrackingService::TrackingServiceError)
 
     visit(courses_path(topic_id: 'maths'))
     fill_in('postcode', with: 'NW6 8ET')

--- a/spec/features/find_training_courses_spec.rb
+++ b/spec/features/find_training_courses_spec.rb
@@ -137,10 +137,10 @@ RSpec.feature 'Find training courses', type: :feature do
     find('.search-button-results').click
 
     expect(tracking_service).to have_received(:track_events).with(
-      key: :courses_index_search,
       props:
       [
         {
+          key: :courses_index_search,
           label: 'Courses near me - Postcode search',
           value: 'NW6 8ET'
         }

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -86,6 +86,58 @@ RSpec.feature 'Questions' do
     expect(page).to have_selector('input[checked="checked"]', count: 2)
   end
 
+  scenario 'If user selects training options, they get tracked in GA' do
+    tracking_service = instance_spy(TrackingService)
+    allow(TrackingService).to receive(:new).and_return(tracking_service)
+
+    user_targets_job
+    visit(training_questions_path)
+    check('I need to improve my English skills', allow_label_click: true)
+    uncheck('I need to improve my maths skills', allow_label_click: true)
+    click_on('Continue')
+
+    expect(tracking_service).to have_received(:track_events).with(
+      key: :training,
+      props:
+      [
+        {
+          label: 'Check your maths and English skills - Ticked',
+          value: 'english_skills'
+        },
+        {
+          label: 'Check your maths and English skills - Unticked',
+          value: 'math_skills'
+        }
+      ]
+    )
+  end
+
+  scenario 'If user selects no training options, we still track those options in GA' do
+    tracking_service = instance_spy(TrackingService)
+    allow(TrackingService).to receive(:new).and_return(tracking_service)
+
+    user_targets_job
+    visit(training_questions_path)
+    uncheck('I need to improve my English skills', allow_label_click: true)
+    uncheck('I need to improve my maths skills', allow_label_click: true)
+    click_on('Continue')
+
+    expect(tracking_service).to have_received(:track_events).with(
+      key: :training,
+      props:
+      [
+        {
+          label: 'Check your maths and English skills - Unticked',
+          value: 'english_skills'
+        },
+        {
+          label: 'Check your maths and English skills - Unticked',
+          value: 'math_skills'
+        }
+      ]
+    )
+  end
+
   scenario 'Shows list of unselected job hunting options' do
     user_targets_job
     visit(job_hunting_questions_path)
@@ -102,6 +154,67 @@ RSpec.feature 'Questions' do
     visit(job_hunting_questions_path)
 
     expect(page).to have_selector('input[checked="checked"]', count: 2)
+  end
+
+  scenario 'If user selects job hunting options, they get tracked in GA' do
+    tracking_service = instance_spy(TrackingService)
+    allow(TrackingService).to receive(:new).and_return(tracking_service)
+
+    user_targets_job
+    visit(job_hunting_questions_path)
+    check('I want advice on creating or updating a CV', allow_label_click: true)
+    check('I want advice on preparing for interviews', allow_label_click: true)
+    click_on('Continue')
+
+    expect(tracking_service).to have_received(:track_events).with(
+      key: :job_hunting,
+      props:
+      [
+        {
+          label: 'Get help with your job hunting skills - Ticked',
+          value: 'cv'
+        },
+        {
+          label: 'Get help with your job hunting skills - Ticked',
+          value: 'interviews'
+        },
+        {
+          label: 'Get help with your job hunting skills - Unticked',
+          value: 'cover_letter'
+        }
+      ]
+    )
+  end
+
+  scenario 'If user selects no job hunting options, we still track them in GA' do
+    tracking_service = instance_spy(TrackingService)
+    allow(TrackingService).to receive(:new).and_return(tracking_service)
+
+    user_targets_job
+    visit(job_hunting_questions_path)
+    uncheck('I want advice on creating or updating a CV', allow_label_click: true)
+    uncheck('I want advice on preparing for interviews', allow_label_click: true)
+    uncheck('I want advice on writing a cover letter', allow_label_click: true)
+    click_on('Continue')
+
+    expect(tracking_service).to have_received(:track_events).with(
+      key: :job_hunting,
+      props:
+      [
+        {
+          label: 'Get help with your job hunting skills - Unticked',
+          value: 'cv'
+        },
+        {
+          label: 'Get help with your job hunting skills - Unticked',
+          value: 'cover_letter'
+        },
+        {
+          label: 'Get help with your job hunting skills - Unticked',
+          value: 'interviews'
+        }
+      ]
+    )
   end
 
   def user_targets_job

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -97,15 +97,16 @@ RSpec.feature 'Questions' do
     click_on('Continue')
 
     expect(tracking_service).to have_received(:track_events).with(
-      key: :training,
       props:
       [
         {
-          label: 'Check your maths and English skills - Ticked',
+          key: :training_ticked,
+          label: 'Check your maths and English skills',
           value: 'english_skills'
         },
         {
-          label: 'Check your maths and English skills - Unticked',
+          key: :training_unticked,
+          label: 'Check your maths and English skills',
           value: 'math_skills'
         }
       ]
@@ -123,15 +124,16 @@ RSpec.feature 'Questions' do
     click_on('Continue')
 
     expect(tracking_service).to have_received(:track_events).with(
-      key: :training,
       props:
       [
         {
-          label: 'Check your maths and English skills - Unticked',
+          key: :training_unticked,
+          label: 'Check your maths and English skills',
           value: 'english_skills'
         },
         {
-          label: 'Check your maths and English skills - Unticked',
+          key: :training_unticked,
+          label: 'Check your maths and English skills',
           value: 'math_skills'
         }
       ]
@@ -167,19 +169,21 @@ RSpec.feature 'Questions' do
     click_on('Continue')
 
     expect(tracking_service).to have_received(:track_events).with(
-      key: :job_hunting,
       props:
       [
         {
-          label: 'Get help with your job hunting skills - Ticked',
+          key: :job_hunting_ticked,
+          label: 'Get help with your job hunting skills',
           value: 'cv'
         },
         {
-          label: 'Get help with your job hunting skills - Ticked',
+          key: :job_hunting_ticked,
+          label: 'Get help with your job hunting skills',
           value: 'interviews'
         },
         {
-          label: 'Get help with your job hunting skills - Unticked',
+          key: :job_hunting_unticked,
+          label: 'Get help with your job hunting skills',
           value: 'cover_letter'
         }
       ]
@@ -198,19 +202,21 @@ RSpec.feature 'Questions' do
     click_on('Continue')
 
     expect(tracking_service).to have_received(:track_events).with(
-      key: :job_hunting,
       props:
       [
         {
-          label: 'Get help with your job hunting skills - Unticked',
+          key: :job_hunting_unticked,
+          label: 'Get help with your job hunting skills',
           value: 'cv'
         },
         {
-          label: 'Get help with your job hunting skills - Unticked',
+          key: :job_hunting_unticked,
+          label: 'Get help with your job hunting skills',
           value: 'cover_letter'
         },
         {
-          label: 'Get help with your job hunting skills - Unticked',
+          key: :job_hunting_unticked,
+          label: 'Get help with your job hunting skills',
           value: 'interviews'
         }
       ]

--- a/spec/features/skills_builder_spec.rb
+++ b/spec/features/skills_builder_spec.rb
@@ -97,6 +97,48 @@ RSpec.feature 'Build your skills', type: :feature do
     expect(page).not_to have_text('Baldness')
   end
 
+  scenario 'Tracks both ticked and unticked skills' do
+    tracking_service = instance_spy(TrackingService)
+    allow(TrackingService).to receive(:new).and_return(tracking_service)
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    uncheck('Baldness', allow_label_click: true)
+
+    click_on('Select these skills')
+
+    expect(tracking_service).to have_received(:track_events).with(
+      key: :skills_builder,
+      props: [
+        {
+          label: 'Hitman - Ticked',
+          value: 'Chameleon-like blend in tactics'
+        },
+        {
+          label: 'Hitman - Ticked',
+          value: 'License to kill'
+        },
+        {
+          label: 'Hitman - Unticked',
+          value: 'Baldness'
+        }
+      ]
+    )
+  end
+
+  scenario 'If all skills are unticked, nothing gets tracked in GA' do
+    tracking_service = instance_spy(TrackingService)
+    allow(TrackingService).to receive(:new).and_return(tracking_service)
+
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    uncheck('Baldness', allow_label_click: true)
+    uncheck('Chameleon-like blend in tactics', allow_label_click: true)
+    uncheck('License to kill', allow_label_click: true)
+
+    click_on('Select these skills')
+
+    expect(tracking_service).not_to have_received(:track_events)
+  end
+
   scenario 'User unticks all skills for a second profile then that profile should not be on Your Skills page' do
     hitman = create(
       :job_profile,

--- a/spec/features/skills_builder_spec.rb
+++ b/spec/features/skills_builder_spec.rb
@@ -107,18 +107,20 @@ RSpec.feature 'Build your skills', type: :feature do
     click_on('Select these skills')
 
     expect(tracking_service).to have_received(:track_events).with(
-      key: :skills_builder,
       props: [
         {
-          label: 'Hitman - Ticked',
+          key: :skills_builder_ticked,
+          label: 'Hitman',
           value: 'Chameleon-like blend in tactics'
         },
         {
-          label: 'Hitman - Ticked',
+          key: :skills_builder_ticked,
+          label: 'Hitman',
           value: 'License to kill'
         },
         {
-          label: 'Hitman - Unticked',
+          key: :skills_builder_unticked,
+          label: 'Hitman',
           value: 'Baldness'
         }
       ]

--- a/spec/features/your_information_spec.rb
+++ b/spec/features/your_information_spec.rb
@@ -90,10 +90,10 @@ RSpec.feature 'Your information' do
     click_on('Continue')
 
     expect(tracking_service).to have_received(:track_events).with(
-      key: :pages_location_eligibility_search,
       props:
       [
         {
+          key: :pages_location_eligibility_search,
           label: 'Your location - Postcode search',
           value: 'NW6 1JJ'
         }

--- a/spec/features/your_information_spec.rb
+++ b/spec/features/your_information_spec.rb
@@ -89,17 +89,22 @@ RSpec.feature 'Your information' do
     fill_in_user_information_form
     click_on('Continue')
 
-    expect(tracking_service).to have_received(:track_event).with(
+    expect(tracking_service).to have_received(:track_events).with(
       key: :pages_location_eligibility_search,
-      label: 'Your location - Postcode search',
-      value: 'NW6 1JJ'
+      props:
+      [
+        {
+          label: 'Your location - Postcode search',
+          value: 'NW6 1JJ'
+        }
+      ]
     )
   end
 
   scenario 'when TrackingService errors, user journey is not affected' do
     tracking_service = instance_double(TrackingService)
     allow(TrackingService).to receive(:new).and_return(tracking_service)
-    allow(tracking_service).to receive(:track_event).and_raise(TrackingService::TrackingServiceError)
+    allow(tracking_service).to receive(:track_events).and_raise(TrackingService::TrackingServiceError)
     create(:course, latitude: 0.1, longitude: 1, topic: 'maths')
 
     Geocoder::Lookup::Test.add_stub(

--- a/spec/helpers/ga_tracking_helper_spec.rb
+++ b/spec/helpers/ga_tracking_helper_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe GaTrackingHelper do
+  describe '#track_selections' do
+    before do
+      helper.singleton_class.class_eval do
+        def track_events(event_key, props = [])
+          TrackingService.new.track_events(key: event_key, props: props)
+        end
+      end
+    end
+
+    let(:selected_options) {
+      {
+        label: 'Florist',
+        values: ['must love plants', 'good sales skills']
+      }
+    }
+
+    let(:unselected_options) {
+      {
+        label: 'Florist',
+        values: ['attention to details']
+      }
+    }
+
+    it 'sends the correct props to the TrackingService' do
+      tracking_service = instance_spy(TrackingService)
+      allow(TrackingService).to receive(:new).and_return(tracking_service)
+
+      helper.track_selections(
+        :skills_builder,
+        selected: selected_options,
+        unselected: unselected_options
+      )
+
+      expect(tracking_service).to have_received(:track_events).with(
+        key: :skills_builder,
+        props:
+        [
+          {
+            label: 'Florist',
+            value: 'must love plants'
+          },
+          {
+            label: 'Florist',
+            value: 'good sales skills'
+          },
+          {
+            label: 'Florist',
+            value: 'attention to details'
+          }
+        ]
+      )
+    end
+  end
+end

--- a/spec/helpers/ga_tracking_helper_spec.rb
+++ b/spec/helpers/ga_tracking_helper_spec.rb
@@ -4,14 +4,15 @@ RSpec.describe GaTrackingHelper do
   describe '#track_selections' do
     before do
       helper.singleton_class.class_eval do
-        def track_events(event_key, props = [])
-          TrackingService.new.track_events(key: event_key, props: props)
+        def track_events(props = [])
+          TrackingService.new.track_events(props: props)
         end
       end
     end
 
     let(:selected_options) {
       {
+        key: :skills_builder_ticked,
         label: 'Florist',
         values: ['must love plants', 'good sales skills']
       }
@@ -19,6 +20,7 @@ RSpec.describe GaTrackingHelper do
 
     let(:unselected_options) {
       {
+        key: :skills_builder_unticked,
         label: 'Florist',
         values: ['attention to details']
       }
@@ -29,24 +31,25 @@ RSpec.describe GaTrackingHelper do
       allow(TrackingService).to receive(:new).and_return(tracking_service)
 
       helper.track_selections(
-        :skills_builder,
         selected: selected_options,
         unselected: unselected_options
       )
 
       expect(tracking_service).to have_received(:track_events).with(
-        key: :skills_builder,
         props:
         [
           {
+            key: :skills_builder_ticked,
             label: 'Florist',
             value: 'must love plants'
           },
           {
+            key: :skills_builder_ticked,
             label: 'Florist',
             value: 'good sales skills'
           },
           {
+            key: :skills_builder_unticked,
             label: 'Florist',
             value: 'attention to details'
           }

--- a/spec/services/tracking_service_spec.rb
+++ b/spec/services/tracking_service_spec.rb
@@ -25,50 +25,61 @@ RSpec.describe TrackingService do
     }
   }
 
-  def fake_ga_request_with(payload, debug: false)
-    api_endpoint = debug ? TrackingService::DEBUG_API_ENDPOINT : TrackingService::API_ENDPOINT
-
-    stub_request(:post, api_endpoint)
+  def fake_debug_request_with(payload)
+    stub_request(:post, TrackingService::DEBUG_API_ENDPOINT)
       .with(body: URI.encode_www_form(payload))
       .to_return(body: ga_response, status: 200)
   end
 
-  describe '.track_event' do
+  def fake_batch_request_with(bulk_payload)
+    stub_request(:post, TrackingService::BATCH_API_ENDPOINT)
+      .with(body: bulk_payload)
+      .to_return(body: ga_response, status: 200)
+  end
+
+  describe '.track_events' do
     context 'without a ga_tracking ID' do
       subject(:service) { described_class.new }
 
       it 'does not make a call to GA' do
         net_http = instance_spy(Net::HTTP)
 
-        service.track_event(key: 'key', label: 'label', value: 'value')
+        service.track_events(key: 'key', props: [{ label: 'label', values: 'value' }])
 
         expect(net_http).not_to have_received(:start)
       end
     end
 
-    context 'without event props' do
-      it 'does not make a call to GA' do
-        net_http = instance_spy(Net::HTTP)
+    context 'without event key and props' do
+      let(:net_http) { instance_spy(Net::HTTP) }
 
-        service.track_event(key: nil, label: nil, value: nil)
-
-        expect(net_http).not_to have_received(:start)
+      it 'raises TrackingServiceError' do
+        expect {
+          service.track_events(
+            key: nil,
+            props: nil
+          )
+        }.to raise_error(described_class::TrackingServiceError, 'Event key and event props must be present')
       end
     end
 
     context 'with a valid ga_tracking ID' do
       before do
-        fake_ga_request_with(event_payload)
+        fake_batch_request_with(URI.encode_www_form(event_payload))
 
         allow(SecureRandom).to receive(:uuid).and_return(anonymized_client_id)
       end
 
       it 'returns the correct response' do
         expect(
-          service.track_event(
+          service.track_events(
             key: :event_category,
-            label: 'Event Label',
-            value: 'Event action'
+            props: [
+              {
+                label: 'Event Label',
+                value: 'Event action'
+              }
+            ]
           )
         ).to eq ga_response
       end
@@ -101,17 +112,21 @@ RSpec.describe TrackingService do
       }
 
       before do
-        fake_ga_request_with(event_payload, debug: true)
+        fake_debug_request_with(event_payload)
 
         allow(SecureRandom).to receive(:uuid).and_return(anonymized_client_id)
       end
 
       it 'returns an actual JSON object' do
         expect(
-          service.track_event(
+          service.track_events(
             key: :event_category,
-            label: 'Event Label',
-            value: 'Event action'
+            props: [
+              {
+                label: 'Event Label',
+                value: 'Event action'
+              }
+            ]
           )
         ).to eq ga_response
       end
@@ -122,12 +137,82 @@ RSpec.describe TrackingService do
         allow(Net::HTTP).to receive(:start).and_raise(RuntimeError)
 
         expect {
-          service.track_event(
+          service.track_events(
             key: :event_category,
-            label: 'Event Label',
-            value: 'Event action'
+            props: [
+              {
+                label: 'Event Label',
+                values: 'Event action'
+              }
+            ]
           )
         }.to raise_exception(described_class::TrackingServiceError)
+      end
+    end
+
+    context 'when batch size is exceeded' do
+      let(:tracked_actions) { build_list(:skill, 21) }
+      let(:props) {
+        tracked_actions.map do |value|
+          {
+            label: 'Label',
+            value: value
+          }
+        end
+      }
+
+      it 'raises a TrackingServiceError' do
+        expect {
+          service.track_events(
+            key: :event_category,
+            props: props
+          )
+        }.to raise_error(described_class::TrackingServiceError, 'Batch size cannot be over 20')
+      end
+    end
+
+    context 'when sending multiple values to GA' do
+      let(:bulk_payload) {
+        [
+          URI.encode_www_form(event_payload),
+          URI.encode_www_form(other_event_payload)
+        ].join("\n")
+      }
+
+      let(:other_event_payload) {
+        {
+          tid: ga_tracking_id,
+          cid: anonymized_client_id,
+          t: 'event',
+          v: 1,
+          ec: 'event_category',
+          el: 'Event Label',
+          ea: 'New event action'
+        }
+      }
+
+      before do
+        fake_batch_request_with(bulk_payload)
+
+        allow(SecureRandom).to receive(:uuid).and_return(anonymized_client_id)
+      end
+
+      it 'sends them in batch' do
+        expect(
+          service.track_events(
+            key: :event_category,
+            props: [
+              {
+                label: 'Event Label',
+                value: 'Event action'
+              },
+              {
+                label: 'Event Label',
+                value: 'New event action'
+              }
+            ]
+          )
+        ).to eq ga_response
       end
     end
   end

--- a/spec/services/tracking_service_spec.rb
+++ b/spec/services/tracking_service_spec.rb
@@ -44,22 +44,21 @@ RSpec.describe TrackingService do
       it 'does not make a call to GA' do
         net_http = instance_spy(Net::HTTP)
 
-        service.track_events(key: 'key', props: [{ label: 'label', values: 'value' }])
+        service.track_events(props: [{ key: 'key', label: 'label', values: 'value' }])
 
         expect(net_http).not_to have_received(:start)
       end
     end
 
-    context 'without event key and props' do
+    context 'without event props' do
       let(:net_http) { instance_spy(Net::HTTP) }
 
       it 'raises TrackingServiceError' do
         expect {
           service.track_events(
-            key: nil,
             props: nil
           )
-        }.to raise_error(described_class::TrackingServiceError, 'Event key and event props must be present')
+        }.to raise_error(described_class::TrackingServiceError, 'Event props must be present')
       end
     end
 
@@ -73,9 +72,9 @@ RSpec.describe TrackingService do
       it 'returns the correct response' do
         expect(
           service.track_events(
-            key: :event_category,
             props: [
               {
+                key: :event_category,
                 label: 'Event Label',
                 value: 'Event action'
               }
@@ -120,9 +119,9 @@ RSpec.describe TrackingService do
       it 'returns an actual JSON object' do
         expect(
           service.track_events(
-            key: :event_category,
             props: [
               {
+                key: :event_category,
                 label: 'Event Label',
                 value: 'Event action'
               }
@@ -138,9 +137,9 @@ RSpec.describe TrackingService do
 
         expect {
           service.track_events(
-            key: :event_category,
             props: [
               {
+                key: :event_category,
                 label: 'Event Label',
                 values: 'Event action'
               }
@@ -156,7 +155,8 @@ RSpec.describe TrackingService do
         tracked_actions.map do |value|
           {
             label: 'Label',
-            value: value
+            value: value,
+            key: :event_category
           }
         end
       }
@@ -164,7 +164,6 @@ RSpec.describe TrackingService do
       it 'raises a TrackingServiceError' do
         expect {
           service.track_events(
-            key: :event_category,
             props: props
           )
         }.to raise_error(described_class::TrackingServiceError, 'Batch size cannot be over 20')
@@ -200,13 +199,14 @@ RSpec.describe TrackingService do
       it 'sends them in batch' do
         expect(
           service.track_events(
-            key: :event_category,
             props: [
               {
+                key: :event_category,
                 label: 'Event Label',
                 value: 'Event action'
               },
               {
+                key: :event_category,
                 label: 'Event Label',
                 value: 'New event action'
               }


### PR DESCRIPTION
### Description
Switch to GA server side tracking for user events

1) Replace AppInsights server side tracking with GA
server side tracking
2) Allow batch requests sending
3) Tracked sections:
- skills search
- postcode search
- courses search
- skills builder
- training questions
- job_hunting questions

<img width="1135" alt="Screen Shot 2019-12-04 at 09 51 31" src="https://user-images.githubusercontent.com/1955084/70132241-b9126380-167b-11ea-84aa-b3b03657286b.png">

### Approach

Decided to go with the following approach:

```ruby
track_events(:key, props), where props is an array of props defined by a (label, value) pair.
```
I do think it's really intuitive from a usage perspective. Can't think of a better way of doing it.

https://dfedigital.atlassian.net/browse/GET-794