### PR TITLE
GET-728 Add skills gap section to Job profiles

### DIFF
--- a/app/controllers/job_profiles_controller.rb
+++ b/app/controllers/job_profiles_controller.rb
@@ -2,6 +2,8 @@ class JobProfilesController < ApplicationController
   def show
     @job_profile = JobProfileDecorator.new(resource)
     @job_vacancy_count = job_vacancy_count
+    @skills_to_develop = @job_profile.skills - user_skills
+    @existing_skills = @job_profile.skills & user_skills
   end
 
   def target
@@ -34,5 +36,9 @@ class JobProfilesController < ApplicationController
     ).count
   rescue FindAJobService::APIError
     nil
+  end
+
+  def user_skills
+    @user_skills ||= Skill.find(user_session.skill_ids)
   end
 end

--- a/app/views/job_profiles/_skills_section.html.erb
+++ b/app/views/job_profiles/_skills_section.html.erb
@@ -1,8 +1,17 @@
 <h2 class="govuk-heading-m">Skills and knowledge</h2>
-<p class="govuk-body-m">Employers may ask for:</p>
-<ul class="govuk-list govuk-list--bullet">
-  <%= render @job_profile.skills %>
-</ul>
+<p class="govuk-body-m">Employers may ask for these skills for this type of work.</p>
+<% if @existing_skills.any? %>
+  <h3 class="govuk-heading-s">Skills you have</h3>
+  <ul class="govuk-list govuk-list--bullet">
+    <%= render @existing_skills %>
+  </ul>
+<% end %>
+<% if @skills_to_develop.any? %>
+  <h3 class="govuk-heading-s">Skills you may need to develop</h3>
+  <ul class="govuk-list govuk-list--bullet">
+    <%= render @skills_to_develop %>
+  </ul>
+<% end %>
 <p class="govuk-body-m">
   You may not need all of these skills to apply for this type of work - you could develop some of them while you are in the job or you could take a course. If you need help with your maths and English skills, this service can help with this when you create your action plan.
 </p>

--- a/spec/features/job_profile_spec.rb
+++ b/spec/features/job_profile_spec.rb
@@ -92,6 +92,115 @@ RSpec.feature 'Job profile spec' do
     expect(page).to have_current_path(training_questions_path)
   end
 
+  scenario 'User can see their skills gap in section skills need to develop' do
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics'),
+        create(:skill, name: 'License to kill'),
+        create(:skill, name: 'Baldness')
+      ]
+    )
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    uncheck('Chameleon-like blend in tactics', allow_label_click: true)
+    uncheck('License to kill', allow_label_click: true)
+    click_on('Select these skills')
+    visit(job_profile_path(job_profile.slug))
+
+    expect(page.all('h3:contains("Skills you may need to develop") + ul.govuk-list li').collect(&:text)).to eq(
+      ['Chameleon-like blend in tactics', 'License to kill']
+    )
+  end
+
+  scenario 'User can see their existing skills in section skills you have' do
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics'),
+        create(:skill, name: 'License to kill'),
+        create(:skill, name: 'Baldness')
+      ]
+    )
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    uncheck('License to kill', allow_label_click: true)
+    click_on('Select these skills')
+    visit(job_profile_path(job_profile.slug))
+
+    expect(page.all('h3:contains("Skills you have") + ul.govuk-list li').collect(&:text)).to eq(
+      ['Chameleon-like blend in tactics', 'Baldness']
+    )
+  end
+
+  scenario 'User can see all skills under Skills need to develop if no skills selected' do
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics'),
+        create(:skill, name: 'License to kill'),
+        create(:skill, name: 'Baldness')
+      ]
+    )
+    visit(job_profile_path(job_profile.slug))
+
+    expect(page.all('h3:contains("Skills you may need to develop") + ul.govuk-list li').collect(&:text)).to eq(
+      ['Chameleon-like blend in tactics', 'License to kill', 'Baldness']
+    )
+  end
+
+  scenario 'User does not see skills you have if no skills selected' do
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics'),
+        create(:skill, name: 'License to kill'),
+        create(:skill, name: 'Baldness')
+      ]
+    )
+    visit(job_profile_path(job_profile.slug))
+
+    expect(page).not_to have_content('Skills you have')
+  end
+
+  scenario 'User can see all skills under skills you have if all skills selected' do
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics'),
+        create(:skill, name: 'License to kill'),
+        create(:skill, name: 'Baldness')
+      ]
+    )
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    click_on('Select these skills')
+    visit(job_profile_path(job_profile.slug))
+
+    expect(page.all('h3:contains("Skills you have") + ul.govuk-list li').collect(&:text)).to eq(
+      ['Chameleon-like blend in tactics', 'License to kill', 'Baldness']
+    )
+  end
+
+  scenario 'User does not see Skills you may need to develop if all skills selected' do
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics'),
+        create(:skill, name: 'License to kill'),
+        create(:skill, name: 'Baldness')
+      ]
+    )
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    click_on('Select these skills')
+    visit(job_profile_path(job_profile.slug))
+
+    expect(page).not_to have_content('Skills you may need to develop')
+  end
+
   def user_enters_location
     visit(your_information_path)
     fill_in('user_personal_data[first_name]', with: 'John')


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-728

* Add existing skills by checking intersection with user session
* Add missing skills by diffing user session with job profile skills
* Only show section if there are any skills available