### PR TITLE
Update copy and UX for "no matches" in skills matcher

### DIFF
--- a/app/views/skills_matcher/_no_results.html.erb
+++ b/app/views/skills_matcher/_no_results.html.erb
@@ -1,4 +1,11 @@
-<h1 class="govuk-heading-xl">More information needed</h1>
-<p class="govuk-body">You'll get more job suggestions if you <%= link_to 'add more skills from another role', check_your_skills_path, class: 'govuk-link' %> you’ve done.</p>
-<!-- TODO: update copy to avoid linking to deprecated route -->
-<p class="govuk-body">If you haven't done any other jobs, doing some training will increase your job options. <%#= link_to 'Find a training course', training_hub_path, class: 'govuk-link' %></p>
+<p class="govuk-body">0 results found</p>
+<p class="govuk-body">There are no job matches for the skills you selected. If you select more skills, you should get more job matches.</p>
+<p class="govuk-body">You could:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>think about whether you may have more skills than you first thought and select them</li>
+  <li>go back and add one or more previous jobs</li>
+  <li>call an adviser on
+      <%= link_to t('contact_us.telephone'), t('contact_us.telephone_link'), class: 'govuk-!-padding-left-1 govuk-link' %>
+      - they can help you discover your skills</li>
+</ul>
+<p class="govuk-body"><%= link_to 'Go back to your skills page', skills_path %></p>

--- a/app/views/skills_matcher/index.html.erb
+++ b/app/views/skills_matcher/index.html.erb
@@ -11,13 +11,13 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
+    <p class="govuk-body">You may already have many of the skills for these types of work. Select a job title to find out if you need to do more training.</p>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <p class="govuk-body govuk-!-margin-bottom-1">If you have a particular job in mind, find out how well your skills match to it.</p>
+    <p class="govuk-body"><%= link_to 'Search for a job title', job_profiles_path, class: 'govuk-link' %></p>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <% if @results.present? %>
-      <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
-      <p class="govuk-body">You may already have many of the skills for these types of work. Select a job title to find out if you need to do more training.</p>
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-      <p class="govuk-body govuk-!-margin-bottom-1">If you have a particular job in mind, find out how well your skills match to it.</p>
-      <p class="govuk-body"><%= link_to 'Search for a job title', job_profiles_path, class: 'govuk-link' %></p>
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
       <ul class="govuk-list">
         <%= render @job_profiles %>
       </ul>

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -141,7 +141,7 @@ RSpec.feature 'Skills matcher', type: :feature do
     click_on('Select these skills')
     click_on('Find out what you can do with these skills')
 
-    expect(page).to have_text('More information needed')
+    expect(page).to have_text('0 results found')
   end
 
   scenario 'search for unknown job title shows no results' do


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-747

### Changes proposed in this pull request
The no results page now intentionally keeps the existing title and intro paragraph, plus the link to search for a specific job title regardless of skills match results appearing or not.

### Guidance to review
Try using this test scenario: `be a religious leader and only tick ‘knowledge of philosophy and religion’`
