### PR TITLE
GET-769 job profile content tweaks

### DIFF
--- a/app/decorators/job_profile_decorator.rb
+++ b/app/decorators/job_profile_decorator.rb
@@ -32,23 +32,13 @@ class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLengt
     html_body.xpath(HOW_TO_BECOME_XPATH).text
   end
 
-  def salary_range # rubocop:disable Metrics/MethodLength
+  def salary_range
     return 'Variable' unless salary_min && salary_max
 
-    content_tag(:div, class: 'govuk-grid-row salary-container') {
-      column_data(
-        content: number_to_currency(salary_min, precision: 0) + tag(:br) + '(starter)',
-        content_classes: 'salary-range'
-      ) +
-        column_data(
-          content: ' – ',
-          column_classes: 'salary-separator-container',
-          content_classes: 'salary-separator'
-        ) +
-        column_data(
-          content: number_to_currency(salary_max, precision: 0) + tag(:br) + '(experienced)',
-          content_classes: 'salary-range'
-        )
+    content_tag(:div, class: 'salary-columns') {
+      column_data(content: number_to_currency(salary_min, precision: 0) + tag(:br) + '(starter)') +
+        column_data(content: ' – ', content_classes: 'salary-separator') +
+        column_data(content: number_to_currency(salary_max, precision: 0) + tag(:br) + '(experienced)')
     }.html_safe
   end
 
@@ -196,9 +186,9 @@ class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLengt
     content_tag :hr, nil, class: 'govuk-section-break govuk-section-break--m govuk-section-break--visible'
   end
 
-  def column_data(content:, column_classes: nil, content_classes:)
-    content_tag(:div, class: "govuk-grid-column-one-third #{column_classes}".strip) do
-      content_tag(:p, content, class: content_classes)
+  def column_data(content:, content_classes: nil)
+    content_tag(:div, class: 'salary-column') do
+      content_tag(:p, content, class: "govuk-!-margin-0 #{content_classes}".strip)
     end
   end
 end

--- a/app/decorators/job_profile_decorator.rb
+++ b/app/decorators/job_profile_decorator.rb
@@ -3,6 +3,7 @@
 class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLength
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::NumberHelper
+  include ActionView::Context
 
   # rubocop:disable Metrics/LineLength
   HOW_TO_BECOME_XPATH = "//h2[contains(@class, 'job-profile-heading')]".freeze
@@ -31,10 +32,24 @@ class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLengt
     html_body.xpath(HOW_TO_BECOME_XPATH).text
   end
 
-  def salary_range
+  def salary_range # rubocop:disable Metrics/MethodLength
     return 'Variable' unless salary_min && salary_max
 
-    "#{number_to_currency(salary_min, precision: 0)} to #{number_to_currency(salary_max, precision: 0)}"
+    content_tag(:div, class: 'govuk-grid-row salary-container') {
+      column_data(
+        content: number_to_currency(salary_min, precision: 0) + tag(:br) + '(starter)',
+        content_classes: 'salary-range'
+      ) +
+        column_data(
+          content: ' – ',
+          column_classes: 'salary-separator-container',
+          content_classes: 'salary-separator'
+        ) +
+        column_data(
+          content: number_to_currency(salary_max, precision: 0) + tag(:br) + '(experienced)',
+          content_classes: 'salary-range'
+        )
+    }.html_safe
   end
 
   def working_hours
@@ -179,5 +194,11 @@ class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLengt
 
   def separator_line
     content_tag :hr, nil, class: 'govuk-section-break govuk-section-break--m govuk-section-break--visible'
+  end
+
+  def column_data(content:, column_classes: nil, content_classes:)
+    content_tag(:div, class: "govuk-grid-column-one-third #{column_classes}".strip) do
+      content_tag(:p, content, class: content_classes)
+    end
   end
 end

--- a/app/views/job_profiles/_apprenticeship.html.erb
+++ b/app/views/job_profiles/_apprenticeship.html.erb
@@ -2,6 +2,6 @@
 
 <% if apprenticeship_section.present? %>
   <h2 class='govuk-heading-m'>Apprenticeship</h2>
-  <p class="govuk-body-m">You can do an apprenticeship at any age. You can often work and learn at your existing level of pay and seniority.</p>
+  <p class="govuk-body-m">You can do an apprenticeship at any age. You may be able to earn the same money and work at the same level as you do now.</p>
   <%= apprenticeship_section.html_safe %>
 <% end %>

--- a/app/views/job_profiles/_highlights.html.erb
+++ b/app/views/job_profiles/_highlights.html.erb
@@ -7,7 +7,7 @@
       <div class="govuk-grid-column-three-quarters">
         <h4 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-1">Typical Salary</h4>
         <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-2 responsive-section-break">
-        <p class="govuk-body"><%= @job_profile.salary_range %></p>
+        <%= @job_profile.salary_range %>
       </div>
     </div>
   </div>

--- a/app/views/job_profiles/_relevant_sections.html.erb
+++ b/app/views/job_profiles/_relevant_sections.html.erb
@@ -11,5 +11,7 @@
 <%= render 'jobs_in_your_area' %>
 
 <h2 class="govuk-heading-m">Select type of work</h2>
-<p class="govuk-body">Select this as your target type of work and we’ll help you prepare to apply.</p>
+<p class="govuk-body">Select this as your target type of work and we’ll add it to your personal action plan. We will start by checking if you need any maths and English training or job hunting advice.</p>
+<p class="govuk-body">If you change your mind, you can choose a different type of work on your personal action plan.</p>
 <%= button_to('Target this type of work', target_job_profile_path(@job_profile.slug), class: 'govuk-button govuk-!-margin-top-1 govuk-!-margin-bottom-6', data: { module: 'govuk-button' }) %>
+<%= link_to('Back to your job matches', skills_matcher_index_path, class: 'govuk-link') %>

--- a/app/webpacker/styles/_job-profile.scss
+++ b/app/webpacker/styles/_job-profile.scss
@@ -173,3 +173,35 @@
     padding-right: 0;
   }
 }
+
+.salary-container {
+  @include govuk-media-query($until: tablet) {
+    margin-left: 18%;
+  }
+}
+
+.salary-range {
+  text-align: center;
+  padding: 0 !important;
+  margin: 0 !important;
+  @include govuk-media-query($until: desktop) {
+    text-align: left;
+  }
+}
+
+.salary-separator-container {
+  padding: 0;
+  width: 35px !important;
+  margin-left: 15px;
+  @include govuk-media-query($until: desktop) {
+    margin: 0 45px;
+  }
+}
+
+.salary-separator {
+  text-align: center;
+  @include govuk-media-query($until: desktop) {
+    text-align: left;
+    margin: 0;
+  }
+}

--- a/app/webpacker/styles/_job-profile.scss
+++ b/app/webpacker/styles/_job-profile.scss
@@ -174,34 +174,30 @@
   }
 }
 
-.salary-container {
+.salary-columns {
+  display: flex;
+  flex-flow: row wrap;
+
   @include govuk-media-query($until: tablet) {
-    margin-left: 18%;
-  }
-}
-
-.salary-range {
-  text-align: center;
-  padding: 0 !important;
-  margin: 0 !important;
-  @include govuk-media-query($until: desktop) {
-    text-align: left;
-  }
-}
-
-.salary-separator-container {
-  padding: 0;
-  width: 35px !important;
-  margin-left: 15px;
-  @include govuk-media-query($until: desktop) {
-    margin: 0 45px;
+    width: 30%;
   }
 }
 
 .salary-separator {
-  text-align: center;
-  @include govuk-media-query($until: desktop) {
-    text-align: left;
-    margin: 0;
+  padding: 5px;
+
+  @include govuk-media-query($from: tablet) {
+    text-align: center;
+    padding: 0 2px;
+  }
+}
+
+.salary-column {
+  flex: 1;
+}
+
+@media screen and (max-width: 30%) {
+  .salary-columns .salary-column {
+    flex-basis: 10%;
   }
 }

--- a/spec/decorators/job_profile_decorator_spec.rb
+++ b/spec/decorators/job_profile_decorator_spec.rb
@@ -19,7 +19,21 @@ RSpec.describe JobProfileDecorator do
       let(:model) { build_stubbed :job_profile, salary_min: 18_000, salary_max: 30_000 }
 
       it 'formats the salary range' do
-        expect(job_profile.salary_range).to eq '£18,000 to £30,000'
+        expected_salary_range = <<~HTML.gsub(/\n/, '')
+          <div class="govuk-grid-row salary-container">
+          <div class="govuk-grid-column-one-third">
+          <p class="salary-range">£18,000<br />(starter)</p>
+          </div>
+          <div class="govuk-grid-column-one-third salary-separator-container">
+          <p class="salary-separator"> – </p>
+          </div>
+          <div class="govuk-grid-column-one-third">
+          <p class="salary-range">£30,000<br />(experienced)</p>
+          </div>
+          </div>
+        HTML
+
+        expect(job_profile.salary_range).to eq(expected_salary_range)
       end
     end
 

--- a/spec/decorators/job_profile_decorator_spec.rb
+++ b/spec/decorators/job_profile_decorator_spec.rb
@@ -20,15 +20,15 @@ RSpec.describe JobProfileDecorator do
 
       it 'formats the salary range' do
         expected_salary_range = <<~HTML.gsub(/\n/, '')
-          <div class="govuk-grid-row salary-container">
-          <div class="govuk-grid-column-one-third">
-          <p class="salary-range">£18,000<br />(starter)</p>
+          <div class="salary-columns">
+          <div class="salary-column">
+          <p class="govuk-!-margin-0">£18,000<br />(starter)</p>
           </div>
-          <div class="govuk-grid-column-one-third salary-separator-container">
-          <p class="salary-separator"> – </p>
+          <div class="salary-column">
+          <p class="govuk-!-margin-0 salary-separator"> – </p>
           </div>
-          <div class="govuk-grid-column-one-third">
-          <p class="salary-range">£30,000<br />(experienced)</p>
+          <div class="salary-column">
+          <p class="govuk-!-margin-0">£30,000<br />(experienced)</p>
           </div>
           </div>
         HTML


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-769

* Add expected/experienced to salary range. This required adding three custom columns for responsiveness as it wouldn't work with normal columns from the govuk styles, which collapsed and overlapped in strange ways. 
* Amend apprenticeships content
* Amend target job section
* Add new link to bottom of page to go back to job matches