### PR TITLE
Add closing date and copy changes for job vacancies

### DIFF
--- a/app/decorators/job_vacancy_decorator.rb
+++ b/app/decorators/job_vacancy_decorator.rb
@@ -8,10 +8,12 @@ class JobVacancyDecorator < SimpleDelegator
       .html_safe
   end
 
+  def formatted_closing_date
+    formatted_date(closing_date)
+  end
+
   def formatted_date_posted
-    date_posted
-      &.to_time
-      &.strftime('%d %B %Y')
+    formatted_date(date_posted)
   end
 
   private
@@ -20,5 +22,11 @@ class JobVacancyDecorator < SimpleDelegator
     return unless company
 
     content_tag(:b, company)
+  end
+
+  def formatted_date(date_value)
+    date_value
+      &.to_time
+      &.strftime('%d %B %Y')
   end
 end

--- a/app/models/job_vacancy.rb
+++ b/app/models/job_vacancy.rb
@@ -13,6 +13,10 @@ class JobVacancy
     body['url']
   end
 
+  def closing_date
+    body['closing'].presence
+  end
+
   def date_posted
     body['posted'].presence
   end

--- a/app/views/job_vacancies/_job_vacancy.html.erb
+++ b/app/views/job_vacancies/_job_vacancy.html.erb
@@ -1,9 +1,13 @@
 <li>
   <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><%= link_to job_vacancy.title, job_vacancy.url, class: 'govuk-link' %></h2>
-  <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><span class="govuk-visually-hidden">Date posted:</span><%= job_vacancy.formatted_date_posted %></h3>
+  <% if job_vacancy.date_posted.present? %>
+    <p class="govuk-body govuk-!-margin-bottom-0">Date posted: <b><%= job_vacancy.formatted_date_posted %></b></p>
+  <% end %>
+  <% if job_vacancy.closing_date.present? %>
+    <p class="govuk-body govuk-!-margin-bottom-0">Closing date: <b><%= job_vacancy.formatted_closing_date %></b></p>
+  <% end %>
   <p class="govuk-body govuk-!-margin-bottom-0"><span class="govuk-visually-hidden">Company and location:</span><%= job_vacancy.company_and_location %></p>
   <p class="govuk-body govuk-!-margin-bottom-1"><span class="govuk-visually-hidden">Salary:</span><b><%= job_vacancy.salary %></b></p>
   <p class="govuk-body"><%= job_vacancy.description %></p>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-top-0">
 </li>
-

--- a/app/views/job_vacancies/index.html.erb
+++ b/app/views/job_vacancies/index.html.erb
@@ -15,6 +15,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= target_job.name %> jobs near me</h1>
     <p class="govuk-body">These jobs within 20 miles of your postcode are currently being advertised in the <%= link_to('Find a job', 'https://findajob.dwp.gov.uk/', class: 'govuk-link') %> service from the Department for Work and Pensions.</p>
+    <p class="govuk-body">Selecting one of these jobs will take you to another government service.</p>
     <div class="govuk-grid-column-full govuk-!-padding-0">
       <%= form_with model: @job_vacancy_search, local: true, url: jobs_near_me_path do |form| %>
         <%= form_group_tag @job_vacancy_search, :postcode do %>

--- a/spec/decorators/job_vacancy_decorator_spec.rb
+++ b/spec/decorators/job_vacancy_decorator_spec.rb
@@ -33,6 +33,28 @@ RSpec.describe JobVacancyDecorator do
     end
   end
 
+  describe '#formatted_closing_date' do
+    it 'returns the formatted closing date' do
+      job_vacancy = JobVacancy.new('closing' => '2019-10-11T18:56:40')
+      decorated_vacancy = described_class.new(job_vacancy)
+
+      expect(decorated_vacancy.formatted_closing_date).to eq('11 October 2019')
+    end
+
+    it 'returns nil if closing date is empty' do
+      job_vacancy = JobVacancy.new('closing' => '')
+      decorated_vacancy = described_class.new(job_vacancy)
+
+      expect(decorated_vacancy.formatted_closing_date).to be_nil
+    end
+
+    it 'returns nil if closing date is missing' do
+      decorated_vacancy = described_class.new(JobVacancy.new({}))
+
+      expect(decorated_vacancy.formatted_closing_date).to be_nil
+    end
+  end
+
   describe '#formatted_date_posted' do
     it 'returns the posted date formatted' do
       job_vacancy = JobVacancy.new('posted' => '2019-10-11T18:56:40')

--- a/spec/models/job_vacancy_spec.rb
+++ b/spec/models/job_vacancy_spec.rb
@@ -25,6 +25,23 @@ RSpec.describe JobVacancy do
     end
   end
 
+  describe '#closing_date' do
+    it 'returns the closing date from a parsed body' do
+      body = { 'closing' => '2019-10-11T18:56:40' }
+      expect(described_class.new(body).closing_date).to eq('2019-10-11T18:56:40')
+    end
+
+    it 'returns nil if closing date is empty' do
+      body = { 'closing' => '' }
+      expect(described_class.new(body).closing_date).to be_nil
+    end
+
+    it 'returns nil if closing date is missing' do
+      body = {}
+      expect(described_class.new(body).closing_date).to be_nil
+    end
+  end
+
   describe '#date_posted' do
     it 'returns the posted date from a parsed body' do
       body = { 'posted' => '2019-10-11T18:56:40' }


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-707

### Changes proposed in this pull request
It's not possible to include distance to each vacancy as that info is not included in the DWP FAJ API response - we only pass a partial postcode so even if the API performed a spatial calculation it would not be accurate. Refactored date formatting slightly to DRY things up.

### Guidance to review
The intro text on the prototype is out of date - double checked with Lois and it's only the extra sentence about going to another site that needed to be added.