### PR TITLE
GET-768 First paragraph same size as the following ones

### DIFF
--- a/app/views/job_profiles/skills/index.html.erb
+++ b/app/views/job_profiles/skills/index.html.erb
@@ -21,7 +21,7 @@
               <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3">
                 <%= @job_profile.name %> skills
               </h1>
-              <p class="govuk-body-l">Most <%= @job_profile.name.downcase.pluralize %> will have these skills.</p>
+              <p class="govuk-body">Most <%= @job_profile.name.downcase.pluralize %> will have these skills.</p>
               <p class="govuk-body">We’ll use these skills to suggest other types of work you can do.</p>
               <span id="current-job-skills-hint" class="govuk-hint">
                 If you want to remove any of these skills, click the tick to remove it from the list.


### PR DESCRIPTION
### Context
First paragraph size on Skills Builder page same size as the following ones.

<img width="661" alt="Screen Shot 2019-12-04 at 15 30 27" src="https://user-images.githubusercontent.com/1955084/70155972-15d94280-16ab-11ea-9389-728406010cf2.png">


