### PR TITLE
GET-720 Add plularisation for is/are and fix content on job vacancies

### DIFF
--- a/app/views/job_profiles/_jobs_in_your_area.html.erb
+++ b/app/views/job_profiles/_jobs_in_your_area.html.erb
@@ -1,8 +1,8 @@
 <% return unless @job_vacancy_count.present? %>
 <h2 class="govuk-heading-m">Jobs in your area</h2>
 <% if @job_vacancy_count > 0 %>
-  <p class="govuk-body">At least <b><%= pluralize(@job_vacancy_count, 'vacancy', locale: I18n.locale.to_s) %></b> in this type of work are being advertised near you. Get ready to start applying by preparing your CV and cover letter and exploring any training you’ll need.</p>
+  <p class="govuk-body">At least <b><%= pluralize(@job_vacancy_count, 'vacancy', locale: I18n.locale.to_s) %></b> in this type of work <%= t('job_profiles.vacancies', count: @job_vacancy_count) %> being advertised near you. Get ready to start applying by preparing your CV and cover letter and exploring any training you’ll need.</p>
 <% else %>
-  <p class="govuk-body">At present, there are no jobs like this one being advertised near you on the Find a Job service. You may be able to find other jobs like this advertised on other job sites.</p>
+  <p class="govuk-body">At present, there are no vacancies like this one being advertised near you on the Find a Job service. You may be able to find other jobs like this advertised on other job sites.</p>
 <% end %>
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,9 @@ en-GB:
       title: Search for a type of work
       body: Enter a job title to find out how well your skills match to it
       placeholder: Enter a job title
+    vacancies:
+      one: is
+      other: are
     destroy:
       notice: The %{name} role has been removed.
   job_profiles_search:

--- a/spec/features/job_profile_spec.rb
+++ b/spec/features/job_profile_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature 'Job profile spec' do
     user_enters_location
     visit(job_profile_path(job_profile.slug))
 
-    expect(page).to have_content('there are no jobs')
+    expect(page).to have_content('there are no vacancies')
   end
 
   scenario 'User does not see job vacancies if API is down' do


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-720

is/are does not work with normal pluralisation so had to add it in the local to use it see https://guides.rubyonrails.org/i18n.html#pluralization
