### PR TITLE
Add support for sorting skill matcher results

### DIFF
--- a/app/controllers/skills_matcher_controller.rb
+++ b/app/controllers/skills_matcher_controller.rb
@@ -4,19 +4,20 @@ class SkillsMatcherController < ApplicationController
   def index
     return redirect_to task_list_path unless user_session.job_profile_skills?
 
-    @order = preferred_sort_order
     @results = Kaminari.paginate_array(skills_matcher.match).page(params[:page])
     @scores = skills_matcher.job_profile_scores
     @job_profiles = JobProfileDecorator.decorate(@results)
-    @options = helpers.options_for_select(SORT_OPTIONS, @order)
+    @options = helpers.options_for_select(SORT_OPTIONS, order)
   end
 
   private
 
-  def preferred_sort_order
-    user_session.skills_matcher_sort = sort if %w[skills growth].include?(sort)
+  def order
+    @order ||= begin
+      user_session.skills_matcher_sort = sort if %w[skills growth].include?(sort)
 
-    (user_session.skills_matcher_sort || 'skills').to_sym
+      (user_session.skills_matcher_sort || 'skills').to_sym
+    end
   end
 
   def sort
@@ -24,10 +25,10 @@ class SkillsMatcherController < ApplicationController
   end
 
   def sort_params
-    params.permit(:sort)
+    params.permit(:sort, :page)
   end
 
   def skills_matcher
-    @skills_matcher ||= SkillsMatcher.new(user_session, limit: 50, order: @order)
+    @skills_matcher ||= SkillsMatcher.new(user_session, limit: 50, order: order)
   end
 end

--- a/app/controllers/skills_matcher_controller.rb
+++ b/app/controllers/skills_matcher_controller.rb
@@ -1,15 +1,33 @@
 class SkillsMatcherController < ApplicationController
+  SORT_OPTIONS = [['Skills match', :skills], ['Recent job growth', :growth]].freeze
+
   def index
     return redirect_to task_list_path unless user_session.job_profile_skills?
 
+    @order = preferred_sort_order
     @results = Kaminari.paginate_array(skills_matcher.match).page(params[:page])
     @scores = skills_matcher.job_profile_scores
     @job_profiles = JobProfileDecorator.decorate(@results)
+    @options = helpers.options_for_select(SORT_OPTIONS, @order)
   end
 
   private
 
+  def preferred_sort_order
+    user_session.skills_matcher_sort = sort if %w[skills growth].include?(sort)
+
+    (user_session.skills_matcher_sort || 'skills').to_sym
+  end
+
+  def sort
+    sort_params[:sort]
+  end
+
+  def sort_params
+    params.permit(:sort)
+  end
+
   def skills_matcher
-    @skills_matcher ||= SkillsMatcher.new(user_session, limit: 50)
+    @skills_matcher ||= SkillsMatcher.new(user_session, limit: 50, order: @order)
   end
 end

--- a/app/models/skills_matcher.rb
+++ b/app/models/skills_matcher.rb
@@ -37,8 +37,17 @@ class SkillsMatcher
         )
         .from(Arel.sql("(#{skills_matched_query}) as ranked_job_profiles"))
         .joins('LEFT JOIN job_profiles ON job_profiles.id = ranked_job_profiles.job_profile_id')
-        .order(skills_matched: :desc, growth: :desc, name: :asc)
+        .order(order_options)
         .limit(options[:limit])
+    end
+  end
+
+  def order_options
+    case options[:order]
+    when :growth
+      { growth: :desc, skills_matched: :desc, name: :asc }
+    else
+      { skills_matched: :desc, growth: :desc, name: :asc }
     end
   end
 

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -8,6 +8,7 @@ class UserSession
     target_job_id
     training
     job_hunting
+    skills_matcher_sort
   ].freeze
 
   def self.merge_sessions(new_session:, previous_session_data:)
@@ -27,6 +28,14 @@ class UserSession
 
   def postcode=(value)
     session[:postcode] = value
+  end
+
+  def skills_matcher_sort
+    session[:skills_matcher_sort]
+  end
+
+  def skills_matcher_sort=(value)
+    session[:skills_matcher_sort] = value
   end
 
   def target_job_id

--- a/app/views/skills_matcher/_sort_form.html.erb
+++ b/app/views/skills_matcher/_sort_form.html.erb
@@ -1,0 +1,6 @@
+<div class="govuk-form-group hidden" id="sort-container">
+  <%= form_tag nil, method: :get, local: true do |f| %>
+    <%= label_tag :sort, 'Sort by', class: 'govuk-label' %>
+    <%= select_tag :sort, @options, class: 'govuk-select', id: 'sort-select' %>
+  <% end %>
+</div>

--- a/app/views/skills_matcher/index.html.erb
+++ b/app/views/skills_matcher/index.html.erb
@@ -18,6 +18,7 @@
     <p class="govuk-body"><%= link_to 'Search for a job title', job_profiles_path, class: 'govuk-link' %></p>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <% if @results.present? %>
+      <%= render 'sort_form' %>
       <ul class="govuk-list">
         <%= render @job_profiles %>
       </ul>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -2,11 +2,13 @@ import '../styles/application.scss';
 import CookiesBanner from './cookies-banner';
 import OutboundLinkTracking from './outbound-link-tracking';
 import UserFeedback from './user-feedback';
+import Sorting from './sorting';
 import Rails from 'rails-ujs';
 import { initAll } from 'govuk-frontend';
 
 CookiesBanner.start();
 UserFeedback.start();
 OutboundLinkTracking.start();
+Sorting.start();
 Rails.start();
 initAll();

--- a/app/webpacker/packs/sorting.js
+++ b/app/webpacker/packs/sorting.js
@@ -1,0 +1,24 @@
+function Sorting () {
+  this.start = function () {
+    var container = document.querySelector('#sort-container');
+
+    if (typeof(container) !== 'undefined' && container != null) {
+      // Show sort options when JS enabled
+      container.classList.remove('hidden');
+
+      var select = document.querySelector('#sort-select');
+
+      if (typeof(select) !== 'undefined' && select != null) {
+        handleSortOrder(select);
+      }
+    }
+  }
+
+  function handleSortOrder(element) {
+    element.onchange = function(e) {
+      element.form.submit();
+    }
+  }
+}
+
+export default new Sorting();

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -140,6 +140,23 @@ RSpec.feature 'Skills matcher', type: :feature do
     expect(page).to have_current_path(skills_matcher_index_path(sort: 'growth'))
   end
 
+  scenario 'defaults sort order to skills match if not specified', :js do
+    visit_skills_for_current_job_profile(true)
+
+    expect(page).to have_select('sort-select', selected: 'Skills match')
+  end
+
+  scenario 'preserves selected sort order when returning to page', :js do
+    visit_skills_for_current_job_profile(true)
+
+    find("option[value='growth']").click
+
+    visit task_list_path
+    visit skills_matcher_index_path
+
+    expect(page).to have_select('sort-select', selected: 'Recent job growth')
+  end
+
   scenario 'paginates results of search' do
     create_list(:job_profile, 12, name: 'Hacker', skills: [skill1])
     visit_skills_for_current_job_profile

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -120,6 +120,26 @@ RSpec.feature 'Skills matcher', type: :feature do
     )
   end
 
+  scenario 'allows profiles to be optionally sorted by growth' do
+    create(:job_profile, name: 'Hacker', skills: [skill1, skill2], growth: -5)
+    create(:job_profile, name: 'Admin', skills: [skill1], growth: 50)
+    visit_skills_for_current_job_profile
+
+    visit skills_matcher_index_path(sort: 'growth')
+
+    expect(page.all('ul.govuk-list li a,p:contains("Skills match")').collect(&:text)).to eq(
+      ['Assasin', 'Skills match: Good', 'Admin', 'Skills match: Reasonable', 'Hacker', 'Skills match: Good']
+    )
+  end
+
+  scenario 'automatically reloads results when sort order changed', :js do
+    visit_skills_for_current_job_profile(true)
+
+    find("option[value='growth']").click
+
+    expect(page).to have_current_path(skills_matcher_index_path(sort: 'growth'))
+  end
+
   scenario 'paginates results of search' do
     create_list(:job_profile, 12, name: 'Hacker', skills: [skill1])
     visit_skills_for_current_job_profile

--- a/spec/models/skills_matcher_spec.rb
+++ b/spec/models/skills_matcher_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe SkillsMatcher do
       )
     end
 
-    it 'arranges job profiles in job growth order as well as matching skills order' do
+    it 'arranges job profiles in matching skills order as well as job growth order' do
       skill = create(:skill)
       job_profile1 = create(:job_profile, skills: [skill])
       job_profile2 = create(:job_profile, skills: [skill], growth: -5)
@@ -146,6 +146,33 @@ RSpec.describe SkillsMatcher do
         [
           job_profile3,
           job_profile2
+        ]
+      )
+    end
+
+    it 'arranges job profiles in job growth order as well as matching skills order' do
+      skill1 = create(:skill)
+      skill2 = create(:skill)
+      skill3 = create(:skill)
+      job_profile1 = create(:job_profile, skills: [skill1, skill2, skill3])
+      job_profile2 = create(:job_profile, growth: 60, name: 'Researcher', skills: [skill2])
+      job_profile3 = create(:job_profile, growth: -5, name: 'Beekeeper', skills: [skill1, skill2, skill3])
+      job_profile4 = create(:job_profile, growth: -5, name: 'Admin', skills: [skill1, skill2, skill3])
+      job_profile5 = create(:job_profile, growth: 60, name: 'Boat builder', skills: [skill3])
+      session = create_fake_session(
+        job_profile_ids: [job_profile1.id],
+        job_profile_skills: {
+          job_profile1.id.to_s => [skill1.id, skill2.id, skill3.id]
+        }
+      )
+
+      matcher = described_class.new(UserSession.new(session), order: :growth)
+      expect(matcher.match).to eq(
+        [
+          job_profile5,
+          job_profile2,
+          job_profile4,
+          job_profile3
         ]
       )
     end

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe UserSession do
         'target_job_id' => 100,
         'session_id' => 2,
         'training' => ['english_skills'],
-        'job_hunting' => ['cv']
+        'job_hunting' => ['cv'],
+        'skills_matcher_sort' => 'growth'
       }
       new_session = { 'session_id' => 1 }
       described_class.merge_sessions(new_session: new_session, previous_session_data: old_session)
@@ -22,7 +23,8 @@ RSpec.describe UserSession do
         'target_job_id' => 100,
         'session_id' => 1,
         'training' => ['english_skills'],
-        'job_hunting' => ['cv']
+        'job_hunting' => ['cv'],
+        'skills_matcher_sort' => 'growth'
       )
     end
 
@@ -48,6 +50,18 @@ RSpec.describe UserSession do
 
     it 'returns nil if no postcode set' do
       expect(user_session.postcode).to be_nil
+    end
+  end
+
+  describe '#skills_matcher_sort' do
+    it 'returns order if set' do
+      user_session.skills_matcher_sort = 'growth'
+
+      expect(user_session.skills_matcher_sort).to eq('growth')
+    end
+
+    it 'returns nil if no order set' do
+      expect(user_session.skills_matcher_sort).to be_nil
     end
   end
 


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-775

### Changes proposed in this pull request
Preferred sort order is stored in the user session to avoid having to pass this around as a parameter. Added support for another option to specify order in the skills matcher (we only need this for the main list of skill matches, not when searching for a job profile by name - but this could easily be added later if needed).

### Guidance to review
Add some skills, show match results and experiment with sort order. It's pretty hard to tell the order has changed unless the skills are chosen wisely, but the correct query can be observed in the console.