### PR TITLE
Cache all static assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,6 +76,9 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  # caches all static assets for up to a year
+  config.static_cache_control = 'public, max-age=31536000'
+
   # Use a different logger for distributed setups.
   if ENV['RAILS_LOG_TO_STDOUT'].present?
     stdout_logger           = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
### Context

We set static cache-control to 'public, max-age=31536000'
so the browser caches all static assets for up to a year.
In production, every asset has a hash added to its name,
so whenever the file changes the browser requests
the latest version as the hash and therefore the whole
filename changes.