### PR TITLE
GET-738 Low level caching for geocoding

### DIFF
--- a/app/models/course_geospatial_search.rb
+++ b/app/models/course_geospatial_search.rb
@@ -25,7 +25,9 @@ class CourseGeospatialSearch
   end
 
   def coordinates
-    @coordinates ||= Geocoder.coordinates(uk_postcode.to_s)
+    @coordinates ||= Rails.cache.fetch("#{uk_postcode}-coordinates", expires_in: 1.hours) {
+      Geocoder.coordinates(uk_postcode.to_s)
+    }
   rescue SocketError, Timeout::Error, Geocoder::Error => e
     Rails.logger.error("Geocoder API error: #{e.message}")
     raise GeocoderAPIError


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-738

Cache API calls using the postcode as the key. Instead of attempting
to save coordinates in the session, use low level caching for the
coordinates API lookup. We set it to an hour as that seems enough
for users paginating through their results

The reason I avoided saving it in the session are the following:
1) We do not use geocoding everywhere, meaning if we change the
  postcode in find a job we will need to update the coordinates.
  Forcing us to do an API call when we don't need it, meaning
  we might throw an error unnecessarily

2) Attempting to pass in the user session and update the coordinates
   only if they changed also didn't work as sometimes we set the postcode
   on the session even if it doesn't exist (PID form). This also meant
   updating it from the find a job page would render the coordinates
   stale and invalid

3) Setting both coordinates/postcode in the geospatial class itself also
  doesn't work with the FAJ setup mentioned earlier, also because of the rules
  we use around skipping some validation in the geospacial class.

4) Attempting to move coordinates setting out of the class or using a class method
  also didn't work as we need the validation errors generated from the class