### PR TITLE
Rename QA to qa-origin so that it can be fronted by Azure FrontDoor

### DIFF
--- a/azure/config/qa.parameters.json
+++ b/azure/config/qa.parameters.json
@@ -100,7 +100,7 @@
       }
     },
     "customHostName": {
-      "value": "qa.nrs-ghtr.org.uk"
+      "value": "qa-origin.nrs-ghtr.org.uk"
     },
     "certificateName": {
       "value": "nrs-ghtr-org-uk"


### PR DESCRIPTION
### Context



### Changes proposed in this pull request
This sets the QA Webapp hostname to qa-origin, so that it can be fronted by Azure FrontDoor 

### Guidance to review

