### PR TITLE
HOTFIX - google analytics job profile search

### DIFF
--- a/app/controllers/job_profiles_controller.rb
+++ b/app/controllers/job_profiles_controller.rb
@@ -12,7 +12,7 @@ class JobProfilesController < ApplicationController
   def results
     return redirect_to task_list_path unless user_session.job_profile_skills?
 
-    track_event(:job_profiles_index_search, search: search) if search.present?
+    track_event(:job_profiles_index_search, search) if search.present?
 
     build_job_profile_search
     @results = job_profile_search_results

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -253,4 +253,27 @@ RSpec.feature 'Skills matcher', type: :feature do
 
     expect(page).to have_current_path(job_profile_path('fluffer'))
   end
+
+  scenario 'tracks search string in job profile search' do
+    tracking_service = instance_spy(TrackingService)
+    allow(TrackingService).to receive(:new).and_return(tracking_service)
+    visit_skills_for_current_job_profile
+
+    visit(skills_matcher_index_path)
+    click_on('Search for a job title')
+
+    fill_in('search', with: 'fluffer')
+    find('.search-button').click
+
+    expect(tracking_service).to have_received(:track_events).with(
+      props:
+      [
+        {
+          key: :job_profiles_index_search,
+          label: 'Job profiles - Job search',
+          value: 'fluffer'
+        }
+      ]
+    )
+  end
 end


### PR DESCRIPTION
pass in the value without a hash, as this is now appearing as `{'search' => 'some value'}` in google analytics
