### PR TITLE
Add support for viewing and editing user personal data via active admin

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -35,6 +35,11 @@ if defined?(ActiveAdmin)
               link_to FeedbackSurvey.count, admin_feedback_surveys_path
             end
           end
+          panel 'User Personal Data' do
+            h1 do
+              link_to UserPersonalData.count, admin_user_personal_data_path
+            end
+          end
         end
       end
     end

--- a/app/admin/user_personal_data.rb
+++ b/app/admin/user_personal_data.rb
@@ -1,0 +1,33 @@
+if defined?(ActiveAdmin)
+  ActiveAdmin.register UserPersonalData do
+    GENDER_OPTIONS = {
+      'Male' => :male,
+      'Female' => :female,
+      'Prefer not to say' => :not_mentioned
+    }.freeze
+
+    actions :all, except: :new
+
+    permit_params :first_name, :last_name, :postcode, :dob, :gender
+
+    filter :first_name
+    filter :last_name
+    filter :postcode
+    filter :dob
+    filter :gender, as: :select, collection: GENDER_OPTIONS
+
+    form do |f|
+      f.semantic_errors
+      f.inputs do
+        f.input :first_name
+        f.input :last_name
+        f.input :postcode
+        f.input :dob
+        f.input :gender, as: :select, collection: GENDER_OPTIONS
+      end
+      f.actions
+    end
+
+    config.sort_order = 'id_asc'
+  end
+end

--- a/app/models/user_personal_data.rb
+++ b/app/models/user_personal_data.rb
@@ -7,7 +7,7 @@ class UserPersonalData < RestrictedActiveRecordBase
   validates :last_name, presence: true
   validates :postcode, presence: true
   validates :postcode, postcode: true, allow_blank: true
-  validate  :dob_format
+  validate  :dob_format, unless: -> { dob? }
   validate  :dob_in_the_past, if: -> { dob? }
   validates :gender, presence: true
 


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-815

### Changes proposed in this pull request
Needed to tweak validation for `UserPersonalData` slightly to allow ActiveAdmin to edit the `dob` field directly. Other than that this just adds a new Admin class and includes a link on the dashboard. 

### Guidance to review
Worked with Lois to iron out the columns, filters etc. for this and is happy. Will need to add support for the `ADMIN_MODE` flag to get this deployed on a review app, so will cover that in the next story. For now this is still only exposed in development mode so will need to be tested locally.
