### PR TITLE
Add support for `ADMIN_MODE` environment variable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,9 @@ gem 'passwordless', '~> 0.8'
 # Logs formatter
 gem 'rails_semantic_logger', '~> 4.4'
 
+# Admin pages
+gem 'activeadmin', '~> 2.2'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
@@ -108,9 +111,6 @@ group :development do
   # Ruby code analyzer and formatter
   gem 'rubocop', '~> 0.68'
   gem 'rubocop-rspec', '~> 1.32'
-
-  # Admin pages
-  gem 'activeadmin', '~> 2.2'
 end
 
 group :test do

--- a/app/constraints/admin_constraint.rb
+++ b/app/constraints/admin_constraint.rb
@@ -1,0 +1,5 @@
+class AdminConstraint
+  def matches?(_request)
+    Rails.configuration.admin_mode
+  end
+end

--- a/app/constraints/user_constraint.rb
+++ b/app/constraints/user_constraint.rb
@@ -1,0 +1,5 @@
+class UserConstraint
+  def matches?(_request)
+    Rails.configuration.admin_mode == false
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,7 @@ module GetHelpToRetrain
     Dir.glob(Rails.root.join('app', 'middleware', '*.rb')) { |f| require f }
     config.middleware.insert_before Rails::Rack::Logger, StatusReport
 
+    config.admin_mode = ENV['ADMIN_MODE'] == 'true'
     config.google_analytics_tracking_id = ENV['GOOGLE_ANALYTICS_TRACKING_ID']
     config.notify_api_key = ENV['NOTIFY_API_KEY']
     config.find_a_job_api_id = ENV['FIND_A_JOB_API_ID']

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,3 +206,9 @@ en-GB:
               blank: Enter a postcode
             dob:
               invalid: Enter a valid date of birth
+
+  active_admin:
+    filters:
+      predicates:
+        from: "From"
+        to: "To"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,76 +1,83 @@
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
-  ActiveAdmin.routes(self) if Rails.env.development?
   mount Flipflop::Engine => '/features' if Rails.env.development?
 
-  get '/pages/:page', to: 'pages#show'
+  constraints(AdminConstraint.new) do
+    ActiveAdmin.routes(self)
 
-  get '/status', to: 'status#index'
-
-  get '/404', to: 'errors#not_found', via: :all
-  get '/422', to: 'errors#unprocessable_entity', via: :all
-  get '/500', to: 'errors#internal_server_error', via: :all
-
-  get 'task-list', to: 'pages#task_list'
-  get 'cookies-policy', to: 'pages#cookies_policy'
-  get 'privacy-policy', to: 'pages#privacy_policy'
-
-  get 'action-plan', to: 'pages#action_plan'
-  match(
-    'jobs-near-me',
-    to: 'job_vacancies#index', as: :jobs_near_me, via: %i[get post]
-  )
-  get 'offers-near-me', to: 'pages#offers_near_me'
-  get 'training-questions', to: 'questions#training'
-  post 'training-questions', to: 'questions#training_answers'
-  get 'job-hunting-questions', to: 'questions#job_hunting'
-  post 'job-hunting-questions', to: 'questions#job_hunting_answers'
-  get 'course-postcode-search-error', to: 'errors#course_postcode_search_error'
-  get 'return-to-saved-results-error', to: 'errors#return_to_saved_results_error'
-  get 'save-results-error', to: 'errors#save_results_error'
-
-  get 'location-ineligible', to: 'pages#location_ineligible'
-  get 'postcode-search-error', to: 'errors#postcode_search_error'
-  get 'jobs-near-me-error', to: 'errors#jobs_near_me_error'
-
-  match(
-    'courses/:topic_id',
-    to: 'courses#index', as: :courses, via: %i[get post], constraints: { topic_id: /maths|english/ }
-  )
-
-  resources :check_your_skills, path: 'check-your-skills', only: %i[index] do
-    get :results, on: :collection
+    get '/', to: 'admin/dashboard#index'
   end
 
-  resources :job_profiles, path: 'job-profiles', only: %i[index show destroy] do
-    get :results, on: :collection
-    post :target, on: :member
-    resources :skills do
-      get :index, controller: 'job_profiles_skills', on: :collection
+  constraints(UserConstraint.new) do
+    get '/pages/:page', to: 'pages#show'
+
+    get '/status', to: 'status#index'
+
+    get '/404', to: 'errors#not_found', via: :all
+    get '/422', to: 'errors#unprocessable_entity', via: :all
+    get '/500', to: 'errors#internal_server_error', via: :all
+
+    get 'task-list', to: 'pages#task_list'
+    get 'cookies-policy', to: 'pages#cookies_policy'
+    get 'privacy-policy', to: 'pages#privacy_policy'
+
+    get 'action-plan', to: 'pages#action_plan'
+    match(
+      'jobs-near-me',
+      to: 'job_vacancies#index', as: :jobs_near_me, via: %i[get post]
+    )
+    get 'offers-near-me', to: 'pages#offers_near_me'
+    get 'training-questions', to: 'questions#training'
+    post 'training-questions', to: 'questions#training_answers'
+    get 'job-hunting-questions', to: 'questions#job_hunting'
+    post 'job-hunting-questions', to: 'questions#job_hunting_answers'
+    get 'course-postcode-search-error', to: 'errors#course_postcode_search_error'
+    get 'return-to-saved-results-error', to: 'errors#return_to_saved_results_error'
+    get 'save-results-error', to: 'errors#save_results_error'
+
+    get 'location-ineligible', to: 'pages#location_ineligible'
+    get 'postcode-search-error', to: 'errors#postcode_search_error'
+    get 'jobs-near-me-error', to: 'errors#jobs_near_me_error'
+
+    match(
+      'courses/:topic_id',
+      to: 'courses#index', as: :courses, via: %i[get post], constraints: { topic_id: /maths|english/ }
+    )
+
+    resources :check_your_skills, path: 'check-your-skills', only: %i[index] do
+      get :results, on: :collection
     end
+
+    resources :job_profiles, path: 'job-profiles', only: %i[index show destroy] do
+      get :results, on: :collection
+      post :target, on: :member
+      resources :skills do
+        get :index, controller: 'job_profiles_skills', on: :collection
+      end
+    end
+
+    resources :skills_matcher, path: 'job-matches', only: %i[index]
+    resources :skills, only: %i[index]
+
+    get 'your-information', to: 'user_personal_data#index'
+    post 'your-information', to: 'user_personal_data#create'
+
+    resources :user_personal_data, only: %i[index create]
+
+    resources :feedback_surveys, only: %i[create]
+
+    get 'save-your-results', to: 'users#new'
+    post 'save-your-results', to: 'users#create'
+    post 'email-sent-again', to: 'users#registration_send_email_again'
+
+    get 'return-to-saved-results', to: 'users#return_to_saved_results'
+    post 'return-to-saved-results', to: 'users#sign_in'
+    post 'link-sent-again', to: 'users#sign_in_send_email_again'
+
+    get 'link-expired', to: 'users#link_expired'
+    get '/sign-in/:token', to: 'passwordless/sessions#show', authenticatable: 'user', as: :token_sign_in
+
+    root to: 'home#index'
   end
-
-  resources :skills_matcher, path: 'job-matches', only: %i[index]
-  resources :skills, only: %i[index]
-
-  get 'your-information', to: 'user_personal_data#index'
-  post 'your-information', to: 'user_personal_data#create'
-
-  resources :user_personal_data, only: %i[index create]
-
-  resources :feedback_surveys, only: %i[create]
-
-  get 'save-your-results', to: 'users#new'
-  post 'save-your-results', to: 'users#create'
-  post 'email-sent-again', to: 'users#registration_send_email_again'
-
-  get 'return-to-saved-results', to: 'users#return_to_saved_results'
-  post 'return-to-saved-results', to: 'users#sign_in'
-  post 'link-sent-again', to: 'users#sign_in_send_email_again'
-
-  get 'link-expired', to: 'users#link_expired'
-  get '/sign-in/:token', to: 'passwordless/sessions#show', authenticatable: 'user', as: :token_sign_in
-
-  root to: 'home#index'
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/routing/admin_spec.rb
+++ b/spec/routing/admin_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe 'routes for admin pages', type: :routing do
+  context 'when admin mode is enabled' do
+    around do |example|
+      Rails.configuration.admin_mode = true
+      example.run
+    ensure
+      Rails.configuration.admin_mode = false
+    end
+
+    it 'successfully routes site root to admin/dashboard#index' do
+      expect(get('/')).to route_to(controller: 'admin/dashboard', action: 'index')
+    end
+
+    it 'successfully routes /admin path to admin/dashboard#index' do
+      expect(get('/admin')).to route_to(controller: 'admin/dashboard', action: 'index')
+    end
+
+    it 'successfully routes /admin/dashboard to admin/dashboard#index' do
+      expect(get('/admin/dashboard')).to route_to(controller: 'admin/dashboard', action: 'index')
+    end
+
+    it 'successfully routes to admin/categories#index' do
+      expect(get('/admin/categories')).to route_to(controller: 'admin/categories', action: 'index')
+    end
+
+    it 'successfully routes to admin/courses#index' do
+      expect(get('/admin/courses')).to route_to(controller: 'admin/courses', action: 'index')
+    end
+
+    it 'successfully routes to admin/feedback_surveys#index' do
+      expect(get('/admin/feedback_surveys')).to route_to(controller: 'admin/feedback_surveys', action: 'index')
+    end
+
+    it 'successfully routes to admin/job_profiles#index' do
+      expect(get('/admin/job_profiles')).to route_to(controller: 'admin/job_profiles', action: 'index')
+    end
+
+    it 'successfully routes to admin/skills#index' do
+      expect(get('/admin/skills')).to route_to(controller: 'admin/skills', action: 'index')
+    end
+
+    it 'successfully routes to admin/user_personal_data#index' do
+      expect(get('/admin/user_personal_data')).to route_to(controller: 'admin/user_personal_data', action: 'index')
+    end
+
+    it 'does not route requests to main application' do
+      expect(get('/task-list')).not_to be_routable
+    end
+  end
+
+  context 'when admin mode is disabled' do
+    it 'successfully routes site root to home#index' do
+      expect(get('/')).to route_to(controller: 'home', action: 'index')
+    end
+
+    it 'does not route /admin path' do
+      expect(get('/admin')).not_to be_routable
+    end
+
+    it 'does not route /admin/dashboard path' do
+      expect(get('/admin/dashboard')).not_to be_routable
+    end
+
+    it 'does not route /admin/categories' do
+      expect(get('/admin/categories')).not_to be_routable
+    end
+
+    it 'does not route /admin/courses' do
+      expect(get('/admin/courses')).not_to be_routable
+    end
+
+    it 'does not route /admin/feedback_surveys' do
+      expect(get('/admin/feedback_surveys')).not_to be_routable
+    end
+
+    it 'does not route /admin/job_profiles' do
+      expect(get('/admin/job_profiles')).not_to be_routable
+    end
+
+    it 'does not route /admin/skills' do
+      expect(get('/admin/skills')).not_to be_routable
+    end
+
+    it 'does not route /admin/user_personal_data' do
+      expect(get('/admin/user_personal_data')).not_to be_routable
+    end
+
+    it 'routes requests to main application' do
+      expect(get('/task-list')).to route_to(controller: 'pages', action: 'task_list')
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-804

### Changes proposed in this pull request
If this variable is set then only the ActiveAdmin routes are exposed (not yet authenticated). If not set then only the user facing routes are exposed. I left the Feature flag UI out of this for now as we might want to use that in either mode, and it's only available for local development.

With admin mode on, site root directs to the admin pages and no customer facing routes are available. With the admin mode flag off the site behaves in customer facing mode only, no admin routes are available.

Routes are not evaluated dynamically so the proposed `if / then / else` approach didn't work. Adding custom constraint classes proved to be a nice solution though. The diff is a little messy but essentially this just adds a `constraints` block around the two sets of routes.

### Guidance to review
Note that this does not yet introduce authentication. To test locally, set an environment variable (perhaps in `.env.development.local`):

```
ADMIN_MODE=true
```

One the heroku review app I've enabled admin mode and also setup some sample test data for feedback surveys and user personal data.