### PR TITLE
Customize event category for outbound links

### DIFF
--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -4,6 +4,6 @@
   <p class="govuk-body govuk-!-margin-bottom-0">Distance: <b><%= course.distance.round(1) %> miles</b></p>
   <p class="govuk-body-s"><%= course.full_address %></p>
   <p class="govuk-body-s">Tel:<%= link_to(course.phone_number, "tel:#{course.phone_number}", class: 'govuk-!-padding-left-1 govuk-link' ) %></p>
-  <%= link_to 'Visit website', course.url, class: 'govuk-!-margin-bottom-6 govuk-button', aria: { label: "Visit website of #{course.provider}" }, data: { module: 'govuk-button' } %>
+  <%= link_to 'Visit website', course.url, class: 'govuk-!-margin-bottom-6 govuk-button', aria: { label: "Visit website of #{course.provider}" }, data: { module: 'govuk-button', ga_event_category: course.topic } %>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-top-0">
 </li>

--- a/app/webpacker/packs/outbound-link-tracking.js
+++ b/app/webpacker/packs/outbound-link-tracking.js
@@ -25,10 +25,11 @@ function OutboundLinkTracking () {
           addEvent(links[i], 'click', function(e) {
             var url = this.getAttribute('href');
             var win = this.getAttribute('target');
+            var event_category = this.getAttribute('data-ga-event-category') || 'outbound';
 
             // Log event to Analytics, once done, go to the link
             gtag('event', 'click', {
-              'event_category': 'outbound',
+              'event_category': event_category,
               'event_label': url,
               'transport_type': 'beacon',
               'event_callback': hitCallbackHandler(url, win)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
-      "fingerprint": "94ee8acee565270826d7c0d23287a262ebb719194e83207a83de31cd19cdf3a2",
+      "fingerprint": "580b682e8bc524f1a62645390f18000ae40fa0c30c07ab5ed5b10d3105f29bd0",
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/courses/_course.html.erb",
       "line": 7,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"Visit website\", (Unresolved Model).new.url, :class => \"govuk-!-margin-bottom-6 govuk-button\", :aria => ({ :label => (\"Visit website of #{(Unresolved Model).new.provider}\") }), :data => ({ :module => \"govuk-button\" }))",
+      "code": "link_to(\"Visit website\", (Unresolved Model).new.url, :class => \"govuk-!-margin-bottom-6 govuk-button\", :aria => ({ :label => (\"Visit website of #{(Unresolved Model).new.provider}\") }), :data => ({ :module => \"govuk-button\", :ga_event_category => (Unresolved Model).new.topic }))",
       "render_path": [
         {
           "type": "template",
@@ -37,7 +37,7 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/skills_matcher/index.html.erb",
-      "line": 22,
+      "line": 23,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => JobProfileDecorator.decorate(Kaminari.paginate_array(skills_matcher.match).page(params[:page])), {})",
       "render_path": [
@@ -45,7 +45,7 @@
           "type": "controller",
           "class": "SkillsMatcherController",
           "method": "index",
-          "line": 8,
+          "line": 11,
           "file": "app/controllers/skills_matcher_controller.rb",
           "rendered": {
             "name": "skills_matcher/index",
@@ -75,7 +75,7 @@
         {
           "type": "template",
           "name": "job_vacancies/index",
-          "line": 42,
+          "line": 43,
           "file": "app/views/job_vacancies/index.html.erb",
           "rendered": {
             "name": "job_vacancies/_job_vacancy",
@@ -92,6 +92,6 @@
       "note": "The attribute value is escaped at storage level as part of ActiveRecord behaviour. There is no danger."
     }
   ],
-  "updated": "2019-11-18 16:45:08 +0000",
+  "updated": "2019-12-13 15:35:44 +0000",
   "brakeman_version": "4.7.1"
 }


### PR DESCRIPTION
When users click on different course providers,
we want to track which topic these course
providers fall under.

![Screen Shot 2019-12-13 at 15 05 20](https://user-images.githubusercontent.com/1955084/70810248-588dcf80-1dbb-11ea-804f-2b7df86bcbf6.png)

https://dfedigital.atlassian.net/browse/GET-846
