### PR TITLE
Disable irrelevant health checks in admin mode

### DIFF
--- a/app/services/health_check/check_base.rb
+++ b/app/services/health_check/check_base.rb
@@ -2,6 +2,10 @@ module HealthCheck
   class CheckBase
     attr_reader :output
 
+    def enabled?
+      true
+    end
+
     def name
       raise NotImplementedError
     end

--- a/app/services/health_check/find_a_job_check.rb
+++ b/app/services/health_check/find_a_job_check.rb
@@ -2,6 +2,10 @@ module HealthCheck
   class FindAJobCheck < CheckBase
     CACHE_EXPIRY = 50.seconds
 
+    def enabled?
+      Rails.configuration.admin_mode == false
+    end
+
     def name
       'api:findajob.dwp.gov.uk'
     end

--- a/app/services/health_check/notify_check.rb
+++ b/app/services/health_check/notify_check.rb
@@ -2,6 +2,10 @@ module HealthCheck
   class NotifyCheck < CheckBase
     CACHE_EXPIRY = 42.seconds
 
+    def enabled?
+      Rails.configuration.admin_mode == false
+    end
+
     def name
       'api:notifications.service.gov.uk'
     end

--- a/app/services/health_check/postcodes_check.rb
+++ b/app/services/health_check/postcodes_check.rb
@@ -2,6 +2,10 @@ module HealthCheck
   class PostcodesCheck < CheckBase
     CACHE_EXPIRY = 44.seconds
 
+    def enabled?
+      Rails.configuration.admin_mode == false
+    end
+
     def name
       'api:postcodes.io'
     end

--- a/app/services/health_check/report_service.rb
+++ b/app/services/health_check/report_service.rb
@@ -33,7 +33,7 @@ module HealthCheck
     end
 
     def checks
-      @checks ||= CheckBase.descendants.map(&:new)
+      @checks ||= CheckBase.descendants.map(&:new).select(&:enabled?)
     end
   end
 end

--- a/app/services/health_check/sessions_check.rb
+++ b/app/services/health_check/sessions_check.rb
@@ -2,6 +2,10 @@ module HealthCheck
   class SessionsCheck < CheckBase
     CACHE_EXPIRY = 48.seconds
 
+    def enabled?
+      Rails.configuration.admin_mode == false
+    end
+
     def name
       'database:sessions'
     end

--- a/spec/services/health_check/find_a_job_check_spec.rb
+++ b/spec/services/health_check/find_a_job_check_spec.rb
@@ -5,6 +5,19 @@ RSpec.describe HealthCheck::FindAJobCheck do
 
   let(:ping_response) { { 'ping' => 'ok' } }
 
+  describe '#enabled' do
+    it 'is true when not in admin mode' do
+      expect(check).to be_enabled
+    end
+
+    it 'is false when in admin mode' do
+      Rails.configuration.admin_mode = true
+      expect(check).not_to be_enabled
+    ensure
+      Rails.configuration.admin_mode = false
+    end
+  end
+
   describe '#status' do
     context 'with failed Find a Job API call' do
       it 'returns warn on api error' do

--- a/spec/services/health_check/notify_check_spec.rb
+++ b/spec/services/health_check/notify_check_spec.rb
@@ -10,6 +10,19 @@ RSpec.describe HealthCheck::NotifyCheck do
     allow(NotifyService).to receive(:new).and_return(notify_service)
   end
 
+  describe '#enabled' do
+    it 'is true when not in admin mode' do
+      expect(check).to be_enabled
+    end
+
+    it 'is false when in admin mode' do
+      Rails.configuration.admin_mode = true
+      expect(check).not_to be_enabled
+    ensure
+      Rails.configuration.admin_mode = false
+    end
+  end
+
   describe '#status' do
     context 'with failed notify API call' do
       before do

--- a/spec/services/health_check/postcodes_check_spec.rb
+++ b/spec/services/health_check/postcodes_check_spec.rb
@@ -3,6 +3,19 @@ require 'rails_helper'
 RSpec.describe HealthCheck::PostcodesCheck do
   subject(:check) { described_class.new }
 
+  describe '#enabled' do
+    it 'is true when not in admin mode' do
+      expect(check).to be_enabled
+    end
+
+    it 'is false when in admin mode' do
+      Rails.configuration.admin_mode = true
+      expect(check).not_to be_enabled
+    ensure
+      Rails.configuration.admin_mode = false
+    end
+  end
+
   describe '#status' do
     context 'with failed geocoding API call' do
       before do

--- a/spec/services/health_check/sessions_check_spec.rb
+++ b/spec/services/health_check/sessions_check_spec.rb
@@ -3,6 +3,19 @@ require 'rails_helper'
 RSpec.describe HealthCheck::SessionsCheck do
   subject(:check) { described_class.new }
 
+  describe '#enabled' do
+    it 'is true when not in admin mode' do
+      expect(check).to be_enabled
+    end
+
+    it 'is false when in admin mode' do
+      Rails.configuration.admin_mode = true
+      expect(check).not_to be_enabled
+    ensure
+      Rails.configuration.admin_mode = false
+    end
+  end
+
   describe '#status' do
     context 'with no sessions populated' do
       it 'returns fail' do


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-855

### Changes proposed in this pull request
We don't need to connect to external services, and will not be using database backed sessions for admin mode, so it doesn't make sense to have these enabled in the reporting service when the site is in admin mode. This should fix the slot swapping when deploying admin mode site on Azure.

### Guidance to review
Set `ADMIN_MODE=true` and then examine results of `/status` endpoint. I'll set that environment variable on heroku review app once this has been deployed.
