### PR TITLE
Generate ActiveAdmin assets for deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN bundle install --clean --force --without "development test" \
 COPY package.json yarn.lock ./
 RUN yarn install
 COPY . ./
-RUN bundle exec rails webpacker:compile SECRET_KEY_BASE=stubbed
+# assets:precompile is necessary only for ActiveAdmin assets
+RUN bundle exec rails webpacker:compile assets:precompile SECRET_KEY_BASE=stubbed
 
 FROM ruby:2.6-alpine
 


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-856

### Changes proposed in this pull request
This is a temporary measure until ActiveAdmin adds support for Webpacker. There is an ongoing PR to add Webpacker support to ActiveAdmin in a future release, but we can't depend on this being released soon. In the meantime, adding `assets:precompile` step uses the sprockets based pipeline to generate the ActiveAdmin related assets only.

### Guidance to review
Deployed to Dev1, with `ADMIN_MODE` flag on, and it's all working nicely.
