### PR TITLE
Adds all of the newly scraped job profiles to the list of non-recommended jobs

### DIFF
--- a/lib/tasks/data_import/update_recommended_job_profiles.rake
+++ b/lib/tasks/data_import/update_recommended_job_profiles.rake
@@ -8,6 +8,7 @@ namespace :data_import do
       non_recommended_jobs = JobProfile.where(slug: %w[
                                                 advertising-art-director
                                                 advertising-media-buyer
+                                                aid-worker
                                                 anaesthetist
                                                 archaeologist
                                                 archivist
@@ -18,7 +19,10 @@ namespace :data_import do
                                                 barrister
                                                 biochemist
                                                 botanist
+                                                boxer
+                                                celebrant
                                                 chiropractor
+                                                civil-service-manager
                                                 climate-scientist
                                                 clinical-psychologist
                                                 cognitive-behavioural-therapist
@@ -36,6 +40,7 @@ namespace :data_import do
                                                 ecologist
                                                 environmental-consultant
                                                 ergonomist
+                                                film-critic
                                                 forensic-psychologist
                                                 geneticist
                                                 geoscientist
@@ -47,6 +52,7 @@ namespace :data_import do
                                                 materials-engineer
                                                 medical-herbalist
                                                 medical-illustrator
+                                                motorsport-engineer
                                                 music-therapist
                                                 nanotechnologist
                                                 naturopath
@@ -66,6 +72,7 @@ namespace :data_import do
                                                 pathologist
                                                 pharmacist
                                                 pharmacologist
+                                                physician-associate
                                                 physicist
                                                 play-therapist
                                                 psychiatrist
@@ -75,11 +82,13 @@ namespace :data_import do
                                                 royal-navy-officer
                                                 school-nurse
                                                 seismologist
+                                                sonographer
                                                 speech-and-language-therapist
                                                 sport-and-exercise-psychologist
                                                 sports-scientist
                                                 surgeon
                                                 technical-textiles-designer
+                                                test-lead
                                                 translator
                                                 vet
                                                 zoologist


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-862

### Changes proposed in this pull request
Once we have growth data for these then the list can be updated; the data for these has been manually changed already but it's good to keep the rake task in sync just in case someone runs this accidentally in future.

### Guidance to review
Run the rake task - will need to have the new job profiles scraped already.
