### PR TITLE
Get 746 skills rarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ Once job profiles have been scraped from NCS, run the relevant rake task (a one 
   bundle exec rails data_import:update_recommended_job_profiles
 ```
 
+### Skills rarity
+The skills are each associated with one or more job profiles and used to generate matching job profiles within the skills matcher. When job profiles have the same number of shared skills and identical growth prospects, then skills rarity (or ranked rareness) is used to further order skills matcher results. The rarity score is precalculated and held against each skill by running the rake task:
+
+```bash
+  bundle exec rails data_import:update_skills_rarity
+```
+
 ### Additional job profile data
 Growth information and SOC codes for job profiles are imported via an Excel spreadsheet and used to update specific attributes of existing job profiles matched by name (i.e. these must have been previously imported by running the scraping tasks). Copy the relevant spreadsheet locally and then run rake task:
 

--- a/app/admin/skills.rb
+++ b/app/admin/skills.rb
@@ -1,4 +1,5 @@
 if defined?(ActiveAdmin)
+  # rubocop:disable Metrics/BlockLength
   ActiveAdmin.register Skill do
     actions :all, except: %i[new destroy]
 
@@ -10,6 +11,7 @@ if defined?(ActiveAdmin)
       column :id
       column :enabled
       column :name
+      column :rarity
       column :job_profiles
       actions
     end
@@ -24,6 +26,7 @@ if defined?(ActiveAdmin)
       column :id
       column :enabled
       column :name
+      column :rarity
       column :job_profiles do |skill|
         skill.job_profiles.map(&:name)
       end
@@ -31,4 +34,5 @@ if defined?(ActiveAdmin)
 
     config.sort_order = 'id_asc'
   end
+  # rubocop:enable Metrics/BlockLength
 end

--- a/app/models/job_profile_skill.rb
+++ b/app/models/job_profile_skill.rb
@@ -1,4 +1,14 @@
 class JobProfileSkill < PrimaryActiveRecordBase
   belongs_to :job_profile
   belongs_to :skill
+
+  def self.update_rarity
+    rarity_ranking = select(:skill_id,
+                            'count(1) as times_occurring',
+                            'rank() over (order by count(1)) as rarity_rank').group(:skill_id)
+
+    rarity_ranking.all.each do |row|
+      Skill.update(row.skill_id, rarity: row.rarity_rank)
+    end
+  end
 end

--- a/app/models/skills_matcher.rb
+++ b/app/models/skills_matcher.rb
@@ -23,7 +23,8 @@ class SkillsMatcher
 
   def skills_matched_query
     JobProfileSkill
-      .select(:job_profile_id, 'COUNT(job_profile_id) AS skills_matched')
+      .select(:job_profile_id, 'MIN(rarity) as skills_rarity', 'COUNT(job_profile_id) AS skills_matched')
+      .joins('LEFT JOIN skills ON skills.id = job_profile_skills.skill_id')
       .where(skill_id: user_session.skill_ids)
       .group(:job_profile_id)
       .to_sql
@@ -45,9 +46,9 @@ class SkillsMatcher
   def order_options
     case options[:order]
     when :growth
-      { growth: :desc, skills_matched: :desc, name: :asc }
+      { growth: :desc, skills_matched: :desc, skills_rarity: :asc, name: :asc }
     else
-      { skills_matched: :desc, growth: :desc, name: :asc }
+      { skills_matched: :desc, growth: :desc, skills_rarity: :asc, name: :asc }
     end
   end
 

--- a/db/migrate/20191217141306_add_rarity_to_skills.rb
+++ b/db/migrate/20191217141306_add_rarity_to_skills.rb
@@ -1,0 +1,6 @@
+class AddRarityToSkills < ActiveRecord::Migration[6.0]
+  def change
+    add_column :skills, :rarity, :integer
+    add_index :skills, :rarity
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_31_120450) do
+ActiveRecord::Schema.define(version: 2019_12_17_141306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,8 +100,10 @@ ActiveRecord::Schema.define(version: 2019_10_31_120450) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "enabled", default: true, null: false
+    t.integer "rarity"
     t.index ["enabled"], name: "index_skills_on_enabled"
     t.index ["name"], name: "index_skills_on_name"
+    t.index ["rarity"], name: "index_skills_on_rarity"
   end
 
 end

--- a/lib/tasks/data_import/update_skills_rarity.rake
+++ b/lib/tasks/data_import/update_skills_rarity.rake
@@ -1,0 +1,9 @@
+namespace :data_import do
+  # bin/rails data_import:update_skills_rarity
+  desc 'Sets correct rarity ranking for all skills'
+  task update_skills_rarity: :environment do
+    print 'Updating rarity ranking for all skills'
+
+    JobProfileSkill.update_rarity
+  end
+end

--- a/spec/models/job_profile_skill_spec.rb
+++ b/spec/models/job_profile_skill_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe JobProfileSkill do
+  describe '.update_rarity' do
+    let(:unique_skill) { create(:skill) }
+    let(:rare_skill) { create(:skill) }
+    let(:common_skill) { create(:skill) }
+    let(:orphan_skill) { create(:skill) }
+    let(:all_skills) { [unique_skill, rare_skill, common_skill, orphan_skill] }
+
+    before do
+      create(:job_profile, skills: [unique_skill, rare_skill, common_skill])
+      create(:job_profile, skills: [rare_skill, common_skill])
+      create(:job_profile, skills: [common_skill])
+    end
+
+    it 'calculates correct rarity for every skill' do
+      described_class.update_rarity
+      all_skills.map(&:reload)
+      expect(all_skills.map(&:rarity)).to eq [1, 2, 3, nil]
+    end
+  end
+end

--- a/spec/models/skills_matcher_spec.rb
+++ b/spec/models/skills_matcher_spec.rb
@@ -227,6 +227,60 @@ RSpec.describe SkillsMatcher do
       )
     end
 
+    it 'arranges job profiles in matching skills, job growth and skills rarity order' do
+      skill1 = create(:skill, rarity: nil)
+      skill2 = create(:skill, rarity: 3)
+      skill3 = create(:skill, rarity: 2)
+      skill4 = create(:skill, rarity: 1)
+      job_profile1 = create(:job_profile)
+      job_profile2 = create(:job_profile, skills: [skill1, skill2])
+      job_profile3 = create(:job_profile, skills: [skill1, skill3])
+      job_profile4 = create(:job_profile, skills: [skill1, skill4])
+
+      session = create_fake_session(
+        job_profile_ids: [job_profile1.id],
+        job_profile_skills: {
+          job_profile1.id.to_s => [skill1.id, skill2.id, skill3.id, skill4.id]
+        }
+      )
+
+      matcher = described_class.new(UserSession.new(session))
+      expect(matcher.match).to eq(
+        [
+          job_profile4,
+          job_profile3,
+          job_profile2
+        ]
+      )
+    end
+
+    it 'arranges job profiles in job growth, matching skills and skills rarity order' do
+      skill1 = create(:skill, rarity: nil)
+      skill2 = create(:skill, rarity: 3)
+      skill3 = create(:skill, rarity: 2)
+      skill4 = create(:skill, rarity: 1)
+      job_profile1 = create(:job_profile)
+      job_profile2 = create(:job_profile, growth: 0, skills: [skill1, skill2])
+      job_profile3 = create(:job_profile, growth: 0, skills: [skill1, skill3])
+      job_profile4 = create(:job_profile, growth: 0, skills: [skill1, skill4])
+
+      session = create_fake_session(
+        job_profile_ids: [job_profile1.id],
+        job_profile_skills: {
+          job_profile1.id.to_s => [skill1.id, skill2.id, skill3.id, skill4.id]
+        }
+      )
+
+      matcher = described_class.new(UserSession.new(session), order: :growth)
+      expect(matcher.match).to eq(
+        [
+          job_profile4,
+          job_profile3,
+          job_profile2
+        ]
+      )
+    end
+
     it 'ignores unrecommended jobs' do
       skill = create(:skill)
       job_profile1 = create(:job_profile, skills: [skill])

--- a/spec/tasks/update_skills_rarity_spec.rb
+++ b/spec/tasks/update_skills_rarity_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'support/tasks'
+
+RSpec.describe 'data_import:update_skills_rarity' do
+  let(:unique_skill) { create(:skill) }
+  let(:rare_skill) { create(:skill) }
+  let(:common_skill) { create(:skill) }
+  let(:orphan_skill) { create(:skill) }
+  let(:all_skills) { [unique_skill, rare_skill, common_skill, orphan_skill] }
+
+  before do
+    create(:job_profile, skills: [unique_skill, rare_skill, common_skill])
+    create(:job_profile, skills: [rare_skill, common_skill])
+    create(:job_profile, skills: [common_skill])
+  end
+
+  it 'calculates correct rarity for every skill' do
+    task.execute
+    all_skills.map(&:reload)
+    expect(all_skills.map(&:rarity)).to eq [1, 2, 3, nil]
+  end
+end


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/GET-746

### Changes proposed in this pull request
Adds a new `rarity` attribute to `Skill` model. This is precalculated via a new rake task and represents the frequency of each skill by ranking them. The lowest rank of `1` represents unique skills, higher numbers represent more commonplace skills.

When job profiles have identical growth and number of skills matched, then the skills rarity is used to further prioritise matches. This requires updating the skills matcher to also join against skills table to determine appropriate rarity for each skill. However, In order to avoid returning duplicate job profile results the query returns only the lowest rarity of all skills matched to a job profile (i.e. the rarest).

Also added new rarity attribute to admin interface and added appropriate test coverage to demonstrate ordering works as expected.

### Guidance to review
* Add the database migrations
* Run the new rake task
* Try to test with a mixture of rare and common skills (fun!)
