### PR TITLE
Remove Bing key from ENV templates to allow it to be optional

### DIFF
--- a/azure/config/dev1.parameters.json
+++ b/azure/config/dev1.parameters.json
@@ -91,14 +91,6 @@
         "secretName": "dev-findAJobApiKey"
       }
     },
-    "bingSpellCheckApiKey": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
-        },
-        "secretName": "dev-bingSpellCheckApiKey"
-      }
-    },
     "customHostName": {
       "value": "dev1.nrs-ghtr.org.uk"
     },

--- a/azure/config/dev2.parameters.json
+++ b/azure/config/dev2.parameters.json
@@ -72,14 +72,6 @@
         "secretName": "dev-notifyApiKey"
       }
     },
-    "bingSpellCheckApiKey": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
-        },
-        "secretName": "dev-bingSpellCheckApiKey"
-      }
-    },
     "findAJobApiId": {
       "reference": {
         "keyVault": {

--- a/azure/config/prod.parameters.json
+++ b/azure/config/prod.parameters.json
@@ -75,14 +75,6 @@
         "secretName": "prod-notifyApiKey"
       }
     },
-    "bingSpellCheckApiKey": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/eaff0b89-17c5-4a97-9a00-f77551fe2c27/resourceGroups/s108p01-shared/providers/Microsoft.KeyVault/vaults/s108p01-shared-kv-01"
-        },
-        "secretName": "prod-bingSpellCheckApiKey"
-      }
-    },
     "findAJobApiId": {
       "reference": {
         "keyVault": {

--- a/azure/config/qa.parameters.json
+++ b/azure/config/qa.parameters.json
@@ -91,14 +91,6 @@
         "secretName": "qa-findAJobApiKey"
       }
     },
-    "bingSpellCheckApiKey": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
-        },
-        "secretName": "qa-bingSpellCheckApiKey"
-      }
-    },
     "customHostName": {
       "value": "qa-origin.nrs-ghtr.org.uk"
     },

--- a/azure/config/uat.parameters.json
+++ b/azure/config/uat.parameters.json
@@ -75,14 +75,6 @@
         "secretName": "uat-notifyApiKey"
       }
     },
-    "bingSpellCheckApiKey": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
-        },
-        "secretName": "uat-bingSpellCheckApiKey"
-      }
-    },
     "findAJobApiId": {
       "reference": {
         "keyVault": {

--- a/azure/config/ut.parameters.json
+++ b/azure/config/ut.parameters.json
@@ -72,14 +72,6 @@
         "secretName": "ut-notifyApiKey"
       }
     },
-    "bingSpellCheckApiKey": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
-        },
-        "secretName": "ut-bingSpellCheckApiKey"
-      }
-    },
     "findAJobApiId": {
       "reference": {
         "keyVault": {


### PR DESCRIPTION
Removing the Bing key from the specific ENV templates will allow it to be optional. This has been tested on Dev1 