### PR TITLE
SPIKE: GET-866-GA-location-override 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,7 +40,7 @@ class ApplicationController < ActionController::Base
   end
 
   def track_events(props = [])
-    TrackingService.new.track_events(props: props)
+    TrackingService.new(client_tracking_data: client_tracking_data).track_events(props: props)
   rescue TrackingService::TrackingServiceError
     nil
   end

--- a/app/helpers/ga_tracking_helper.rb
+++ b/app/helpers/ga_tracking_helper.rb
@@ -13,7 +13,7 @@ module GaTrackingHelper
 
   def client_tracking_data
     {
-      ga_cookie: cookies[:_ga],
+      ga_cookie: cookies['_ga'],
       ip_address: request.remote_ip,
       user_agent: request.env['HTTP_USER_AGENT']
     }

--- a/app/helpers/ga_tracking_helper.rb
+++ b/app/helpers/ga_tracking_helper.rb
@@ -11,6 +11,14 @@ module GaTrackingHelper
     )
   end
 
+  def client_tracking_data
+    {
+      ga_cookie: cookies[:_ga],
+      ip_address: request.remote_ip,
+      user_agent: request.env['HTTP_USER_AGENT']
+    }
+  end
+
   private
 
   def build_event_props(key:, label:, values:)

--- a/app/services/tracking_service.rb
+++ b/app/services/tracking_service.rb
@@ -48,7 +48,7 @@ class TrackingService
 
   def client_tracking_info
     {
-      cid: client_tracking_data[:ga_cookies] || SecureRandom.uuid,
+      cid: client_tracking_data[:ga_cookie] || SecureRandom.uuid,
       ua: client_tracking_data[:user_agent],
       uip: client_tracking_data[:ip_address]
     }

--- a/app/services/tracking_service.rb
+++ b/app/services/tracking_service.rb
@@ -8,10 +8,10 @@ class TrackingService
 
   MAX_BATCH_SIZE = 20
 
-  attr_reader :ga_tracking_id
+  attr_reader :client_tracking_data
 
-  def initialize(ga_tracking_id: Rails.configuration.google_analytics_tracking_id, debug: false)
-    @ga_tracking_id = ga_tracking_id
+  def initialize(client_tracking_data: {}, debug: false)
+    @client_tracking_data = client_tracking_data
     @debug = debug
   end
 
@@ -46,19 +46,28 @@ class TrackingService
     @debug
   end
 
-  def anonymized_client_id
-    SecureRandom.uuid
+  def client_tracking_info
+    {
+      cid: client_tracking_data[:ga_cookies] || SecureRandom.uuid,
+      ua: client_tracking_data[:user_agent],
+      uip: client_tracking_data[:ip_address]
+    }
+  end
+
+  def ga_tracking_id
+    Rails.configuration.google_analytics_tracking_id
   end
 
   def build_payload(key, label, value)
     URI.encode_www_form(
-      tid: ga_tracking_id,
-      cid: anonymized_client_id,
-      t: 'event',
-      v: 1,
-      ec: key,
-      el: label,
-      ea: value
+      {
+        tid: ga_tracking_id,
+        t: 'event',
+        v: 1,
+        ec: key,
+        el: label,
+        ea: value
+      }.merge(client_tracking_info)
     )
   end
 


### PR DESCRIPTION
### Context

Finding a way to override the location in GA and use the client's actual IP + User-agent.