### PR TITLE
GET-844 Build specific apprenticeship link for action plan

### DIFF
--- a/app/helpers/action_plan_helper.rb
+++ b/app/helpers/action_plan_helper.rb
@@ -1,0 +1,25 @@
+module ActionPlanHelper
+  APPRENTICESHIPS_URL = 'https://www.findapprenticeship.service.gov.uk/apprenticeships'.freeze
+
+  def build_apprenticeships_url(job_name:, postcode: nil)
+    build_uri = URI(APPRENTICESHIPS_URL)
+    build_uri.query = URI.encode_www_form(query_values(job_name, postcode))
+    build_uri.to_s
+  end
+
+  private
+
+  def query_values(job_name, postcode)
+    {
+      'Keywords' => job_name.downcase,
+      'Location' => outcode(postcode),
+      'WithinDistance' => 20
+    }.reject { |_k, v| v.blank? }
+  end
+
+  def outcode(postcode)
+    return unless postcode
+
+    UKPostcode.parse(postcode).outcode
+  end
+end

--- a/app/views/pages/action_plan.html.erb
+++ b/app/views/pages/action_plan.html.erb
@@ -47,7 +47,7 @@
       <h3 class="govuk-heading-m govuk-!-margin-bottom-2">Explore on the job training</h3>
       <p class="govuk-body">Find an adult apprenticeship that lets you earn and learn at your chosen level.</p>
       <p class="govuk-body">
-        <%= link_to 'Find an apprenticeship', 'https://www.gov.uk/apprenticeships-guide', class: 'govuk-link' %>
+        <%= link_to 'Find an apprenticeship', build_apprenticeships_url(job_name: target_job.name, postcode: user_session.postcode), class: 'govuk-link' %>
       </p>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>

--- a/spec/features/action_plan_spec.rb
+++ b/spec/features/action_plan_spec.rb
@@ -122,6 +122,22 @@ RSpec.feature 'Action plan spec' do
     expect(page).to have_current_path(offers_near_me_path)
   end
 
+  scenario 'Page links to appreticeships with target job' do
+    user_targets_a_job
+
+    expect(page).to have_link('Find an apprenticeship', href: 'https://www.findapprenticeship.service.gov.uk/apprenticeships?Keywords=fluffer&WithinDistance=20')
+  end
+
+  scenario 'Page links to appreticeships with target job and outcode' do
+    capture_user_location
+    user_targets_a_job
+
+    expect(page).to have_link(
+      'Find an apprenticeship',
+      href: 'https://www.findapprenticeship.service.gov.uk/apprenticeships?Keywords=fluffer&Location=NW11&WithinDistance=20'
+    )
+  end
+
   private
 
   def user_targets_a_job
@@ -132,5 +148,18 @@ RSpec.feature 'Action plan spec' do
       click_on('Continue')
       click_on('Continue')
     end
+  end
+
+  def capture_user_location
+    visit(your_information_path)
+    fill_in('user_personal_data[first_name]', with: 'John')
+    fill_in('user_personal_data[last_name]', with: 'Mayer')
+    fill_in('user_personal_data[postcode]', with: 'NW11 8QE')
+    fill_in('user_personal_data[birth_day]', with: '1')
+    fill_in('user_personal_data[birth_month]', with: '1')
+    fill_in('user_personal_data[birth_year]', with: DateTime.now.year - 20)
+    choose('user_personal_data[gender]', option: 'male')
+
+    click_on('Continue')
   end
 end

--- a/spec/helpers/action_plan_helper_spec.rb
+++ b/spec/helpers/action_plan_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ActionPlanHelper do
+  describe '.build_apprenticeships_url' do
+    it 'returns target job and outcode in apprenticeship url' do
+      expect(helper.build_apprenticeships_url(job_name: 'App developer', postcode: 'NW118QE')).to eq(
+        'https://www.findapprenticeship.service.gov.uk/apprenticeships?Keywords=app+developer&Location=NW11&WithinDistance=20'
+      )
+    end
+
+    it 'returns target job only if no postcode present in apprenticeship url' do
+      expect(helper.build_apprenticeships_url(job_name: 'App developer')).to eq(
+        'https://www.findapprenticeship.service.gov.uk/apprenticeships?Keywords=app+developer&WithinDistance=20'
+      )
+    end
+
+    it 'returns target job only if postcode not valid in apprenticeship url' do
+      expect(helper.build_apprenticeships_url(job_name: 'App developer', postcode: 'L10AsdfsdF')).to eq(
+        'https://www.findapprenticeship.service.gov.uk/apprenticeships?Keywords=app+developer&WithinDistance=20'
+      )
+    end
+  end
+end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-844

User should be able to navigate to the apprenticeship search page
with their target job, outcode (if available) and distance of 20 miles.

If a user does not have a postcode show an empty search prompting them
for a postcode.

Note that the params in the url were trimmed down to the bare minimum needed without disrupting the search results themselves (see original url in ticket)