### PR TITLE
Do not override succeeded() condition on admin webapp swap

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -97,7 +97,7 @@ jobs:
 
             - task: AzureAppServiceManage@0
               displayName: 'Start Azure Admin Service: ${{parameters.environment}}'
-              condition: ne(variables['ArmOutputs.adminServiceName'], 'disabled')
+              condition: and(succeeded(), ne(variables['ArmOutputs.adminServiceName'], 'disabled'))
               inputs:
                 azureSubscription: '${{parameters.subscriptionServiceConnection}}'
                 Action: 'Start Azure App Service'
@@ -108,7 +108,7 @@ jobs:
 
             - task: AzureAppServiceManage@0
               displayName: 'Swap Slots Admin Service: ${{parameters.environment}}'
-              condition: ne(variables['ArmOutputs.adminServiceName'], 'disabled')
+              condition: and(succeeded(), ne(variables['ArmOutputs.adminServiceName'], 'disabled'))
               inputs:
                 azureSubscription: '${{parameters.subscriptionServiceConnection}}'
                 WebAppName: '${{parameters.resourceGroupName}}admin-as'
@@ -117,7 +117,7 @@ jobs:
 
             - task: AzureAppServiceManage@0
               displayName: 'Stop Azure Admin Service: ${{parameters.environment}}'
-              condition: ne(variables['ArmOutputs.adminServiceName'], 'disabled')
+              condition: and(succeeded(), ne(variables['ArmOutputs.adminServiceName'], 'disabled'))
               inputs:
                 azureSubscription: '${{parameters.subscriptionServiceConnection}}'
                 Action: 'Stop Azure App Service'


### PR DESCRIPTION
### Context

The default succeeded() condition was overwritten by our non-equals "disabled" rule.   

### Changes proposed in this pull request

This fix includes the succeeded() condition explicitly 

### Guidance to review

