### PR TITLE
Remove admin auth config from non-enabled environments

### DIFF
--- a/azure/config/prod.parameters.json
+++ b/azure/config/prod.parameters.json
@@ -75,38 +75,6 @@
         "secretName": "prod-notifyApiKey"
       }
     },
-    "azureClientId": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/eaff0b89-17c5-4a97-9a00-f77551fe2c27/resourceGroups/s108p01-shared/providers/Microsoft.KeyVault/vaults/s108p01-shared-kv-01"
-        },
-        "secretName": "prod-azureClientId"
-      }
-    },
-    "azureClientSecret": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/eaff0b89-17c5-4a97-9a00-f77551fe2c27/resourceGroups/s108p01-shared/providers/Microsoft.KeyVault/vaults/s108p01-shared-kv-01"
-        },
-        "secretName": "prod-azureClientSecret"
-      }
-    },
-    "azureScopes": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/eaff0b89-17c5-4a97-9a00-f77551fe2c27/resourceGroups/s108p01-shared/providers/Microsoft.KeyVault/vaults/s108p01-shared-kv-01"
-        },
-        "secretName": "prod-azureScopes"
-      }
-    },
-    "azureTenantId": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/eaff0b89-17c5-4a97-9a00-f77551fe2c27/resourceGroups/s108p01-shared/providers/Microsoft.KeyVault/vaults/s108p01-shared-kv-01"
-        },
-        "secretName": "prod-azureTenantId"
-      }
-    },
     "findAJobApiId": {
       "reference": {
         "keyVault": {

--- a/azure/config/uat.parameters.json
+++ b/azure/config/uat.parameters.json
@@ -75,38 +75,6 @@
         "secretName": "uat-notifyApiKey"
       }
     },
-    "azureClientId": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
-        },
-        "secretName": "uat-azureClientId"
-      }
-    },
-    "azureClientSecret": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
-        },
-        "secretName": "uat-azureClientSecret"
-      }
-    },
-    "azureScopes": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
-        },
-        "secretName": "uat-azureScopes"
-      }
-    },
-    "azureTenantId": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
-        },
-        "secretName": "uat-azureTenantId"
-      }
-    },
     "findAJobApiId": {
       "reference": {
         "keyVault": {

--- a/azure/config/ut.parameters.json
+++ b/azure/config/ut.parameters.json
@@ -72,38 +72,6 @@
         "secretName": "ut-notifyApiKey"
       }
     },
-    "azureClientId": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
-        },
-        "secretName": "ut-azureClientId"
-      }
-    },
-    "azureClientSecret": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
-        },
-        "secretName": "ut-azureClientSecret"
-      }
-    },
-    "azureScopes": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
-        },
-        "secretName": "ut-azureScopes"
-      }
-    },
-    "azureTenantId": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
-        },
-        "secretName": "ut-azureTenantId"
-      }
-    },
     "findAJobApiId": {
       "reference": {
         "keyVault": {


### PR DESCRIPTION
### Context

These environments are not enabled, so this config should be removed to avoid referencing non-existent secrets in vault



