### PR TITLE
Fix inflated users stats and location in GA

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,7 +41,7 @@ class ApplicationController < ActionController::Base
   end
 
   def track_events(props = [])
-    TrackingService.new.track_events(props: props)
+    TrackingService.new(client_tracking_data: client_tracking_data).track_events(props: props)
   rescue TrackingService::TrackingServiceError
     nil
   end

--- a/app/helpers/ga_tracking_helper.rb
+++ b/app/helpers/ga_tracking_helper.rb
@@ -11,6 +11,14 @@ module GaTrackingHelper
     )
   end
 
+  def client_tracking_data
+    {
+      ga_cookie: cookies['_ga'],
+      ip_address: request.remote_ip,
+      user_agent: request.env['HTTP_USER_AGENT']
+    }
+  end
+
   private
 
   def build_event_props(key:, label:, values:)

--- a/app/helpers/ga_tracking_helper.rb
+++ b/app/helpers/ga_tracking_helper.rb
@@ -13,7 +13,7 @@ module GaTrackingHelper
 
   def client_tracking_data
     {
-      ga_cookie: cookies['_ga'],
+      ga_cookie: cookies['_ga']&.gsub(/^(.*?\..*?\.)/, ''),
       ip_address: request.remote_ip,
       user_agent: request.env['HTTP_USER_AGENT']
     }

--- a/app/services/tracking_service.rb
+++ b/app/services/tracking_service.rb
@@ -8,9 +8,14 @@ class TrackingService
 
   MAX_BATCH_SIZE = 20
 
-  attr_reader :ga_tracking_id
+  attr_reader :ga_tracking_id, :client_tracking_data
 
-  def initialize(ga_tracking_id: Rails.configuration.google_analytics_tracking_id, debug: false)
+  def initialize(
+    ga_tracking_id: Rails.configuration.google_analytics_tracking_id,
+    client_tracking_data: {},
+    debug: false
+  )
+    @client_tracking_data = client_tracking_data
     @ga_tracking_id = ga_tracking_id
     @debug = debug
   end
@@ -46,19 +51,24 @@ class TrackingService
     @debug
   end
 
-  def anonymized_client_id
-    SecureRandom.uuid
+  def client_tracking_info
+    {
+      cid: client_tracking_data[:ga_cookie],
+      uip: client_tracking_data[:ip_address],
+      ua: client_tracking_data[:user_agent]
+    }
   end
 
   def build_payload(key, label, value)
     URI.encode_www_form(
-      tid: ga_tracking_id,
-      cid: anonymized_client_id,
-      t: 'event',
-      v: 1,
-      ec: key,
-      el: label,
-      ea: value
+      {
+        tid: ga_tracking_id,
+        t: 'event',
+        v: 1,
+        ec: key,
+        el: label,
+        ea: value
+      }.merge(client_tracking_info)
     )
   end
 


### PR DESCRIPTION
To fix the inflated stats on users when sending custom
events and also the reported location we need to enrich
the payload we send as follows:

- cid will gold the _ga cookie value (as unique identifier)
- uip will hold the client's IP
- ua will hold the user agent information

### Ticket ID

https://dfedigital.atlassian.net/browse/GET-879


