### PR TITLE
GET-828 Growth nil job profiles should appear in the end rather than beginning

### DIFF
--- a/app/decorators/job_profile_decorator.rb
+++ b/app/decorators/job_profile_decorator.rb
@@ -87,8 +87,7 @@ class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLengt
   end
 
   def growth_type
-    return unless growth
-
+    return 'No data available' unless growth
     return 'Falling' if growth <= -5
     return 'Stable' if growth > -5 && growth <= 5
     return 'Growing' if growth > 5 && growth <= 50

--- a/app/models/skills_matcher.rb
+++ b/app/models/skills_matcher.rb
@@ -46,9 +46,9 @@ class SkillsMatcher
   def order_options
     case options[:order]
     when :growth
-      { growth: :desc, skills_matched: :desc, skills_rarity: :asc, name: :asc }
+      ['growth DESC NULLS LAST', { skills_matched: :desc, skills_rarity: :asc, name: :asc }]
     else
-      { skills_matched: :desc, growth: :desc, skills_rarity: :asc, name: :asc }
+      [{ skills_matched: :desc }, 'growth DESC NULLS LAST', { skills_rarity: :asc, name: :asc }]
     end
   end
 

--- a/app/views/job_profiles/_job_profile.html.erb
+++ b/app/views/job_profiles/_job_profile.html.erb
@@ -8,8 +8,8 @@
   <% end %>
   <p class="govuk-!-margin-0 govuk-!-margin-bottom-3"><%= job_profile.description %></p>
   <p class="govuk-body govuk-!-margin-bottom-1">Skills match: <span class="strong"><%= job_profile.skills_match(@scores[job_profile.id]) || 'None' %></span></p>
+  <p class="govuk-body govuk-!-margin-bottom-1">Recent job growth: <span class="strong"><%= job_profile.growth_type %></span></p>
   <% if job_profile.growth.present? %>
-    <p class="govuk-body govuk-!-margin-bottom-1">Recent job growth: <span class="strong"><%= job_profile.growth_type %></span></p>
     <details class="govuk-details" data-module="govuk-details">
       <summary class="govuk-details__summary" aria-controls="recent-growth-details" aria-expanded="true" role="button">
         <span class="govuk-details__summary-text">What does <%= job_profile.growth_type.downcase %> mean?</span>

--- a/lib/tasks/data_import/update_recommended_job_profiles.rake
+++ b/lib/tasks/data_import/update_recommended_job_profiles.rake
@@ -8,7 +8,6 @@ namespace :data_import do
       non_recommended_jobs = JobProfile.where(slug: %w[
                                                 advertising-art-director
                                                 advertising-media-buyer
-                                                aid-worker
                                                 anaesthetist
                                                 archaeologist
                                                 archivist
@@ -19,10 +18,7 @@ namespace :data_import do
                                                 barrister
                                                 biochemist
                                                 botanist
-                                                boxer
-                                                celebrant
                                                 chiropractor
-                                                civil-service-manager
                                                 climate-scientist
                                                 clinical-psychologist
                                                 cognitive-behavioural-therapist
@@ -40,7 +36,6 @@ namespace :data_import do
                                                 ecologist
                                                 environmental-consultant
                                                 ergonomist
-                                                film-critic
                                                 forensic-psychologist
                                                 geneticist
                                                 geoscientist
@@ -52,7 +47,6 @@ namespace :data_import do
                                                 materials-engineer
                                                 medical-herbalist
                                                 medical-illustrator
-                                                motorsport-engineer
                                                 music-therapist
                                                 nanotechnologist
                                                 naturopath
@@ -72,7 +66,6 @@ namespace :data_import do
                                                 pathologist
                                                 pharmacist
                                                 pharmacologist
-                                                physician-associate
                                                 physicist
                                                 play-therapist
                                                 psychiatrist
@@ -82,13 +75,11 @@ namespace :data_import do
                                                 royal-navy-officer
                                                 school-nurse
                                                 seismologist
-                                                sonographer
                                                 speech-and-language-therapist
                                                 sport-and-exercise-psychologist
                                                 sports-scientist
                                                 surgeon
                                                 technical-textiles-designer
-                                                test-lead
                                                 translator
                                                 vet
                                                 zoologist

--- a/spec/decorators/job_profile_decorator_spec.rb
+++ b/spec/decorators/job_profile_decorator_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe JobProfileDecorator do
       let(:model) { build(:job_profile, growth: nil) }
 
       it 'returns nil' do
-        expect(job_profile.growth_type).to be nil
+        expect(job_profile.growth_type).to eq('No data available')
       end
     end
   end

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -105,7 +105,7 @@ RSpec.feature 'Skills matcher', type: :feature do
     visit_skills_for_current_job_profile
 
     expect(page.all('ul.govuk-list li a,p:contains("Skills match")').collect(&:text)).to eq(
-      ['Assasin', 'Skills match: Good', 'Hacker', 'Skills match: Good', 'Admin', 'Skills match: Good']
+      ['Hacker', 'Skills match: Good', 'Admin', 'Skills match: Good', 'Assasin', 'Skills match: Good']
     )
   end
 
@@ -116,7 +116,7 @@ RSpec.feature 'Skills matcher', type: :feature do
     visit_skills_for_current_job_profile
 
     expect(page.all('ul.govuk-list li a,p:contains("Skills match")').collect(&:text)).to eq(
-      ['Assasin', 'Skills match: Good', 'Hacker', 'Skills match: Good', 'Hitman', 'Skills match: Good', 'Admin', 'Skills match: Good']
+      ['Hacker', 'Skills match: Good', 'Hitman', 'Skills match: Good', 'Admin', 'Skills match: Good', 'Assasin', 'Skills match: Good']
     )
   end
 
@@ -128,7 +128,7 @@ RSpec.feature 'Skills matcher', type: :feature do
     visit skills_matcher_index_path(sort: 'growth')
 
     expect(page.all('ul.govuk-list li a,p:contains("Skills match")').collect(&:text)).to eq(
-      ['Assasin', 'Skills match: Good', 'Admin', 'Skills match: Reasonable', 'Hacker', 'Skills match: Good']
+      ['Admin', 'Skills match: Reasonable', 'Hacker', 'Skills match: Good', 'Assasin', 'Skills match: Good']
     )
   end
 

--- a/spec/models/skills_matcher_spec.rb
+++ b/spec/models/skills_matcher_spec.rb
@@ -193,9 +193,9 @@ RSpec.describe SkillsMatcher do
       matcher = described_class.new(UserSession.new(session))
       expect(matcher.match).to eq(
         [
-          job_profile3,
           job_profile4,
-          job_profile2
+          job_profile2,
+          job_profile3
         ]
       )
     end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-828

Use custom ordering for growth embed in other sorting orders. This
specifies that growth nil should come last, but maintains growth in
decsending order.
https://stackoverflow.com/questions/5826210/rails-order-with-nulls-last

Also add `No data available` on nil growth job profiles.
Regarding non recommended jobs, I've run the rake task on heroku, but we need to do this on azure and copy data when this is in qa