### PR TITLE
Tell Omniauth which callback url to use

### DIFF
--- a/app.json
+++ b/app.json
@@ -48,6 +48,9 @@
     },
     "AZURE_TENANT_ID": {
       "required": false
+    },
+    "AZURE_CALLBACK_URL": {
+      "required": false
     }
   },
   "formation": {

--- a/app/lib/omni_auth/strategies/azure_ad_auth.rb
+++ b/app/lib/omni_auth/strategies/azure_ad_auth.rb
@@ -13,6 +13,7 @@ module OmniAuth
       # Configure the Microsoft identity platform endpoints
       option :client_options,
              site: SITE,
+             callback_url: Rails.application.config.azure_callback_url,
              authorize_url: "/#{Rails.application.config.azure_tenant_id}/oauth2/v2.0/authorize",
              token_url: "/#{Rails.application.config.azure_tenant_id}/oauth2/v2.0/token"
 

--- a/azure/config/dev1.parameters.json
+++ b/azure/config/dev1.parameters.json
@@ -123,6 +123,14 @@
         "secretName": "dev-azureTenantId"
       }
     },
+    "azureCallbackUrl": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "dev-azureCallbackUrl"
+      }
+    },
     "customHostName": {
       "value": "dev1.nrs-ghtr.org.uk"
     },

--- a/azure/config/dev2.parameters.json
+++ b/azure/config/dev2.parameters.json
@@ -107,6 +107,14 @@
         "secretName": "dev-azureTenantId"
       }
     },
+    "azureCallbackUrl": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "dev-azureCallbackUrl"
+      }
+    },
     "findAJobApiId": {
       "reference": {
         "keyVault": {

--- a/azure/config/qa.parameters.json
+++ b/azure/config/qa.parameters.json
@@ -123,6 +123,14 @@
         "secretName": "qa-azureTenantId"
       }
     },
+    "azureCallbackUrl": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
+        },
+        "secretName": "qa-azureCallbackUrl"
+      }
+    },
     "customHostName": {
       "value": "qa-origin.nrs-ghtr.org.uk"
     },

--- a/azure/template.json
+++ b/azure/template.json
@@ -172,6 +172,13 @@
         "description:": "Azure Active Directory - TENANT ID"
       }
     },
+    "azureCallbackUrl": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description:": "Azure Active Directory - CALLBACK URL"
+      }
+    },
     "googleAnalyticsTrackingId": {
       "type": "string",
       "defaultValue": "",

--- a/azure/template.json
+++ b/azure/template.json
@@ -707,6 +707,10 @@
               {
                 "name": "AZURE_TENANT_ID",
                 "value": "[parameters('azureTenantId')]"
+              },
+              {
+                "name": "AZURE_CALLBACK_URL",
+                "value": "[parameters('azureCallbackUrl')]"
               }
             ]
           },

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,5 +50,6 @@ module GetHelpToRetrain
     config.azure_client_secret = ENV['AZURE_CLIENT_SECRET']
     config.azure_scopes = ENV['AZURE_SCOPES']
     config.azure_tenant_id = ENV['AZURE_TENANT_ID']
+    config.azure_callback_url = ENV['AZURE_CALLBACK_URL']
   end
 end


### PR DESCRIPTION
Because we have different envs we require multiple callback
urls defined in Azure AD Directory.

In order for rack to pick the right one, we need to
explicitly mention that URL.