### PR TITLE
GET-859 Remove duplicate banner landmark

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,13 +25,13 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-    <%= render 'shared/cookies_banner' unless current_page?(cookies_policy_path) %>
     <header class="govuk-header" role="banner" data-module="govuk-header">
       <div class="govuk-header__container govuk-width-container">
         <%= render 'shared/navigation/header_logo' %>
         <%= render 'shared/navigation/main_header' %>
       </div>
     </header>
+    <%= render 'shared/cookies_banner' unless current_page?(cookies_policy_path) %>
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper govuk-!-padding-top-1 govuk-main-wrapper--auto-spacing" role="main">

--- a/app/views/shared/_cookies_banner.html.erb
+++ b/app/views/shared/_cookies_banner.html.erb
@@ -1,12 +1,5 @@
 <div id="cookies-banner" class="cookies-modal">
   <div class="cookies-modal-content">
-    <header class="govuk-header" role="banner" data-module="govuk-header">
-      <div class="govuk-header__container govuk-width-container govuk-!-padding-bottom-2">
-        <%= render 'shared/navigation/header_logo' %>
-        <%= render 'shared/navigation/main_header' %>
-      </div>
-    </header>
-
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper govuk-!-padding-top-1 govuk-!-padding-bottom-1" role="main">
         <p class="govuk-body">This service uses cookies to personalise your experience and to collect information about how you use the site. You can find out more about cookies by clicking the cookies settings button.</p>

--- a/app/webpacker/styles/_cookies.scss
+++ b/app/webpacker/styles/_cookies.scss
@@ -3,15 +3,10 @@
   position: fixed;
   z-index: 1000;
   left: 0;
-  top: 0;
   width: 100%;
   height: 100%;
   overflow: auto;
   background-color: rgba(0, 0, 0, 0.6); // scss-lint:disable ColorVariable
-
-  .govuk-header__container {
-    border: none;
-  }
 }
 
 .cookies-modal-content {


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-859

* Stop fixing cookie banner to top to allow it to show the header
* Remove duplicate header from cookie banner partial
* Place cookie banner after header, so now it shows.
Only difference now is that we see the blue border (checking with lois on this)


Testing:
point axe tests to local and run, don't show failure anymore

