### PR TITLE
GET-860 Remove duplicate main section from cookies banner

### DIFF
--- a/app/views/shared/_cookies_banner.html.erb
+++ b/app/views/shared/_cookies_banner.html.erb
@@ -8,11 +8,11 @@
     </header>
 
     <div class="govuk-width-container">
-      <main class="govuk-main-wrapper govuk-!-padding-top-1 govuk-!-padding-bottom-1" role="main">
+      <div class="govuk-main-wrapper govuk-!-padding-top-1 govuk-!-padding-bottom-1" role="region">
         <p class="govuk-body">This service uses cookies to personalise your experience and to collect information about how you use the site. You can find out more about cookies by clicking the cookies settings button.</p>
         <%= link_to 'Accept cookies', '#', id: 'accept-cookies', class: 'govuk-button govuk-button--secondary govuk-!-margin-right-5', data: { module: 'govuk-button' } %>
         <%= link_to 'Cookie settings', cookies_policy_path, class: 'govuk-button govuk-button--secondary', data: { module: 'govuk-button' } %>
-      </main>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-860

* Change main to div in banner to avoid duplicate main section
* Change role to region as that seems to be appropriate as seen
in: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Region_role
and on https://www.gov.uk/

tested by pointing smoke tests to localhost and not seeing failure anymore

