### PR TITLE
Remove AdminUser tracking as it is too noisy

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -4,8 +4,6 @@ class AdminUser < RestrictedActiveRecordBase
   validates :name, presence: true
   validates :resource_id, presence: true, uniqueness: true
 
-  has_paper_trail on: %i[update destroy]
-
   def self.from_omniauth(auth_hash)
     user_info = auth_hash[:info] || {}
 


### PR DESCRIPTION
When logging in  an update event is triggered:

![Screen Shot 2020-01-14 at 08 26 46](https://user-images.githubusercontent.com/1955084/72327359-d25df500-36a8-11ea-99ed-a272807bf694.png)

The provided value is not that significant and it could easily become just noisy and also a bit confusing.
