### PR TITLE
Trap focus inside cookies modal

### DIFF
--- a/app/webpacker/packs/cookies-banner.js
+++ b/app/webpacker/packs/cookies-banner.js
@@ -5,7 +5,7 @@ function CookiesBanner () {
     if (typeof(cookiesModal) !== 'undefined' && cookiesModal != null) {
       if (getCookie('seen_cookie_message') !== 'true') {
         displayCookiesModal(cookiesModal);
-        trapFocus(cookiesModal)
+        trapFocus(cookiesModal);
       }
     }
   }

--- a/app/webpacker/packs/cookies-banner.js
+++ b/app/webpacker/packs/cookies-banner.js
@@ -57,7 +57,7 @@ function CookiesBanner () {
     var KEYCODE_TAB = 9;
 
     element.addEventListener('keydown', function(e) {
-      var isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
+      var isTabPressed = (e.keyCode === KEYCODE_TAB);
 
       if (!isTabPressed) { 
         return; 

--- a/app/webpacker/packs/cookies-banner.js
+++ b/app/webpacker/packs/cookies-banner.js
@@ -52,8 +52,8 @@ function CookiesBanner () {
 
   function trapFocus(element) {
     var focusableElements = element.querySelectorAll('a[href]:not([disabled])');
-    var acceptCookies = focusableElements[2];  
-    var cookieSettings = focusableElements[3];
+    var firstElement = focusableElements[0];  
+    var lastElement = focusableElements[focusableElements.length - 1];
     var KEYCODE_TAB = 9;
 
     element.addEventListener('keydown', function(e) {
@@ -64,13 +64,13 @@ function CookiesBanner () {
       }
 
       if ( e.shiftKey ) /* shift + tab */ {
-        if (document.activeElement === acceptCookies) {
-          cookieSettings.focus();
+        if (document.activeElement === firstElement) {
+          lastElement.focus();
           e.preventDefault();
         }
       } else /* tab */ {
-        if (document.activeElement === cookieSettings) {
-          acceptCookies.focus();
+        if (document.activeElement === lastElement) {
+          firstElement.focus();
           e.preventDefault();
         }
       }

--- a/app/webpacker/packs/cookies-banner.js
+++ b/app/webpacker/packs/cookies-banner.js
@@ -5,6 +5,7 @@ function CookiesBanner () {
     if (typeof(cookiesModal) !== 'undefined' && cookiesModal != null) {
       if (getCookie('seen_cookie_message') !== 'true') {
         displayCookiesModal(cookiesModal);
+        trapFocus(cookiesModal)
       }
     }
   }
@@ -47,6 +48,33 @@ function CookiesBanner () {
       modalElement.style.display = 'none';
       setCookie('seen_cookie_message', 'true', 30);
     }
+  }
+
+  function trapFocus(element) {
+    var focusableElements = element.querySelectorAll('a[href]:not([disabled])');
+    var acceptCookies = focusableElements[2];  
+    var cookieSettings = focusableElements[3];
+    var KEYCODE_TAB = 9;
+
+    element.addEventListener('keydown', function(e) {
+      var isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
+
+      if (!isTabPressed) { 
+        return; 
+      }
+
+      if ( e.shiftKey ) /* shift + tab */ {
+        if (document.activeElement === acceptCookies) {
+          cookieSettings.focus();
+          e.preventDefault();
+        }
+      } else /* tab */ {
+        if (document.activeElement === cookieSettings) {
+          acceptCookies.focus();
+          e.preventDefault();
+        }
+      }
+    });
   }
 }
 


### PR DESCRIPTION
# Context
Prevent users from tabbing anywhere outside the cookies
modal when this is visible.

Inspired from: https://stackoverflow.com/questions/32996817/vanilla-javascript-trap-focus-in-modal-accessibility-tabbing

And other similar resources.

# Ticket
https://dfedigital.atlassian.net/browse/GET-843