### PR TITLE
GET-859 Remove duplicate banner landmark

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,12 +26,14 @@
     </script>
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
     <%= render 'shared/cookies_banner' unless current_page?(cookies_policy_path) %>
-    <header class="govuk-header" role="banner" data-module="govuk-header">
-      <div class="govuk-header__container govuk-width-container">
-        <%= render 'shared/navigation/header_logo' %>
-        <%= render 'shared/navigation/main_header' %>
-      </div>
-    </header>
+    <div id="govuk-header-container">
+      <header class="govuk-header" role="banner" data-module="govuk-header" id="govuk-header">
+        <div class="govuk-header__container govuk-width-container">
+          <%= render 'shared/navigation/header_logo' %>
+          <%= render 'shared/navigation/main_header' %>
+        </div>
+      </header>
+    </div>
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper govuk-!-padding-top-1 govuk-main-wrapper--auto-spacing" role="main">

--- a/app/views/shared/_cookies_banner.html.erb
+++ b/app/views/shared/_cookies_banner.html.erb
@@ -1,12 +1,5 @@
 <div id="cookies-banner" class="cookies-modal">
-  <div class="cookies-modal-content">
-    <header class="govuk-header" role="banner" data-module="govuk-header">
-      <div class="govuk-header__container govuk-width-container govuk-!-padding-bottom-2">
-        <%= render 'shared/navigation/header_logo' %>
-        <%= render 'shared/navigation/main_header' %>
-      </div>
-    </header>
-
+  <div class="cookies-modal-content" id="cookies-modal">
     <div class="govuk-width-container">
       <div class="govuk-main-wrapper govuk-!-padding-top-1 govuk-!-padding-bottom-1" role="region">
         <p class="govuk-body">This service uses cookies to personalise your experience and to collect information about how you use the site. You can find out more about cookies by clicking the cookies settings button.</p>

--- a/app/webpacker/packs/cookies-banner.js
+++ b/app/webpacker/packs/cookies-banner.js
@@ -23,6 +23,9 @@ function CookiesBanner () {
   }
 
   function displayCookiesModal(modalElement) {
+    modalElement.insertBefore(document.querySelector('#govuk-header'), document.querySelector('#cookies-modal'));
+    document.querySelector('.govuk-header__container').classList.add('govuk-!-padding-bottom-2');
+
     modalElement.style.display = 'block';
 
     var cookiesAccept = document.querySelector('#accept-cookies');
@@ -35,6 +38,11 @@ function CookiesBanner () {
   function handleAcceptCookies(modalElement, acceptElement) {
     acceptElement.onclick = function(e) {
       e.preventDefault();
+
+      document.querySelector('#govuk-header-container').appendChild(
+        document.querySelector('#govuk-header')
+      );
+      document.querySelector('.govuk-header__container').classList.remove('govuk-!-padding-bottom-2');
 
       modalElement.style.display = 'none';
       setCookie('seen_cookie_message', 'true', 30);


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-859

* Remove duplicate header from cookie banner partial
* Use js to move header div inside fixed div when cookie banner is visible
  and move it back out when done. If cookie banner is not visible, it will
  appear as normal.
  I've played around with this and another option would be to add a div around
  both cookies and header and fix that, but this seemed like the least obtrusive way.