### PR TITLE
GET-861 Move feedback to inside main landmark

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
     </div>
 
     <div class="govuk-width-container">
-      <main class="govuk-main-wrapper govuk-!-padding-top-1 govuk-main-wrapper--auto-spacing" role="main">
+      <main class="govuk-main-wrapper govuk-!-padding-top-1 govuk-!-padding-bottom-0 govuk-main-wrapper--auto-spacing" role="main">
         <div class="govuk-phase-banner">
           <p class="govuk-phase-banner__content">
             <strong class="govuk-tag govuk-phase-banner__content__tag">beta</strong>
@@ -50,11 +50,11 @@
             <%= content_for :breadcrumb %>
           </ol>
         </nav>
-        <div id="main-content">
+        <div id="main-content" class="govuk-!-padding-bottom-7">
           <%= yield %>
         </div>
+        <%= render 'shared/feedback/survey' %>
       </main>
-      <%= render 'shared/feedback/survey' %>
     </div>
 
 


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-861

Feeback div was outside the main landmarks:
https://dequeuniversity.com/rules/axe/3.3/region?application=axeAPI

Move it into main div, and fix styling so it's exactly like it was before
(move bottom padding to last div instead of main)
This also works the same with javascript disabled.

I've had a look at many gov websites and how they implement this
including https://www.gov.uk/, and all have feedback outside main,
and not in the footer (which I've considered). They however do fail the
axe test. I also had a look at roles and if we could add a role to this
feedback block but nothing felt like it fit.

Testing:
1) Test with smoke tests and should not see this error: region on 1 node
2) Test with disabling javascript to have the same design
3) test with mobile views and desktop views
4) Test with/without sign in partial

