### PR TITLE
GET-872 Remove autocomplete from radio buttons

### DIFF
--- a/app/views/user_personal_data/_form.html.erb
+++ b/app/views/user_personal_data/_form.html.erb
@@ -60,15 +60,15 @@
         <div class="govuk-radios">
           <%= errors_tag @user_personal_data, :gender %>
           <div class="govuk-radios__item">
-            <%= f.radio_button :gender, :female, class: 'govuk-radios__input', autocomplete: 'sex', data: { cy: 'pid-gender-female-radio-btn' } %>
+            <%= f.radio_button :gender, :female, class: 'govuk-radios__input', data: { cy: 'pid-gender-female-radio-btn' } %>
             <%= f.label :gender_female, 'Female', class: 'govuk-label govuk-radios__label' %>
           </div>
           <div class="govuk-radios__item">
-            <%= f.radio_button :gender, :male, class: 'govuk-radios__input', autocomplete: 'sex', data: { cy: 'pid-gender-male-radio-btn' } %>
+            <%= f.radio_button :gender, :male, class: 'govuk-radios__input', data: { cy: 'pid-gender-male-radio-btn' } %>
             <%= f.label :gender_male, 'Male', class: 'govuk-label govuk-radios__label' %>
           </div>
           <div class="govuk-radios__item">
-            <%= f.radio_button :gender, :not_mentioned, class: 'govuk-radios__input', autocomplete: 'sex', data: { cy: 'pid-gender-refuse-radio-btn' } %>
+            <%= f.radio_button :gender, :not_mentioned, class: 'govuk-radios__input', data: { cy: 'pid-gender-refuse-radio-btn' } %>
             <%= f.label :gender_not_mentioned, 'Prefer not to say', class: 'govuk-label govuk-radios__label' %>
           </div>
         </div>


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-872

Radio buttons don't support autocomplete, remove it as per the DAC report
and axe tests
DAC report page 23: https://drive.google.com/drive/u/1/folders/1NaXsVGnJrxot_RwAVGVklY_LIXRMnlcE

Testing:
Run smoke test and check user personal data page does not have this failure: autocomplete valid on 3 nodes
