### PR TITLE
Audit searches on PID

### DIFF
--- a/app/admin/paper_trail_versions.rb
+++ b/app/admin/paper_trail_versions.rb
@@ -39,9 +39,16 @@ if defined?(ActiveAdmin)
         row :changes do |version|
           if version.object_changes.present?
             changes_hash = version.object_changes.except('updated_at')
-            changes_hash.map { |k, v|
-              "<strong>#{k}: #{v.compact.join(' -> ')}</strong>"
-            }.compact.join('<br>').html_safe
+            if version.event == 'search'
+              "<strong>Searched for</strong>:<br>
+                #{changes_hash['query'].map { |k, v| "#{k}: #{v}" }.join('<br>')}".concat(
+                  "<br><br><strong>Results found</strong>: #{changes_hash['results']}"
+                ).html_safe
+            else
+              changes_hash.map { |k, v|
+                "<strong>#{k}: #{v.compact.join(' -> ')}</strong>"
+              }.compact.join('<br>').html_safe
+            end
           end
         end
         row :created_at

--- a/app/admin/paper_trail_versions.rb
+++ b/app/admin/paper_trail_versions.rb
@@ -40,10 +40,7 @@ if defined?(ActiveAdmin)
           if version.object_changes.present?
             changes_hash = version.object_changes.except('updated_at')
             if version.event == 'search'
-              "<strong>Searched for</strong>:<br>
-                #{changes_hash['query']&.map { |k, v| "#{k.humanize}: <strong>#{v}</strong>" }&.join('<br>')}".concat(
-                  "<br><br><strong>Results found</strong>: #{changes_hash['results']}"
-                ).html_safe
+              "<strong>Results found</strong>: #{changes_hash['results']}".html_safe
             else
               changes_hash.map { |k, v|
                 "<strong>#{k}: #{v.compact.join(' -> ')}</strong>"

--- a/app/admin/paper_trail_versions.rb
+++ b/app/admin/paper_trail_versions.rb
@@ -41,7 +41,7 @@ if defined?(ActiveAdmin)
             changes_hash = version.object_changes.except('updated_at')
             if version.event == 'search'
               "<strong>Searched for</strong>:<br>
-                #{changes_hash['query'].map { |k, v| "#{k}: #{v}" }.join('<br>')}".concat(
+                #{changes_hash['query']&.map { |k, v| "#{k.humanize}: <strong>#{v}</strong>" }&.join('<br>')}".concat(
                   "<br><br><strong>Results found</strong>: #{changes_hash['results']}"
                 ).html_safe
             else

--- a/app/admin/user_personal_data.rb
+++ b/app/admin/user_personal_data.rb
@@ -29,7 +29,7 @@ if defined?(ActiveAdmin)
           track_custom_event(
             item_type: 'User Personal Data Page',
             event: 'search',
-            changes: { query: params[:q], results: collection.total_count }
+            changes: { results: collection.total_count }
           )
         end
 

--- a/app/admin/user_personal_data.rb
+++ b/app/admin/user_personal_data.rb
@@ -29,7 +29,7 @@ if defined?(ActiveAdmin)
           track_custom_event(
             item_type: 'User Personal Data Page',
             event: 'search',
-            changes: { query: params[:q], results: collection.count }
+            changes: { query: params[:q], results: collection.total_count }
           )
         end
 

--- a/app/admin/user_personal_data.rb
+++ b/app/admin/user_personal_data.rb
@@ -23,6 +23,18 @@ if defined?(ActiveAdmin)
 
         super
       end
+
+      def index
+        if params[:commit] == 'Filter'
+          track_custom_event(
+            item_type: 'User Personal Data Page',
+            event: 'search',
+            changes: { query: params[:q], results: collection.count }
+          )
+        end
+
+        super
+      end
     end
 
     index do

--- a/app/helpers/admin/authentication_helper.rb
+++ b/app/helpers/admin/authentication_helper.rb
@@ -25,12 +25,13 @@ module Admin
     end
 
     # Send custom tracking events to PaperTrail
-    def track_custom_event(item_type:, event:, item_id: nil)
+    def track_custom_event(item_type:, event:, item_id: nil, changes: nil)
       PaperTrail::Version.create(
         item_type: item_type,
         whodunnit: admin_current_user.id,
         event: event,
-        item_id: item_id
+        item_id: item_id,
+        object_changes: changes
       )
     end
 

--- a/spec/features/admin/auditing_spec.rb
+++ b/spec/features/admin/auditing_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature 'Admin Users Authentication' do
     click_on('Audit Logs')
     all('.view_link')[1].click
 
-    ['Results found: 1', 'Searched for:', 'First name contains: Jamie'].each do |content|
+    ['Results found: 1'].each do |content|
       expect(page).to have_content(content)
     end
   end
@@ -99,7 +99,7 @@ RSpec.feature 'Admin Users Authentication' do
     click_on('Audit Logs')
     all('.view_link')[1].click
 
-    ['Results found: 2', 'Searched for:'].each do |content|
+    ['Results found: 2'].each do |content|
       expect(page).to have_content(content)
     end
   end

--- a/spec/features/admin/auditing_spec.rb
+++ b/spec/features/admin/auditing_spec.rb
@@ -75,6 +75,35 @@ RSpec.feature 'Admin Users Authentication' do
     end
   end
 
+  scenario 'Using the filters on user personal data page gets logged' do
+    create(:user_personal_data, first_name: 'James')
+    create(:user_personal_data, first_name: 'Jamie')
+
+    click_on('User Personal Data')
+    fill_in('q_first_name', with: 'Jamie')
+    click_on('Filter')
+    click_on('Audit Logs')
+    all('.view_link')[1].click
+
+    ['Results found: 1', 'Searched for:', 'First name contains: Jamie'].each do |content|
+      expect(page).to have_content(content)
+    end
+  end
+
+  scenario 'Using the filters without any filter input on user personal data page still gets logged' do
+    create(:user_personal_data, first_name: 'James')
+    create(:user_personal_data, first_name: 'Jamie')
+
+    click_on('User Personal Data')
+    click_on('Filter')
+    click_on('Audit Logs')
+    all('.view_link')[1].click
+
+    ['Results found: 2', 'Searched for:'].each do |content|
+      expect(page).to have_content(content)
+    end
+  end
+
   scenario 'When a user downloads the user personal data as CSV that event gets logged' do
     create(:user_personal_data)
 


### PR DESCRIPTION
### Context
Re-using the object changes field, and
capture the search query and results count while on
PID on auditing.

### Screenshot

![Screen Shot 2020-01-15 at 11 50 41](https://user-images.githubusercontent.com/1955084/72431664-4a9de680-378d-11ea-8ea1-4ee85156c7a9.png)

### Notes
Useful resource for retrieving the full filtered collection (not just first page of results): https://stackoverflow.com/questions/26215985/activeadmin-access-filtered-collection

### Ticket
https://dfedigital.atlassian.net/browse/GET-878


