### PR TITLE
GET-874 Fix order of headings

### DIFF
--- a/app/views/check_your_skills/_results_list.html.erb
+++ b/app/views/check_your_skills/_results_list.html.erb
@@ -1,9 +1,9 @@
 <ul class="govuk-list">
   <% job_profiles.each do |job_profile| %>
     <li class="govuk-!-padding-bottom-3 govuk-!-padding-top-4">
-      <h3 class="govuk-!-margin-0">
+      <h2 class="govuk-heading-m govuk-!-margin-0">
         <%= link_to job_profile.name, job_profile_skills_path(job_profile.slug, search: params[:search]), class: 'govuk-link' %>
-      </h3>
+      </h2>
       <% if job_profile.alternative_titles.present? %>
         <span class="govuk-visually-hidden">Alternative titles for this job include:</span>
         <p class="govuk-body-s govuk-!-margin-bottom-2 muted-text"><%= job_profile.alternative_titles %></p>

--- a/app/views/job_profiles/_highlights.html.erb
+++ b/app/views/job_profiles/_highlights.html.erb
@@ -5,7 +5,7 @@
         <div class="profile-highlights salary-icon" role="img" aria-label="Pound sterling icon"></div>
       </div>
       <div class="govuk-grid-column-three-quarters">
-        <h4 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-1">Typical Salary</h4>
+        <h2 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-1">Typical Salary</h2>
         <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-2 responsive-section-break">
         <%= @job_profile.salary_range %>
       </div>
@@ -19,7 +19,7 @@
           <div class="profile-highlights <%= @job_profile.growth_icon %>" role="img" aria-label="Arrow pointing upwards"></div>
         </div>
         <div class="govuk-grid-column-three-quarters">
-          <h4 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-1">Recent job growth</h4>
+          <h2 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-1">Recent job growth</h2>
           <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-2 responsive-section-break">
           <p id="lifestyle" class="govuk-body"><%= @job_profile.growth_type %></p>
         </div>

--- a/app/views/job_profiles/_job_profile.html.erb
+++ b/app/views/job_profiles/_job_profile.html.erb
@@ -1,7 +1,7 @@
 <li class="govuk-!-padding-bottom-1">
-  <h3 class="govuk-!-margin-bottom-0 govuk-!-margin-top-2">
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-margin-top-2">
      <%= link_to job_profile.name, job_profile_path(job_profile.slug), class: 'govuk-link' %>
-  </h3>
+  </h2>
   <% if job_profile.alternative_titles.present? %>
     <span class="govuk-visually-hidden">Alternative titles for this job include:</span>
     <p class="govuk-body-s govuk-!-margin-bottom-2 muted-text"><%= job_profile.alternative_titles %></p>

--- a/app/views/user_personal_data/_form.html.erb
+++ b/app/views/user_personal_data/_form.html.erb
@@ -18,9 +18,9 @@
     <%= form_group_tag @user_personal_data, :dob do %>
       <%= field_set_tag nil, class: 'govuk-fieldset', role: 'group', aria: { describedby: 'date-of-birth-hint' } do %>
         <legend class='govuk-fieldset__legend govuk-fieldset__legend--xl'>
-          <h3 class="govuk-heading-m govuk-!-margin-bottom-0">
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
             Date of birth
-          </h3>
+          </h2>
         </legend>
         <span id="date-of-birth-hint" class="govuk-hint">
           For example, 12 11 1980
@@ -53,9 +53,9 @@
     <%= form_group_tag @user_personal_data, :gender do %>
       <%= field_set_tag nil, class: 'govuk-fieldset', role: 'group' do %>
         <legend class='govuk-fieldset__legend govuk-fieldset__legend--xl'>
-          <h3 class="govuk-heading-m govuk-!-margin-bottom-0">
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
             Gender
-          </h3>
+          </h2>
         </legend>
         <div class="govuk-radios">
           <%= errors_tag @user_personal_data, :gender %>


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-874

* Fix order of headings on user personal information page
* Fix order of headings on skills matcher as well as check your skills
results pages. This causes the text to be slightly bigger
* Fix order of headings on job profile page

Testing:
1) User personal information page there should be no change in size
2) Skills matcher/check your skills very slight change in size will run past steve tomorrow
3) Profile page no change in size (brief section: typical salary and recent growth)

failure to look for in AXE: `11Y ERROR! heading-order on 1 Node`
`Description:  Ensures the order of headings is semantically correct`
