### PR TITLE
GET-876 Add missing aria label to submit tag in feedback

### DIFF
--- a/app/views/shared/feedback/_survey.html.erb
+++ b/app/views/shared/feedback/_survey.html.erb
@@ -4,7 +4,7 @@
       <h2 class="feedback-prompt-content">Is this page useful?</h2>
       <%= form_with url: feedback_surveys_path, class: 'feedback-survey-form', id: 'page-is-useful-form', aria: { hidden: false } do |f| %>
         <%= hidden_field_tag('page_useful', 'yes', id: 'page_useful_yes') %>
-        <%= submit_tag('Yes', role: 'button', class: 'unbutton-survey feedback-prompt-link') %>
+        <%= submit_tag('Yes', role: 'button', class: 'unbutton-survey feedback-prompt-link', aria: { label: 'this page is useful' }) %>
         <span class="govuk-visually-hidden">this page is useful</span>
       <% end %>
       <%= link_to '#', {


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-876

An input element with type submit should include the aria-label
as seen from: https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse

We do not need a labeled by as the label is hidden and on the button itself.

Testing:
Run smoke test and the following error should disappear from all pages:
```
A11Y ERROR!
button-name on 1 Node
Ensures buttons have discernible text
```

