### PR TITLE
Allow multiple callbacks rack

### DIFF
--- a/app/lib/omni_auth/strategies/azure_ad_auth.rb
+++ b/app/lib/omni_auth/strategies/azure_ad_auth.rb
@@ -53,7 +53,7 @@ module OmniAuth
       # query parameters. Azure fails validation because that doesn't match the
       # registered callback.
       def callback_url
-        options[:redirect_uri]
+        options[:redirect_uri] || (full_host + script_name + callback_path)
       end
     end
   end


### PR DESCRIPTION
### Context

We want to build the redirect_uri in Omniauth ideally dynamically by parsing the requests at the rack level.

Check: https://github.com/omniauth/omniauth/blob/c2380ae848ce4e0e39b4bb94c5b8e3fd0a544825/lib/omniauth/strategy.rb to understand how that's done.
omniauth/omniauth-oauth2#93
https://docs.microsoft.com/en-us/graph/tutorials/ruby?tutorial-step=3

We also leave the option to explicitly set the `redirect_uri` as options.

This will allow us to have multiple callback urls setup in Azure AD.
