### PR TITLE
Update Job Profile page markup

### DIFF
--- a/app/views/job_profiles/_apply_to_become.html.erb
+++ b/app/views/job_profiles/_apply_to_become.html.erb
@@ -1,0 +1,21 @@
+<div class="action-plan-section">
+  <h2 class="govuk-heading-m govuk-!-margin-top-4">Apply to <%= @job_profile.become %></h2>
+  <% if @job_vacancy_count.present? %>
+    <% if @job_vacancy_count > 0 %>
+      <p class="govuk-body">At least <b><%= pluralize(@job_vacancy_count, 'vacancy', locale: I18n.locale.to_s) %></b> in this type of work <%= t('job_profiles.vacancies', count: @job_vacancy_count) %> being advertised near you. You can prepare to apply for these jobs by building a personal action plan.</p>
+    <% else %>
+      <p class="govuk-body">At the moment the Find a job service is advertising <b>no vacancies</b> in your area for this type of job. You may be able to find vacancies if you search other job websites. Or you can go back to your job matches and find types of work with vacancies in your area.</p>
+      <p class="govuk-body">You can prepare to apply for any <%= @job_profile.name.downcase %> vacancies that appear in future by building a personal action plan. </p>
+    <% end %>
+  <% end %>
+  <p class="govuk-body">You’ll be asked if you need any training in:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>maths</li>
+    <li>English</li>
+    <li>computer skills</li>
+  </ul>
+  <p class="govuk-body">You’ll also be offered support with job hunting, such as advice on writing a CV.</p>
+  <p class="govuk-body">You can change your target job at any time.</p>
+  <%= button_to('Target this type of work', target_job_profile_path(@job_profile.slug), class: 'govuk-button govuk-!-margin-top-1 govuk-!-margin-bottom-6', data: { module: 'govuk-button' }) %>
+  <%= link_to('Back to your job matches', skills_matcher_index_path, class: 'govuk-link') %>
+</div>

--- a/app/views/job_profiles/_apprenticeship.html.erb
+++ b/app/views/job_profiles/_apprenticeship.html.erb
@@ -1,6 +1,7 @@
 <% apprenticeship_section = @job_profile.section(:apprenticeship) %>
 
 <% if apprenticeship_section.present? %>
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
   <h2 class='govuk-heading-m'>Apprenticeship</h2>
   <p class="govuk-body-m">You can do an apprenticeship at any age. You may be able to earn the same money and work at the same level as you do now.</p>
   <%= apprenticeship_section.html_safe %>

--- a/app/views/job_profiles/_jobs_in_your_area.html.erb
+++ b/app/views/job_profiles/_jobs_in_your_area.html.erb
@@ -1,8 +1,0 @@
-<% return unless @job_vacancy_count.present? %>
-<h2 class="govuk-heading-m">Jobs in your area</h2>
-<% if @job_vacancy_count > 0 %>
-  <p class="govuk-body">At least <b><%= pluralize(@job_vacancy_count, 'vacancy', locale: I18n.locale.to_s) %></b> in this type of work <%= t('job_profiles.vacancies', count: @job_vacancy_count) %> being advertised near you. Get ready to start applying by preparing your CV and cover letter and exploring any training you’ll need.</p>
-<% else %>
-  <p class="govuk-body">At present, there are no vacancies like this one being advertised near you on the Find a Job service. You may be able to find other jobs like this advertised on other job sites.</p>
-<% end %>
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/app/views/job_profiles/_relevant_sections.html.erb
+++ b/app/views/job_profiles/_relevant_sections.html.erb
@@ -8,10 +8,4 @@
 <%= @job_profile.section(:career_tips).html_safe %>
 <%= @job_profile.section(:work).html_safe %>
 <%= @job_profile.section(:restrictions_and_requirements).html_safe %>
-<%= render 'jobs_in_your_area' %>
-
-<h2 class="govuk-heading-m">Select type of work</h2>
-<p class="govuk-body">Select this as your target type of work and we’ll add it to your personal action plan. We will start by checking if you need any maths and English training or job hunting advice.</p>
-<p class="govuk-body">If you change your mind, you can choose a different type of work on your personal action plan.</p>
-<%= button_to('Target this type of work', target_job_profile_path(@job_profile.slug), class: 'govuk-button govuk-!-margin-top-1 govuk-!-margin-bottom-6', data: { module: 'govuk-button' }) %>
-<%= link_to('Back to your job matches', skills_matcher_index_path, class: 'govuk-link') %>
+<%= render 'apply_to_become' %>

--- a/app/views/job_profiles/_skills_section.html.erb
+++ b/app/views/job_profiles/_skills_section.html.erb
@@ -15,4 +15,3 @@
 <p class="govuk-body-m">
   You may not need all of these skills to apply for this type of work - you could develop some of them while you are in the job or you could take a course. If you need help with your maths and English skills, this service can help with this when you create your action plan.
 </p>
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/spec/decorators/job_profile_decorator_spec.rb
+++ b/spec/decorators/job_profile_decorator_spec.rb
@@ -184,6 +184,18 @@ RSpec.describe JobProfileDecorator do
     end
   end
 
+  describe '#become' do
+    let(:html_body) do
+      '<section id="HowToBecome">
+        <h2 class="heading-large job-profile-heading">How to become an RAF officer</h2>
+       </section>'
+    end
+
+    it 'strips down How to from #how_to_become' do
+      expect(job_profile.become).to eq 'become an RAF officer'
+    end
+  end
+
   describe '#working_hours' do
     let(:html_body) do
       '<div id="WorkingHours" class="column-30 job-profile-heroblock">

--- a/spec/features/job_profile_spec.rb
+++ b/spec/features/job_profile_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature 'Job profile spec' do
     user_enters_location
     visit(job_profile_path(job_profile.slug))
 
-    expect(page).to have_content('there are no vacancies')
+    expect(page).to have_content('At the moment the Find a job service is advertising no vacancies')
   end
 
   scenario 'User does not see job vacancies if API is down' do


### PR DESCRIPTION
### Context
Following changes are introduced:

1. Select type of work changes into Apply to become section
2. This new section since it's the last and has a special style
for its delimiter, we are moving the dynamic sections' delimiters
on top of each section rather than after, so that the last dynamic
section's delimiter does not collide with the custom one that belongs
to Apply to become section.
3. Since concat/+ in ruby escape strings, we need to call an html_safe
on the our dynamic sections' bodies when prepending the delimiter.

### Ticket
https://dfedigital.atlassian.net/browse/GET-888
