### PR TITLE
GET-897 Add progress indicator on question pages

### DIFF
--- a/app/helpers/question_helper.rb
+++ b/app/helpers/question_helper.rb
@@ -17,4 +17,14 @@ module QuestionHelper
   def it_training_questions
     it_training_questions_path if user_session.it_training.nil?
   end
+
+  def progression_indicator(show_indicator:, step:)
+    return unless show_indicator
+
+    content_tag(
+      :span,
+      "Step #{step} of 3",
+      class: 'govuk-caption-xl'
+    )
+  end
 end

--- a/app/views/questions/it_training.html.erb
+++ b/app/views/questions/it_training.html.erb
@@ -15,6 +15,7 @@
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="it-training-options-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <%= progression_indicator(show_indicator: it_training_questions, step: 2) %>
             <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3">
               <%= t('.title') %>
             </h1>

--- a/app/views/questions/job_hunting.html.erb
+++ b/app/views/questions/job_hunting.html.erb
@@ -15,6 +15,7 @@
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="job-hunting-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <%= progression_indicator(show_indicator: job_hunting_questions, step: 3) %>
             <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3">
               <%= t('.title') %>
             </h1>

--- a/app/views/questions/training.html.erb
+++ b/app/views/questions/training.html.erb
@@ -15,6 +15,7 @@
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="training-options-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <%= progression_indicator(show_indicator: training_questions, step: 1) %>
             <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3">
               <%= t('.title') %>
             </h1>

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -230,6 +230,44 @@ RSpec.feature 'Questions' do
     expect(page).to have_selector('input[checked="checked"]', count: 2)
   end
 
+  scenario 'user sees progression on question pages' do
+    user_targets_job
+    (1..3).each do |step|
+      expect(page).to have_text("Step #{step} of 3")
+
+      click_on('Continue')
+    end
+  end
+
+  scenario 'user does not see progression on question pages after reaching action plan' do
+    user_targets_job
+    click_on('Continue')
+    click_on('Continue')
+    click_on('Continue')
+
+    {
+      '1' => training_questions_path,
+      '2' => it_training_questions_path,
+      '3' => job_hunting_questions_path
+    }.each do |step, question_page|
+      visit(question_page)
+
+      expect(page).not_to have_text("Step #{step} of 3")
+    end
+  end
+
+  scenario 'user sees progression on question pages if journey interrupted' do
+    user_targets_job
+    click_on('Continue')
+    visit(it_training_questions_path)
+
+    (2..3).each do |step|
+      expect(page).to have_text("Step #{step} of 3")
+
+      click_on('Continue')
+    end
+  end
+
   scenario 'If user selects job hunting options, they get tracked in GA' do
     tracking_service = instance_spy(TrackingService)
     allow(TrackingService).to receive(:new).and_return(tracking_service)

--- a/spec/helpers/question_helper_spec.rb
+++ b/spec/helpers/question_helper_spec.rb
@@ -79,4 +79,16 @@ RSpec.describe QuestionHelper do
       expect(helper.it_training_questions).to eq(it_training_questions_path)
     end
   end
+
+  describe '#progression_indicator' do
+    it 'returns nil when show indictator is false' do
+      expect(helper.progression_indicator(show_indicator: nil, step: 1)).to be_nil
+    end
+
+    it 'returns progress indicator when show indicator is true with correct page' do
+      expect(helper.progression_indicator(show_indicator: true, step: 2)).to eq(
+        '<span class="govuk-caption-xl">Step 2 of 3</span>'
+      )
+    end
+  end
 end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-897

* Add indicator on all question pages up to 3
* Indicator should not appear on page if already seen example when editing
from the action plan page
* If user interrups their question journey, they should see the indicator