### PR TITLE
Add copy change User Personal Information

### DIFF
--- a/app/views/user_personal_data/index.html.erb
+++ b/app/views/user_personal_data/index.html.erb
@@ -15,6 +15,7 @@
     <h1 class="govuk-heading-xl"><%= t('user_personal_data.title') %></h1>
     <p class="govuk-body">We use this information to improve our service and make sure it's effective.</p>
     <p class="govuk-body">We will share this information with other government departments.</p>
+    <p class="govuk-body">Your age and gender won’t affect the job suggestions we give you.</p>
     <%= render 'form' %>
   </div>
   <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
### Context

- DOB should be a h2 rather than a h3 - DAC advise that we should not skip from h1 to h3
- Add sentence as per prototype to say “Your age and gender won’t affect the job suggestions we give you.”

### Ticket
https://dfedigital.atlassian.net/browse/GET-882

