### PR TITLE
GET-897 Fix progression on question pages bug

### DIFF
--- a/app/helpers/question_helper.rb
+++ b/app/helpers/question_helper.rb
@@ -1,8 +1,6 @@
 module QuestionHelper
   def action_plan_or_questions_path
-    training_questions ||
-      it_training_questions ||
-      job_hunting_questions ||
+    questions_path ||
       action_plan_path
   end
 
@@ -18,13 +16,19 @@ module QuestionHelper
     it_training_questions_path if user_session.it_training.nil?
   end
 
-  def progression_indicator(show_indicator:, step:)
-    return unless show_indicator
+  def progression_indicator(step:)
+    return unless questions_path
 
     content_tag(
       :span,
       "Step #{step} of 3",
       class: 'govuk-caption-xl'
     )
+  end
+
+  def questions_path
+    training_questions ||
+      it_training_questions ||
+      job_hunting_questions
   end
 end

--- a/app/views/questions/it_training.html.erb
+++ b/app/views/questions/it_training.html.erb
@@ -15,7 +15,7 @@
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="it-training-options-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <%= progression_indicator(show_indicator: it_training_questions, step: 2) %>
+            <%= progression_indicator(step: 2) %>
             <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3">
               <%= t('.title') %>
             </h1>

--- a/app/views/questions/job_hunting.html.erb
+++ b/app/views/questions/job_hunting.html.erb
@@ -15,7 +15,7 @@
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="job-hunting-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <%= progression_indicator(show_indicator: job_hunting_questions, step: 3) %>
+            <%= progression_indicator(step: 3) %>
             <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3">
               <%= t('.title') %>
             </h1>

--- a/app/views/questions/training.html.erb
+++ b/app/views/questions/training.html.erb
@@ -15,7 +15,7 @@
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="training-options-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <%= progression_indicator(show_indicator: training_questions, step: 1) %>
+            <%= progression_indicator(step: 1) %>
             <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3">
               <%= t('.title') %>
             </h1>

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -256,6 +256,18 @@ RSpec.feature 'Questions' do
     end
   end
 
+  scenario 'user sees progression on question pages if user goes back to previous page mid journey' do
+    user_targets_job
+    click_on('Continue')
+    visit(training_questions_path)
+
+    (1..3).each do |step|
+      expect(page).to have_text("Step #{step} of 3")
+
+      click_on('Continue')
+    end
+  end
+
   scenario 'user sees progression on question pages if journey interrupted' do
     user_targets_job
     click_on('Continue')

--- a/spec/helpers/question_helper_spec.rb
+++ b/spec/helpers/question_helper_spec.rb
@@ -81,14 +81,26 @@ RSpec.describe QuestionHelper do
   end
 
   describe '#progression_indicator' do
-    it 'returns nil when show indictator is false' do
-      expect(helper.progression_indicator(show_indicator: nil, step: 1)).to be_nil
+    it 'shows progress indicator and step when no questions page have been visited' do
+      expect(helper.progression_indicator(step: 1)).to eq(
+        '<span class="govuk-caption-xl">Step 1 of 3</span>'
+      )
     end
 
-    it 'returns progress indicator when show indicator is true with correct page' do
-      expect(helper.progression_indicator(show_indicator: true, step: 2)).to eq(
+    it 'shows progress indicator and step when at least one question page has been visited' do
+      user_session.training = ['english_skills']
+
+      expect(helper.progression_indicator(step: 2)).to eq(
         '<span class="govuk-caption-xl">Step 2 of 3</span>'
       )
+    end
+
+    it 'hides progress indicator if all question pages have been visited' do
+      user_session.training = ['english_skills']
+      user_session.it_training = ['computer_skills']
+      user_session.job_hunting = ['cv']
+
+      expect(helper.progression_indicator(step: 1)).to be_nil
     end
   end
 end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-897

If user goes back mid journey, we should show progress indicator, until user gets
to action plan page.

Remaining behaviour remains the same.

Testing:
1) Normal journey shows normal progress
2) Interrupted journey shows only page where journey abandoned and progress
3) Going back shows progress mid journey
4) Action plan editing question shows no progress

