### PR TITLE
GET-854 Add role button to links styled as buttons which affect journey

### DIFF
--- a/app/views/errors/course_postcode_search_error.html.erb
+++ b/app/views/errors/course_postcode_search_error.html.erb
@@ -6,7 +6,7 @@
       <h1 class="govuk-heading-xl">Sorry, there is a problem with this service</h1>
       <p class="govuk-body">Postcode search is not working right now.</p>
       <p class="govuk-body-m">You can continue using this service to check your existing skills and explore the types of jobs you could apply to do.</p>
-      <%= link_to 'Continue', action_plan_path, class: 'govuk-button', data: { module: 'govuk-button' } %>
+      <%= link_to 'Continue', action_plan_path, class: 'govuk-button', role: 'button', data: { module: 'govuk-button' } %>
     </div>
   </div>
 </main>

--- a/app/views/errors/jobs_near_me_error.html.erb
+++ b/app/views/errors/jobs_near_me_error.html.erb
@@ -6,7 +6,7 @@
       <h1 class="govuk-heading-xl">Sorry, there is a problem with this service</h1>
       <p class="govuk-body">The <%= link_to 'Find a job', 'https://findajob.dwp.gov.uk/', class: 'govuk-link' %> service is not working right now.</p>
       <p class="govuk-body-m">You can continue using this service to check your existing skills and explore the types of jobs you could apply to do.</p>
-      <%= link_to 'Continue', action_plan_path, class: 'govuk-button', data: { module: 'govuk-button' } %>
+      <%= link_to 'Continue', action_plan_path, class: 'govuk-button', role: 'button', data: { module: 'govuk-button' } %>
     </div>
   </div>
 </main>

--- a/app/views/errors/postcode_search_error.html.erb
+++ b/app/views/errors/postcode_search_error.html.erb
@@ -6,7 +6,7 @@
       <h1 class="govuk-heading-xl">Sorry, there is a problem with this service</h1>
       <p class="govuk-body">Postcode search isn't working right now.</p>
       <p class="govuk-body-m">You can continue using this service to check your existing skills and explore the types of jobs you could apply to do.</p>
-      <%= link_to 'Continue', task_list_path, class: 'govuk-button', data: { module: 'govuk-button' } %>
+      <%= link_to 'Continue', task_list_path, class: 'govuk-button', role: 'button', data: { module: 'govuk-button' } %>
     </div>
   </div>
 </main>

--- a/app/views/errors/save_results_error.html.erb
+++ b/app/views/errors/save_results_error.html.erb
@@ -16,7 +16,7 @@
     <p class="govuk-body">We have saved your results using the email address you have provided.</p>
     <p class="govuk-body">We cannot send you a confirmation email right now because of an error with our system. Your results are still saved.</p>
     <p class="govuk-body">To see your saved skills and job matches in future, just return to the service and enter your email address. You will then be sent a link so you can return to your saved results.</p>
-    <%= link_to 'Continue', user_session.registration_triggered_path || task_list_path, class: 'govuk-button', data: { module: 'govuk-button' } %>
+    <%= link_to 'Continue', user_session.registration_triggered_path || task_list_path, class: 'govuk-button', role: 'button', data: { module: 'govuk-button' } %>
   </div>
   <div class="govuk-grid-column-one-third">
     <%= render "shared/contact_us" %>

--- a/app/views/pages/location_ineligible.html.erb
+++ b/app/views/pages/location_ineligible.html.erb
@@ -14,7 +14,7 @@
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
     <p class="govuk-body-m">The service will be rolled out across England during 2020. In the meantime you can use it to check your existing skills and explore the types of jobs you could apply for.</p>
     <p class="govuk-body-m">Find more training and careers advice for your area through the <%= link_to('National Careers Service', 'https://nationalcareers.service.gov.uk/', class: 'govuk-link') %>.</p>
-    <%= link_to 'Continue', task_list_path, class: 'govuk-button', data: { module: 'govuk-button' } %>
+    <%= link_to 'Continue', task_list_path, class: 'govuk-button', role: 'button', data: { module: 'govuk-button' } %>
   </div>
   <div class="govuk-grid-column-one-third">
     <%= render "shared/contact_us" %>

--- a/app/views/shared/_cookies_banner.html.erb
+++ b/app/views/shared/_cookies_banner.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-width-container">
       <div class="govuk-main-wrapper govuk-!-padding-top-1 govuk-!-padding-bottom-1" role="region">
         <p class="govuk-body">This service uses cookies to personalise your experience and to collect information about how you use the site. You can find out more about cookies by clicking the cookies settings button.</p>
-        <%= link_to 'Accept cookies', '#', id: 'accept-cookies', class: 'govuk-button govuk-button--secondary govuk-!-margin-right-5', data: { module: 'govuk-button' } %>
+        <%= link_to 'Accept cookies', '#', id: 'accept-cookies', class: 'govuk-button govuk-button--secondary govuk-!-margin-right-5', role: 'button', data: { module: 'govuk-button' } %>
         <%= link_to 'Cookie settings', cookies_policy_path, class: 'govuk-button govuk-button--secondary', data: { module: 'govuk-button' } %>
       </div>
     </div>

--- a/app/views/skills/_job_profiles_with_skills.html.erb
+++ b/app/views/skills/_job_profiles_with_skills.html.erb
@@ -26,4 +26,4 @@
   </div>
 <% end %>
 
-<%= link_to('Find out what you can do with these skills', skills_matcher_index_path, class: 'govuk-button govuk-!-margin-top-3', data: { cy: 'find-out-what-you-can-do-btn', module: 'govuk-button' }) %>
+<%= link_to('Find out what you can do with these skills', skills_matcher_index_path, class: 'govuk-button govuk-!-margin-top-3', role: 'button', data: { cy: 'find-out-what-you-can-do-btn', module: 'govuk-button' }) %>

--- a/app/views/users/registration_email_sent_again.html.erb
+++ b/app/views/users/registration_email_sent_again.html.erb
@@ -18,7 +18,7 @@
       <li>check the email address you entered is correct</li>
       <li>check your junk mail</li>
     </ul>
-    <%= link_to 'Continue', user_session.registration_triggered_path || task_list_path, class: 'govuk-button', data: { module: 'govuk-button' } %>
+    <%= link_to 'Continue', user_session.registration_triggered_path || task_list_path, class: 'govuk-button', role: 'button', data: { module: 'govuk-button' } %>
   </div>
   <div class="govuk-grid-column-one-third">
     <%= render "shared/contact_us" %>

--- a/app/views/users/registration_results_saved.html.erb
+++ b/app/views/users/registration_results_saved.html.erb
@@ -19,7 +19,7 @@
       <p class="govuk-body">If you haven't received this email you can <%= submit_tag('send it again', class: 'unbutton govuk-body govuk-link') %>.</p>
     <% end %>
     <p class="govuk-body">If the email address above is incorrect, <%= link_to 'enter your email address again',save_your_results_path, class: 'govuk-link' %>.</p>
-    <%= link_to 'Continue', user_session.registration_triggered_path || task_list_path, class: 'govuk-button', data: { module: 'govuk-button' } %>
+    <%= link_to 'Continue', user_session.registration_triggered_path || task_list_path, class: 'govuk-button', role: 'button', data: { module: 'govuk-button' } %>
   </div>
   <div class="govuk-grid-column-one-third">
     <%= render "shared/contact_us" %>


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-854

Add role button to all buttons which affect a user's journey. As per recommendation from DAC report:
If continuing through the service it is recommended that ‘Continue’ buttons are used for consistency purposes and to inform the user that they’ll be continuing throughout the service.
The ‘button’ is still a link in semantics, and has not been given a role of button as an alternative
page 41

✅ Axe tests pass
✅ Siteimprove does not fail on those new added roles
