### PR TITLE
Get 785

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -259,6 +259,7 @@
     "appServiceRuntimeStack": "[concat('COMPOSE|', base64(replace(base64ToString(parameters('dockerComposeFile')),'__CONTAINER_REFERENCE__',parameters('containerImageReference'))))]",
     "adminServiceRuntimeStack": "[concat('DOCKER|', parameters('containerImageReference'))]",
     "warmupPingPath": "/status",
+    "warmupAllowedStatuses": "200,301",
     "containerStartTimeLimit": "300"
   },
   "resources": [
@@ -595,6 +596,9 @@
                 "name": "WEBSITE_SWAP_WARMUP_PING_PATH",
                 "value": "[variables('warmupPingPath')]"
               },
+              {  "name": "WEBSITE_SWAP_WARMUP_PING_STATUSES",
+                 "value": "[variables('warmupAllowedStatuses')]"
+              },
               {
                 "name": "WEBSITES_CONTAINER_START_TIME_LIMIT",
                 "value": "[variables('containerStartTimeLimit')]"
@@ -724,6 +728,9 @@
               {
                 "name": "WEBSITE_SWAP_WARMUP_PING_PATH",
                 "value": "[variables('warmupPingPath')]"
+              },
+              {  "name": "WEBSITE_SWAP_WARMUP_PING_STATUSES",
+                 "value": "[variables('warmupAllowedStatuses')]"
               },
               {
                 "name": "WEBSITES_CONTAINER_START_TIME_LIMIT",


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/GET-785

### Changes proposed in this pull request

This change re-introduces the validation of the health-check status codes. 
But also accepts a 301 in addition to the 200, as the request seems to be make in HTTP and there is a redirect for the HTTPS endpoint.

This should cover an application not ready scenario, but it's effect is not clear when the health-check is not a 200, as you still get a 301.

### Guidance to review

https://ruslany.net/2019/06/azure-app-service-deployment-slots-tips-and-tricks/

