### PR TITLE
Introduce growth_type in skills matcher query

### DIFF
--- a/app/models/skills_matcher.rb
+++ b/app/models/skills_matcher.rb
@@ -30,25 +30,30 @@ class SkillsMatcher
       .to_sql
   end
 
+  # rubocop:disable Metrics/MethodLength
   def build_query
     @build_query ||= begin
       job_profile_scope
         .select(
-          :skills_matched, :id, :name, :description, :alternative_titles, :salary_min, :salary_max, :slug, :growth
+          :skills_matched, :id, :name, :description, :alternative_titles, :salary_min, :salary_max, :slug, :growth,
+          growth_type
         )
         .from(Arel.sql("(#{skills_matched_query}) as ranked_job_profiles"))
         .joins('LEFT JOIN job_profiles ON job_profiles.id = ranked_job_profiles.job_profile_id')
         .order(order_options)
         .limit(options[:limit])
     end
+
+    @build_query
   end
+  # rubocop:enable Metrics/MethodLength
 
   def order_options
     case options[:order]
     when :growth
-      ['growth DESC NULLS LAST', { skills_matched: :desc, skills_rarity: :asc, name: :asc }]
+      ['growth_type DESC', { skills_matched: :desc, skills_rarity: :asc, name: :asc }]
     else
-      [{ skills_matched: :desc }, 'growth DESC NULLS LAST', { skills_rarity: :asc, name: :asc }]
+      [{ skills_matched: :desc }, 'growth_type DESC', { skills_rarity: :asc, name: :asc }]
     end
   end
 
@@ -56,5 +61,16 @@ class SkillsMatcher
     JobProfile
       .recommended
       .where.not(id: user_session.job_profile_ids)
+  end
+
+  def growth_type
+    <<-SQL
+    CASE WHEN growth <= - 5 THEN 1
+      WHEN growth > -5 AND growth <= 5 THEN 2
+      WHEN growth > 5 AND growth <= 50 THEN 3
+      WHEN growth > 50 THEN 4
+      ELSE 0 END
+      AS growth_type
+    SQL
   end
 end

--- a/app/models/skills_matcher.rb
+++ b/app/models/skills_matcher.rb
@@ -51,9 +51,9 @@ class SkillsMatcher
   def order_options
     case options[:order]
     when :growth
-      ['growth_type DESC', { skills_matched: :desc, skills_rarity: :asc, name: :asc }]
+      { growth_type: :desc, skills_matched: :desc, skills_rarity: :asc, name: :asc }
     else
-      [{ skills_matched: :desc }, 'growth_type DESC', { skills_rarity: :asc, name: :asc }]
+      { skills_matched: :desc, growth_type: :desc, skills_rarity: :asc, name: :asc }
     end
   end
 

--- a/spec/models/skills_matcher_spec.rb
+++ b/spec/models/skills_matcher_spec.rb
@@ -200,7 +200,6 @@ RSpec.describe SkillsMatcher do
       )
     end
 
-
     it 'arranges job profiles in matching skills order, then job growth type order, then alphabetical order' do
       skill1 = create(:skill)
       skill2 = create(:skill)

--- a/spec/models/skills_matcher_spec.rb
+++ b/spec/models/skills_matcher_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SkillsMatcher do
       )
       matcher = described_class.new(UserSession.new(session), limit: 10)
 
-      expect(matcher.match.size).to eq 10
+      expect(matcher.match.length).to eq 10
     end
 
     it 'returns multiple jobs matching skill selected ignoring job profiles in the session' do
@@ -129,7 +129,7 @@ RSpec.describe SkillsMatcher do
       )
     end
 
-    it 'arranges job profiles in matching skills order as well as job growth order' do
+    it 'arranges job profiles in matching skills order as well as job growth type order' do
       skill = create(:skill)
       job_profile1 = create(:job_profile, skills: [skill])
       job_profile2 = create(:job_profile, skills: [skill], growth: -5)
@@ -150,7 +150,7 @@ RSpec.describe SkillsMatcher do
       )
     end
 
-    it 'arranges job profiles in job growth order as well as matching skills order' do
+    it 'arranges job profiles in job growth type order as well as matching skills order' do
       skill1 = create(:skill)
       skill2 = create(:skill)
       skill3 = create(:skill)
@@ -177,7 +177,7 @@ RSpec.describe SkillsMatcher do
       )
     end
 
-    it 'arranges job profiles in job growth order unless job growth is nil' do
+    it 'arranges job profiles in job growth type order and profiles with job growth nil go at the end' do
       skill = create(:skill)
       job_profile1 = create(:job_profile, skills: [skill])
       job_profile2 = create(:job_profile, skills: [skill], growth: -5)
@@ -200,14 +200,16 @@ RSpec.describe SkillsMatcher do
       )
     end
 
-    it 'arranges job profiles in job growth order, alphabetical order as well as matching skills order' do
+
+    it 'arranges job profiles in matching skills order, then job growth type order, then alphabetical order' do
       skill1 = create(:skill)
       skill2 = create(:skill)
       skill3 = create(:skill)
       job_profile1 = create(:job_profile, skills: [skill1, skill2, skill3])
-      job_profile2 = create(:job_profile, name: 'Researcher', skills: [skill2], growth: 52)
+      job_profile2 = create(:job_profile, name: 'Researcher', skills: [skill2], growth: 59)
       job_profile3 = create(:job_profile, name: 'Beekeeper', skills: [skill1, skill2, skill3], growth: 45)
-      job_profile4 = create(:job_profile, name: 'Admin', skills: [skill1, skill2, skill3], growth: -5)
+      job_profile4 = create(:job_profile, name: 'Office Admin', skills: [skill1, skill2, skill3], growth: -5)
+      job_profile6 = create(:job_profile, name: 'Admin', skills: [skill1, skill2, skill3], growth: -6)
       job_profile5 = create(:job_profile, name: 'Boat builder', skills: [skill3], growth: 52)
       session = create_fake_session(
         job_profile_ids: [job_profile1.id],
@@ -220,6 +222,7 @@ RSpec.describe SkillsMatcher do
       expect(matcher.match).to eq(
         [
           job_profile3,
+          job_profile6,
           job_profile4,
           job_profile5,
           job_profile2
@@ -227,15 +230,15 @@ RSpec.describe SkillsMatcher do
       )
     end
 
-    it 'arranges job profiles in matching skills, job growth and skills rarity order' do
+    it 'arranges job profiles in matching skills, job growth type and skills rarity order' do
       skill1 = create(:skill, rarity: nil)
       skill2 = create(:skill, rarity: 3)
       skill3 = create(:skill, rarity: 2)
       skill4 = create(:skill, rarity: 1)
       job_profile1 = create(:job_profile)
-      job_profile2 = create(:job_profile, skills: [skill1, skill2])
-      job_profile3 = create(:job_profile, skills: [skill1, skill3])
-      job_profile4 = create(:job_profile, skills: [skill1, skill4])
+      job_profile2 = create(:job_profile, skills: [skill1, skill2], growth: 1.6)
+      job_profile3 = create(:job_profile, skills: [skill1, skill3], growth: 4.2)
+      job_profile4 = create(:job_profile, skills: [skill1, skill4], growth: 2)
 
       session = create_fake_session(
         job_profile_ids: [job_profile1.id],
@@ -254,7 +257,7 @@ RSpec.describe SkillsMatcher do
       )
     end
 
-    it 'arranges job profiles in job growth, matching skills and skills rarity order' do
+    it 'arranges job profiles in job growth_type, matching skills and skills rarity order' do
       skill1 = create(:skill, rarity: nil)
       skill2 = create(:skill, rarity: 3)
       skill3 = create(:skill, rarity: 2)


### PR DESCRIPTION
### Context
New order is as follows:
- number of skills matched;
- within that, order by job growth type
- within that, order by rarity of skills

Growth type codes:
- No data available: 0
- Falling: 1
- Stable: 2
- Growing: 3
- Growing strongly: 4

Introducing this new metric does not increase the
computation cost massively:

Before: 597.38ms
After: 618.77ms

### Benchmarks

![Screen Shot 2020-01-24 at 09 34 27](https://user-images.githubusercontent.com/1955084/73066846-1027fe00-3e9f-11ea-9e3a-fcee2ca10132.png)
![Screen Shot 2020-01-24 at 09 33 30](https://user-images.githubusercontent.com/1955084/73066848-1322ee80-3e9f-11ea-95e7-8a3fc9560036.png)

### Ticket
https://dfedigital.atlassian.net/browse/GET-911