### PR TITLE
GET-791 Add error summary to all forms with validation

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,4 +1,17 @@
 module FormHelper
+  def error_summary(object)
+    return unless object.errors.any?
+
+    content_tag('div', class: 'govuk-error-summary', **error_summary_attributes) do
+      safe_join(
+        [
+          tag.h2('There is a problem', id: 'error-summary-title', class: 'govuk-error-summary__title'),
+          error_list(object)
+        ]
+      )
+    end
+  end
+
   def form_group_tag(object, attribute, tag_class: [], &_block)
     css_classes = ['govuk-form-group'] + tag_class
     css_classes << 'govuk-form-group--error' if object.errors.key?(attribute)
@@ -35,5 +48,43 @@ module FormHelper
     object.errors.messages[attribute].map { |message|
       content_tag(:span, 'Error:', class: 'govuk-visually-hidden') + ' ' + message
     }
+  end
+
+  def error_summary_attributes
+    {
+      tabindex: -1,
+      role: 'alert',
+      data: {
+        module: 'govuk-error-summary'
+      },
+      aria: {
+        labelledby: 'error-summary-title'
+      }
+    }
+  end
+
+  def error_list(object)
+    content_tag('div', class: 'govuk-error-summary__body') do
+      content_tag('ul', class: 'govuk-list govuk-error-summary__list') do
+        safe_join(
+          object.errors.messages.map { |attribute, messages|
+            error_list_item(object.class.model_name.singular, attribute, messages.first)
+          }
+        )
+      end
+    end
+  end
+
+  def error_list_item(object_name, attribute, message)
+    content_tag('li') do
+      link_to(
+        message,
+        same_page_link(error_id(object_name, attribute))
+      )
+    end
+  end
+
+  def same_page_link(target)
+    '#'.concat(target)
   end
 end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -79,12 +79,8 @@ module FormHelper
     content_tag('li') do
       link_to(
         message,
-        same_page_link(error_id(object_name, attribute))
+        '#' + error_id(object_name, attribute)
       )
     end
-  end
-
-  def same_page_link(target)
-    '#'.concat(target)
   end
 end

--- a/app/views/check_your_skills/index.html.erb
+++ b/app/views/check_your_skills/index.html.erb
@@ -11,6 +11,7 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds" >
+    <%= error_summary(@job_profile_search) %>
     <% if user_session.job_profile_skills? %>
       <%= render "shared/search/form", search_path: check_your_skills_path, scope: 'check_your_skills.index.additional_skills' %>
     <% else %>

--- a/app/views/check_your_skills/results.html.erb
+++ b/app/views/check_your_skills/results.html.erb
@@ -12,10 +12,11 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds" >
+    <%= error_summary(@job_profile_search) %>
     <% if @job_profiles.blank? %>
       <%= render '/shared/search/no_results', scope: 'check_your_skills.results' %>
     <% else %>
-      <%= render "search_form", scope: user_session.job_profile_skills? ? 'check_your_skills.results.additional_skills' : 'check_your_skills.results' %> 
+      <%= render "search_form", scope: user_session.job_profile_skills? ? 'check_your_skills.results.additional_skills' : 'check_your_skills.results' %>
       <%= render "results_list", job_profiles: @job_profiles %>
       <div class="govuk-grid-column-full govuk-!-padding-top-6 govuk-!-margin-bottom-4 govuk-!-margin-top-6 pagination__section">
         <%= paginate @job_profiles %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -13,6 +13,7 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
+    <%= error_summary(@search) %>
     <h1 class="govuk-heading-xl"><%= params[:topic_id].titleize %> courses near me</h1>
     <p class="govuk-body-l">Apply for a course by calling the course provider or visiting their website.</p>
     <div class="govuk-grid-column-full govuk-!-padding-0">

--- a/app/views/job_profiles/index.html.erb
+++ b/app/views/job_profiles/index.html.erb
@@ -11,6 +11,7 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds" >
+    <%= error_summary(@job_profile_search) %>
     <%= render "shared/search/form", search_path: job_profiles_path, scope: 'job_profiles.index' %>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/app/views/job_profiles/results.html.erb
+++ b/app/views/job_profiles/results.html.erb
@@ -11,6 +11,7 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds" >
+    <%= error_summary(@job_profile_search) %>
     <% if @job_profiles.blank? %>
       <%= render 'no_results', scope: 'job_profiles.index' %>
     <% else %>

--- a/app/views/job_profiles/skills/index.html.erb
+++ b/app/views/job_profiles/skills/index.html.erb
@@ -14,6 +14,7 @@
 <div class="govuk-grid-row govuk-!-margin-top-7 govuk-body">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-grid-column-full govuk-!-padding-0">
+      <%= error_summary(@skills_builder) %>
       <%= form_tag job_profile_skills_path, method: 'get' do %>
         <%= form_group_tag @skills_builder, :skills do %>
           <fieldset class="govuk-fieldset" aria-describedby="current-job-skills-hint">

--- a/app/views/job_vacancies/index.html.erb
+++ b/app/views/job_vacancies/index.html.erb
@@ -13,6 +13,7 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
+    <%= error_summary(@job_vacancy_search) %>
     <h1 class="govuk-heading-xl"><%= target_job.name %> jobs near me</h1>
     <p class="govuk-body">These jobs within 20 miles of your postcode are currently being advertised in the <%= link_to('Find a job', 'https://findajob.dwp.gov.uk/', class: 'govuk-link') %> service from the Department for Work and Pensions.</p>
     <p class="govuk-body">Selecting one of these jobs will take you to another government service.</p>

--- a/app/views/user_personal_data/index.html.erb
+++ b/app/views/user_personal_data/index.html.erb
@@ -12,6 +12,7 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
+    <%= error_summary(@user_personal_data) %>
     <h1 class="govuk-heading-xl"><%= t('user_personal_data.title') %></h1>
     <p class="govuk-body">We use this information to improve our service and make sure it's effective.</p>
     <p class="govuk-body">We will share this information with other government departments.</p>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -10,6 +10,7 @@
 %>
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
+    <%= error_summary(@user) %>
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
     <p class="govuk-body">If you like, you can save your skills list and job matches so you can return to them later.</p>
     <p class="govuk-body">To save your results, just enter your email address below.</p>

--- a/app/views/users/return_to_saved_results.html.erb
+++ b/app/views/users/return_to_saved_results.html.erb
@@ -11,6 +11,7 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
+    <%= error_summary(@user) %>
     <h1 class="govuk-heading-xl"><%= t('return_to_saved_results.title') %></h1>
     <p class="govuk-body"><%= t('return_to_saved_results.sub_title') %></p>
     <p class="govuk-body">The link expires after one hour.</p>

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -216,6 +216,24 @@ RSpec.feature 'Check your skills', type: :feature do
     expect(page).to have_text(/Enter a job title/)
   end
 
+  scenario 'Error summary message present if no search is entered' do
+    visit(check_your_skills_path)
+    find('.search-button').click
+
+    expect(page).to have_content('There is a problem')
+  end
+
+  scenario 'Error summary contains error if no search is entered' do
+    visit(check_your_skills_path)
+    find('.search-button').click
+
+    expect(page.all('ul.govuk-error-summary__list li a').collect(&:text)).to eq(
+      [
+        'Enter a job title'
+      ]
+    )
+  end
+
   scenario 'User gets relevant messaging if no search in results is entered' do
     create(:job_profile, name: 'Hacker')
     visit(results_check_your_skills_path(search: 'Hacker'))
@@ -223,5 +241,21 @@ RSpec.feature 'Check your skills', type: :feature do
     find('.search-button').click
 
     expect(page).to have_text(/Enter a job title/)
+  end
+
+  scenario 'Error summary message present if no search is entered on results page' do
+    visit(results_check_your_skills_path(search: ''))
+
+    expect(page).to have_content('There is a problem')
+  end
+
+  scenario 'Error summary contains error if no search is entered on results page' do
+    visit(results_check_your_skills_path(search: ''))
+
+    expect(page.all('ul.govuk-error-summary__list li a').collect(&:text)).to eq(
+      [
+        'Enter a job title'
+      ]
+    )
   end
 end

--- a/spec/features/find_training_courses_spec.rb
+++ b/spec/features/find_training_courses_spec.rb
@@ -128,6 +128,26 @@ RSpec.feature 'Find training courses', type: :feature do
     expect(page).to have_text(/Enter a postcode/)
   end
 
+  scenario 'Error summary message present if no address is entered' do
+    create(:course, topic: 'maths')
+    visit(courses_path(topic_id: 'maths'))
+    find('.search-button-results').click
+
+    expect(page).to have_content('There is a problem')
+  end
+
+  scenario 'Error summary contains error if no address is entered' do
+    create(:course, topic: 'maths')
+    visit(courses_path(topic_id: 'maths'))
+    find('.search-button-results').click
+
+    expect(page.all('ul.govuk-error-summary__list li a').collect(&:text)).to eq(
+      [
+        'Enter a postcode'
+      ]
+    )
+  end
+
   scenario 'tracks search postcode' do
     tracking_service = instance_spy(TrackingService)
     allow(TrackingService).to receive(:new).and_return(tracking_service)

--- a/spec/features/jobs_near_me_spec.rb
+++ b/spec/features/jobs_near_me_spec.rb
@@ -152,6 +152,24 @@ RSpec.feature 'Jobs near me', type: :feature do
     expect(page).to have_text(/Enter a postcode/)
   end
 
+  scenario 'Error summary message present if no address is entered' do
+    user_targets_a_job
+    find('.search-button-results').click
+
+    expect(page).to have_content('There is a problem')
+  end
+
+  scenario 'Error summary contains error if no address is entered' do
+    user_targets_a_job
+    find('.search-button-results').click
+
+    expect(page.all('ul.govuk-error-summary__list li a').collect(&:text)).to eq(
+      [
+        'Enter a postcode'
+      ]
+    )
+  end
+
   scenario 'User gets relevant messaging if there is an API error' do
     find_a_job_service = instance_double(FindAJobService)
     allow(FindAJobService).to receive(:new).and_return(find_a_job_service)

--- a/spec/features/skills_builder_spec.rb
+++ b/spec/features/skills_builder_spec.rb
@@ -314,6 +314,22 @@ RSpec.feature 'Build your skills', type: :feature do
     expect(page).to have_text(/Select at least one skill/)
   end
 
+  scenario 'Error summary message present if no skills selected' do
+    unselect_all_skills_for(job_profile)
+
+    expect(page).to have_content('There is a problem')
+  end
+
+  scenario 'Error summary contains error if no skills selected' do
+    unselect_all_skills_for(job_profile)
+
+    expect(page.all('ul.govuk-error-summary__list li a').collect(&:text)).to eq(
+      [
+        'Select at least one skill'
+      ]
+    )
+  end
+
   scenario 'remains on skills page if no skills present on session for a job profile' do
     unselect_all_skills_for(job_profile)
     visit(skills_path)

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -207,6 +207,46 @@ RSpec.feature 'Skills matcher', type: :feature do
     expect(page).to have_text('1 result found')
   end
 
+  scenario 'Error summary message present if no search is entered on job search page' do
+    visit_skills_for_current_job_profile
+
+    visit job_profiles_path
+    find('.search-button').click
+
+    expect(page).to have_content('There is a problem')
+  end
+
+  scenario 'Error summary contains error if no search is entered on job search page' do
+    visit_skills_for_current_job_profile
+
+    visit job_profiles_path
+    find('.search-button').click
+
+    expect(page.all('ul.govuk-error-summary__list li a').collect(&:text)).to eq(
+      [
+        'Enter a job title'
+      ]
+    )
+  end
+
+  scenario 'Error summary message present if no search is entered on job results page' do
+    visit_skills_for_current_job_profile
+    visit(results_job_profiles_path(search: ''))
+
+    expect(page).to have_content('There is a problem')
+  end
+
+  scenario 'Error summary contains error if no search is entered on job results page' do
+    visit_skills_for_current_job_profile
+    visit(results_job_profiles_path(search: ''))
+
+    expect(page.all('ul.govuk-error-summary__list li a').collect(&:text)).to eq(
+      [
+        'Enter a job title'
+      ]
+    )
+  end
+
   scenario 'search for specific job title shows skills match' do
     visit_skills_for_current_job_profile
 

--- a/spec/features/user_registration_spec.rb
+++ b/spec/features/user_registration_spec.rb
@@ -56,6 +56,24 @@ RSpec.feature 'User registration' do
     expect(page).to have_text(/Enter an email address/)
   end
 
+  scenario 'Error summary message present if no email is entered' do
+    visit(save_your_results_path)
+    click_on('Save your results')
+
+    expect(page).to have_content('There is a problem')
+  end
+
+  scenario 'Error summary contains error if no email is entered' do
+    visit(save_your_results_path)
+    click_on('Save your results')
+
+    expect(page.all('ul.govuk-error-summary__list li a').collect(&:text)).to eq(
+      [
+        'Enter an email address'
+      ]
+    )
+  end
+
   scenario 'User gets relevant messaging if invalid email is entered' do
     visit(save_your_results_path)
     fill_in('email', with: 'wrong email')

--- a/spec/features/user_sign_in_spec.rb
+++ b/spec/features/user_sign_in_spec.rb
@@ -280,6 +280,27 @@ RSpec.feature 'User sign in' do
     expect(page).to have_text(/Enter a valid email address/)
   end
 
+  scenario 'Error summary message present if no email is entered' do
+    visit return_to_saved_results_path
+
+    click_on('Send link')
+
+    expect(page).to have_content('There is a problem')
+  end
+
+  scenario 'Error summary contains error if invalid email is entered' do
+    visit return_to_saved_results_path
+
+    fill_in('email', with: 'dummy-mail')
+    click_on('Send link')
+
+    expect(page.all('ul.govuk-error-summary__list li a').collect(&:text)).to eq(
+      [
+        'Enter a valid email address'
+      ]
+    )
+  end
+
   scenario 'valid email submission redirects to link sent page' do
     visit return_to_saved_results_path
 

--- a/spec/features/your_information_spec.rb
+++ b/spec/features/your_information_spec.rb
@@ -117,6 +117,26 @@ RSpec.feature 'Your information' do
     expect(page).to have_current_path(task_list_path)
   end
 
+  scenario 'Error summary message present when there is an error in the page' do
+    click_on('Continue')
+
+    expect(page).to have_content('There is a problem')
+  end
+
+  scenario 'Error summary contains list of all errors on the page' do
+    fill_in('user_personal_data[postcode]', with: 'NW6 1JJ')
+    click_on('Continue')
+
+    expect(page.all('ul.govuk-error-summary__list li a').collect(&:text)).to eq(
+      [
+        first_name_blank_error,
+        last_name_blank_error,
+        dob_invalid_error,
+        gender_blank_error
+      ]
+    )
+  end
+
   scenario 'Error message present when first name is missing' do
     click_on('Continue')
 

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -3,6 +3,30 @@ require 'rails_helper'
 RSpec.describe FormHelper do
   let(:search) { CourseGeospatialSearch.new(postcode: 'NW9 8ET') }
 
+  describe '#error_summary' do
+    it 'returns nothing if object supplied has no errors' do
+      expect(helper.error_summary(search)).to be_nil
+    end
+
+    it 'returns the error summary title' do
+      search.errors.add(:postcode, 'Test error')
+
+      expect(helper.error_summary(search)).to include(
+        '<h2 id="error-summary-title" class="govuk-error-summary__title">There is a problem</h2>'
+      )
+    end
+
+    it 'returns a link for each object error with the correct error id' do
+      search.errors.add(:postcode, 'Test error')
+      search.errors.add(:postcode_in_uk, 'Postcode not in uk')
+
+      expect(helper.error_summary(search)).to include(
+        '<a href="#course_geospatial_search_postcode-error">Test error</a>',
+        '<a href="#course_geospatial_search_postcode_in_uk-error">Postcode not in uk</a>'
+      )
+    end
+  end
+
   describe '#form_group_tag' do
     it 'wraps the supplied block in a form group <div> tag' do
       expect(helper.form_group_tag(search, :postcode) { content_tag(:div) }).to eq('<div class="govuk-form-group"><div></div></div>')


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-791

* Add method to accept object and return an error summary listing all errors from the object
* taken from: https://github.com/DFE-Digital/govuk_design_system_formbuilder/blob/88101aec9760233f0734de69a78e4db71112733e/lib/govuk_design_system_formbuilder/elements/error_summary.rb
* Formatting adheres to https://design-system.service.gov.uk/components/error-summary/
* Errors link to where they are on form on the page. We are building the error id the same way we build it within the form
* Add helper to pages:
user personal data:
check your skills search and results:
skill builder:
job profile search and results:
courses:
job vacancy search:
save and return to saved results:

