### PR TITLE
Remove bottom spacing for buttons on action plan

### DIFF
--- a/app/views/pages/_job_hunting.html.erb
+++ b/app/views/pages/_job_hunting.html.erb
@@ -8,39 +8,41 @@
 </div>
 <% if user_session.job_hunting.present? %>
   <p class="govuk-body">You chose to improve your job hunting skills. Getting this kind of advice can improve your chances of finding work.</p>
+  
+  <div class="action-plan-list">
+    <% if user_session.job_hunting.include?('cv') %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <h3 class="govuk-heading-s">Your CV</h3>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= link_to 'Get CV advice', cv_advice_path, class: 'govuk-button govuk-button--secondary action-plan-action', data: { module: 'govuk-button' } %>
+        </div>
+      </div>
+    <% end %>
 
-  <% if user_session.job_hunting.include?('cv') %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
-        <h3 class="govuk-heading-s">Your CV</h3>
+    <% if user_session.job_hunting.include?('cover_letter') %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <h3 class="govuk-heading-s">Your cover letter</h3>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= link_to 'Get cover letter advice', cover_letter_advice_path, class: 'govuk-button govuk-button--secondary action-plan-action', data: { module: 'govuk-button' } %>
+        </div>
       </div>
-      <div class="govuk-grid-column-one-half">
-        <%= link_to 'Get CV advice', cv_advice_path, class: 'govuk-button govuk-button--secondary action-plan-action', data: { module: 'govuk-button' } %>
-      </div>
-    </div>
-  <% end %>
+    <% end %>
 
-  <% if user_session.job_hunting.include?('cover_letter') %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
-        <h3 class="govuk-heading-s">Your cover letter</h3>
+    <% if user_session.job_hunting.include?('interviews') %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <h3 class="govuk-heading-s">Your interview skills</h3>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= link_to 'Get interview advice', interview_advice_path, class: 'govuk-button govuk-button--secondary action-plan-action', data: { module: 'govuk-button' } %>
+        </div>
       </div>
-      <div class="govuk-grid-column-one-half">
-        <%= link_to 'Get cover letter advice', cover_letter_advice_path, class: 'govuk-button govuk-button--secondary action-plan-action', data: { module: 'govuk-button' } %>
-      </div>
-    </div>
-  <% end %>
-
-  <% if user_session.job_hunting.include?('interviews') %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
-        <h3 class="govuk-heading-s">Your interview skills</h3>
-      </div>
-      <div class="govuk-grid-column-one-half">
-        <%= link_to 'Get interview advice', interview_advice_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-2 action-plan-action', data: { module: 'govuk-button' } %>
-      </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 <% else %>
   <p class="govuk-body">You did not choose to get advice on your CV, cover letter or interview skills. If you change your mind you can edit the advice you need.</p>
 <% end %>

--- a/app/views/pages/_training.html.erb
+++ b/app/views/pages/_training.html.erb
@@ -11,38 +11,40 @@
 <% if user_session.training.present? || user_session.it_training.present? %>
   <p class="govuk-body">You chose to look for some training. Employers value these skills so this can improve your chances of getting a job.</p>
 
-  <% if user_session.training.include?('math_skills') %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
-        <h3 class="govuk-heading-s">Maths course</h3>
+  <div class="action-plan-list">
+    <% if user_session.training.include?('math_skills') %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <h3 class="govuk-heading-s">Maths course</h3>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= link_to 'Find a maths course', courses_path(:maths), class: 'govuk-button govuk-button--secondary action-plan-action', data: { module: 'govuk-button' } %>
+        </div>
       </div>
-      <div class="govuk-grid-column-one-half">
-        <%= link_to 'Find a maths course', courses_path(:maths), class: 'govuk-button govuk-button--secondary action-plan-action', data: { module: 'govuk-button' } %>
-      </div>
-    </div>
-  <% end %>
+    <% end %>
 
-  <% if user_session.training.include?('english_skills') %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
-        <h3 class="govuk-heading-s">English course</h3>
+    <% if user_session.training.include?('english_skills') %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <h3 class="govuk-heading-s">English course</h3>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= link_to 'Find an English course', courses_path(:english), class: 'govuk-button govuk-button--secondary action-plan-action', data: { module: 'govuk-button' } %>
+        </div>
       </div>
-      <div class="govuk-grid-column-one-half">
-        <%= link_to 'Find an English course', courses_path(:english), class: 'govuk-button govuk-button--secondary action-plan-action', data: { module: 'govuk-button' } %>
-      </div>
-    </div>
-  <% end %>
+    <% end %>
 
-  <% if user_session.it_training.include?('computer_skills') %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
-        <h3 class="govuk-heading-s">Computer skills training</h3>
+    <% if user_session.it_training.include?('computer_skills') %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <h3 class="govuk-heading-s">Computer skills training</h3>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= link_to 'Go to learning provider website', 'https://www.learnmyway.com/subjects', class: 'govuk-button govuk-button--secondary action-plan-action', data: { module: 'govuk-button' } %>
+        </div>
       </div>
-      <div class="govuk-grid-column-one-half">
-        <%= link_to 'Go to learning provider website', 'https://www.learnmyway.com/subjects', class: 'govuk-button govuk-button--secondary action-plan-action govuk-!-margin-bottom-2', data: { module: 'govuk-button' } %>
-      </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 <% else %>
   <p class="govuk-body">Improve your chances of getting a job by completing training that employers value. You did not choose to get help with your maths or English. If you change your mind, you can edit your training choices.</p>
 <% end %>

--- a/app/webpacker/styles/_action-plan.scss
+++ b/app/webpacker/styles/_action-plan.scss
@@ -18,3 +18,7 @@
     width: 100%;
   }
 }
+
+.action-plan-list  div.govuk-grid-row:last-child a {
+  margin-bottom: govuk-spacing(2);
+}

--- a/app/webpacker/styles/_action-plan.scss
+++ b/app/webpacker/styles/_action-plan.scss
@@ -19,6 +19,6 @@
   }
 }
 
-.action-plan-list  div.govuk-grid-row:last-child a {
+.action-plan-list .govuk-grid-row:last-child a {
   margin-bottom: govuk-spacing(2);
 }


### PR DESCRIPTION
### Context

Moving the spacing on top of the training and job
hunting options removes the weird spacing happening
when only one option is selected for each section.

### Ticket
https://dfedigital.atlassian.net/browse/GET-778


