### PR TITLE
Fix WAI-ARIA group name accessibility issue

### DIFF
--- a/app/views/user_personal_data/_form.html.erb
+++ b/app/views/user_personal_data/_form.html.erb
@@ -16,7 +16,7 @@
   <% end %>
   <div class="govuk-form-group">
     <%= form_group_tag @user_personal_data, :dob do %>
-      <%= field_set_tag nil, class: 'govuk-fieldset', role: 'group', aria: { describedby: 'date-of-birth-hint' } do %>
+      <%= field_set_tag nil, class: 'govuk-fieldset', role: 'group', aria: { describedby: 'date-of-birth-hint', label: 'Date of birth' } do %>
         <legend class='govuk-fieldset__legend govuk-fieldset__legend--xl'>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
             Date of birth
@@ -51,7 +51,7 @@
   </div>
   <div class="govuk-radios">
     <%= form_group_tag @user_personal_data, :gender do %>
-      <%= field_set_tag nil, class: 'govuk-fieldset', role: 'group' do %>
+      <%= field_set_tag nil, class: 'govuk-fieldset', role: 'group', aria: { label: 'Gender' } do %>
         <legend class='govuk-fieldset__legend govuk-fieldset__legend--xl'>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
             Gender


### PR DESCRIPTION
### Context
Siteimprove captured the WAI-ARIA group name issue
around the PID form for the date of birth & gender sections.

### Screenshots

![Screen Shot 2020-01-31 at 13 23 07](https://user-images.githubusercontent.com/1955084/73542979-d8383200-442d-11ea-91a4-6e0e8d7c6ceb.png)

### Ticket
https://dfedigital.atlassian.net/browse/GET-851

