### PR TITLE
Filter out dob params from ActiveAdmin form

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -13,4 +13,5 @@ Rails.application.config.filter_parameters += %i[
   email
   authenticity_token
   token
+  dob
 ]


### PR DESCRIPTION
### Context

Active admin uses its own parameters convention for
the date of birth: dob(3i), dob(2i), dob(1i).

Apparently there is a known issue with filtering date types
at the active admin page classes.

Adding dob among the filtered params at Rails level does fix
the problem.

### Screenshot
<img width="1429" alt="Screen Shot 2020-02-05 at 13 18 40" src="https://user-images.githubusercontent.com/1955084/73851088-d4891e80-4824-11ea-85aa-771889b27cba.png">
<img width="1258" alt="Screen Shot 2020-02-05 at 13 30 49" src="https://user-images.githubusercontent.com/1955084/73851093-d5ba4b80-4824-11ea-8405-801ff930f672.png">
<img width="832" alt="Screen Shot 2020-02-05 at 14 23 57" src="https://user-images.githubusercontent.com/1955084/73851097-d6eb7880-4824-11ea-8728-0c6e699399d5.png">

### Ticket ID
https://dfedigital.atlassian.net/browse/GET-970

### Testing
1. Configure Raven for local environment
2. Break the code intentionally by adding the following:
```ruby
controller do
  def update
    super
    something.weird
  end
end
```
to `user-personal_data/admin`

This will cause an exception that will be reported in Sentry. Check the Rails logs as well and you should see the dob params filtered out on both Rails & Sentry logs.

