### PR TITLE
GET-943 Align label and text area name

### DIFF
--- a/app/views/shared/feedback/_survey.html.erb
+++ b/app/views/shared/feedback/_survey.html.erb
@@ -27,7 +27,7 @@
     <%= form_with url: feedback_surveys_path, id: 'page-is-not-useful-form', aria: { hidden: true } do |f| %>
       <%= hidden_field_tag('page_useful', 'no', id: 'page_useful_no') %>
       <div class="govuk-form-group govuk-!-margin-top-6">
-        <%= label_tag :feedback_survey_message, 'How should we improve this page?', class: 'govuk-label govuk-!-margin-bottom-4' %>
+        <%= label_tag :message, 'How should we improve this page?', class: 'govuk-label govuk-!-margin-bottom-4' %>
         <%= text_area_tag :message, nil, class: 'govuk-textarea govuk-!-width-two-thirds', rows: 3, maxlength: 250 %>
       </div>
       <%= f.button('Send message', name: nil, class: 'govuk-button govuk-!-margin-top-0 govuk-!-margin-bottom-4', data: { module: 'govuk-button' }) %>


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-943

Label should have same name as text area id, this removes all the errors
regarding the label and text area in siteimprove
