### PR TITLE
GET-962 Add aria label to cookie banner

### DIFF
--- a/app/views/shared/_cookies_banner.html.erb
+++ b/app/views/shared/_cookies_banner.html.erb
@@ -1,7 +1,7 @@
 <div id="cookies-banner" class="cookies-modal">
   <div class="cookies-modal-content" id="cookies-modal">
     <div class="govuk-width-container">
-      <div class="govuk-main-wrapper govuk-!-padding-top-1 govuk-!-padding-bottom-1" role="region">
+      <div class="govuk-main-wrapper govuk-!-padding-top-1 govuk-!-padding-bottom-1" role="region" aria-label="cookie banner">
         <p class="govuk-body">This service uses cookies to personalise your experience and to collect information about how you use the site. You can find out more about cookies by clicking the cookies settings button.</p>
         <%= link_to 'Accept cookies', '#', id: 'accept-cookies', class: 'govuk-button govuk-button--secondary govuk-!-margin-right-5', role: 'button', data: { module: 'govuk-button' } %>
         <%= link_to 'Cookie settings', cookies_policy_path, class: 'govuk-button govuk-button--secondary', data: { module: 'govuk-button' } %>


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-962

Add aria label to cookie banner marked as role region to remove siteimprove
error. The label was taken from https://www.gov.uk/
