### PR TITLE
GET-964 Change link text to avoid siteimrpove link purpose error

### DIFF
--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -19,7 +19,7 @@
       <li>remember who you are if you return to your saved progress so we can show you your information and information relevant to you</li>
     </ul>
     <p class="govuk-body">‘Get help to retrain’ cookies aren’t used to identify you personally. We record tracking information anonymously, so cookies do not track your personal data, only your activity on the site.</p>
-    <p class="govuk-body">Find out more about cookies on <%= link_to('GOV.UK', 'https://www.gov.uk/help/cookie-details', class: 'govuk-link') %>.</p>
+    <p class="govuk-body"><%= link_to('Find out more about cookies on GOV.UK', 'https://www.gov.uk/help/cookie-details', class: 'govuk-link') %></p>
 
     <h2 class="govuk-heading-m">How we use cookies</h2>
     <p class="govuk-body">We use Google Analytics and Azure Application Insights software as well as service-specific cookies to collect information about how you use ‘Get help to retrain’. We do this to help make sure the service is meeting the needs of its users and to help us make improvements.</p>


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-964

Wrap whole text in link, so we don't get same different links same text
error from siteimrpove on page
