### PR TITLE
GET-989 Temporarily disable job vacancies on job profile page

### DIFF
--- a/app/controllers/job_profiles_controller.rb
+++ b/app/controllers/job_profiles_controller.rb
@@ -51,10 +51,11 @@ class JobProfilesController < ApplicationController
   end
 
   def job_vacancy_count
-    JobVacancySearch.new(
-      name: resource.name,
-      postcode: user_session.postcode
-    ).count
+    # Disabling temporarily until search improved
+    # JobVacancySearch.new(
+    #   name: resource.name,
+    #   postcode: user_session.postcode
+    # ).count
   rescue FindAJobService::APIError
     nil
   end

--- a/spec/features/job_profile_spec.rb
+++ b/spec/features/job_profile_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Job profile spec' do
     expect(page).not_to have_content('Apprenticeship')
   end
 
-  scenario 'User can see number of job vacancies near them' do
+  xscenario 'User can see number of job vacancies near them' do
     job_vacancy_search = instance_double(JobVacancySearch, count: 3)
     allow(JobVacancySearch).to receive(:new).and_return(job_vacancy_search)
     job_profile = create(:job_profile, :with_html_content)
@@ -36,7 +36,7 @@ RSpec.feature 'Job profile spec' do
     expect(page).to have_content('At least 3 vacancies')
   end
 
-  scenario 'User can see singular job vacancy if only one near them' do
+  xscenario 'User can see singular job vacancy if only one near them' do
     job_vacancy_search = instance_double(JobVacancySearch, count: 1)
     allow(JobVacancySearch).to receive(:new).and_return(job_vacancy_search)
     job_profile = create(:job_profile, :with_html_content)
@@ -47,7 +47,7 @@ RSpec.feature 'Job profile spec' do
     expect(page).to have_content('At least 1 vacancy')
   end
 
-  scenario 'User can see no job vacancies near them if none are available' do
+  xscenario 'User can see no job vacancies near them if none are available' do
     job_vacancy_search = instance_double(JobVacancySearch, count: 0)
     allow(JobVacancySearch).to receive(:new).and_return(job_vacancy_search)
     job_profile = create(:job_profile, :with_html_content)


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-989

disable vacancies temporarily until we investigate searching further. The page will just not render anything in that section for now