### PR TITLE
GET-956 Track save and return events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,8 +27,8 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def track_event(event_key, event_value)
-    event_label = I18n.t(event_key, scope: :events)
+  def track_event(event_key, event_value, scope = 'events')
+    event_label = I18n.t(event_key, scope: scope)
 
     track_events(
       [

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,6 +33,8 @@ class UsersController < ApplicationController
   def register_user
     if user.new_record?
       user.register_new_user(user_session, request.base_url)
+
+      track_event(:progress, 'save_journey', 'events.save')
     else
       sign_in_user
     end
@@ -42,6 +44,8 @@ class UsersController < ApplicationController
   def sign_in_user
     passwordless_session = build_passwordless_session(user)
     user.register_existing_user(passwordless_session, request.base_url)
+
+    track_event(:progress, 'return_journey', 'events.return_to_saved')
   end
 
   def set_redirect_path_for_registration

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,10 @@ en-GB:
     job_hunting: Get help with your job hunting skills
     training: Check your maths and English skills
     it_training: Computer skills training
+    save:
+      progress: Saved progress
+    return_to_saved:
+      progress: Returned to progress
 
   contact_us:
     title: Free local advice


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-956

* Track if user saves their progress
* Track if user returns to their saved progress
* Track if existing user saves their progress
* Do not track non existing user trying to save their progress
* Do not track if user enters invalid email
* Change track event method parameters to accept a scope. We
  need to do this to allow the same key to be mapped to different
  values for the save and return.

GA key on heroku for testing