### PR TITLE
Hotfix footer links

### DIFF
--- a/app/webpacker/styles/_footer.scss
+++ b/app/webpacker/styles/_footer.scss
@@ -1,4 +1,8 @@
 .govuk-footer__inline-list .govuk-footer__link,
 .govuk-footer__list .govuk-footer__link {
   text-decoration: underline;
+
+  &:focus {
+    text-decoration: none;
+  }
 }


### PR DESCRIPTION
On focus remove underline from list footer links to adhere to other links
in footer.

