### PR TITLE
Error message (no results found) are consistent

### DIFF
--- a/app/views/check_your_skills/_search_form.html.erb
+++ b/app/views/check_your_skills/_search_form.html.erb
@@ -1,3 +1,4 @@
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-7"><%= t(:title, scope: scope) %></h1>
+<p class="govuk-body-l"><%= t(:body, scope: scope) %></p>
 <%= render "shared/search/results_form", search_path: results_check_your_skills_path, scope: 'check_your_skills.results' %>
-<p class="govuk-body-l govuk-!-margin-bottom-2"><%= t(:body, scope: scope) %></p>
+<p class="govuk-body">Select the job title that best matches what you do now. If you can't see your job title, try using a different name for this job title - for example, checkout operator instead of cashier.</p>

--- a/app/views/check_your_skills/results.html.erb
+++ b/app/views/check_your_skills/results.html.erb
@@ -14,7 +14,7 @@
   <div class="govuk-grid-column-two-thirds" >
     <%= error_summary(@job_profile_search) %>
     <% if @job_profiles.blank? %>
-      <%= render '/shared/search/no_results', scope: 'check_your_skills.results' %>
+      <%= render '/shared/search/no_results', scope: user_session.job_profile_skills? ? 'check_your_skills.results.additional_skills' : 'check_your_skills.results' %>
     <% else %>
       <%= render "search_form", scope: user_session.job_profile_skills? ? 'check_your_skills.results.additional_skills' : 'check_your_skills.results' %>
       <%= render "results_list", job_profiles: @job_profiles %>

--- a/app/views/job_profiles/_no_results.html.erb
+++ b/app/views/job_profiles/_no_results.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-xl"><%= t('title', scope: scope) %></h1>
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-7"><%= t('title', scope: scope) %></h1>
 <p class="govuk-body-l"><%= t('body', scope: scope) %></p>
 <%= render "shared/search/results_form", search_path: { action: :results }, scope: scope %>
 <p class="govuk-body">0 results found</p>

--- a/app/views/job_profiles/_search_form.html.erb
+++ b/app/views/job_profiles/_search_form.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-xl"><%= t(:title, scope: 'job_profiles.index') %></h1>
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-7"><%= t(:title, scope: 'job_profiles.index') %></h1>
 <p class="govuk-body-l"><%= t(:body, scope: 'job_profiles.index') %></p>
 <%= render "shared/search/results_form", search_path: results_job_profiles_path, scope: 'job_profiles.index' %>
 <p class="govuk-body">Select the job title that best matches what you're looking for.</p>

--- a/app/views/shared/search/_form.html.erb
+++ b/app/views/shared/search/_form.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-xl"><%= t('title', scope: scope) %></h1>
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-7"><%= t('title', scope: scope) %></h1>
 <p class="govuk-body-l"><%= t('body', scope: scope) %></p>
 <%= form_tag search_path, method: 'get' do %>
   <%= form_group_tag @job_profile_search, :term do %>

--- a/app/views/shared/search/_no_results.html.erb
+++ b/app/views/shared/search/_no_results.html.erb
@@ -1,8 +1,11 @@
-<h1 class="govuk-heading-xl">No results found</h1>
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-7"><%= t('title', scope: scope) %></h1>
+<p class="govuk-body-l"><%= t('body', scope: scope) %></p>
 <%= render "shared/search/results_form", search_path: { action: :results }, scope: scope %>
+<p class="govuk-body">0 results found</p>
+<p class="govuk-body">We can't find any results for this job title.</p>
 <p class="govuk-body">You could try:</p>
 <ul class="govuk-list govuk-list--bullet">
   <li>checking your spelling</li>
-  <li>using a different name for the job</li>
-  <li>searching for a different role</li>
+  <li>using a different name for this job  title – for example, checkout operator instead of cashier</li>
+  <li>searching for a different job title</li>
 </ul>

--- a/app/views/skills/_job_profiles_with_skills.html.erb
+++ b/app/views/skills/_job_profiles_with_skills.html.erb
@@ -22,7 +22,7 @@
 
 <% unless user_session.job_profiles_cap_reached? %>
   <div class='govuk-!-margin-top-7'>
-    <%= link_to('Add more skills from another job or volunteer role', check_your_skills_path, class: 'govuk-link') %>
+    <%= link_to('Add another job or volunteer role', check_your_skills_path, class: 'govuk-link') %>
   </div>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,19 +100,20 @@ en-GB:
 
   check_your_skills:
     index:
-      title: Tell us your job title
+      title: Tell us your current job title
       body: Tell us your current job title so we know what skills you already have.
       placeholder: Enter your current job title
       additional_skills:
-        title: Add more skills
-        body: Tell us another job or volunteer role you've done.
+        title: Tell us your previous job title
+        body: Tell us your previous job title or volunteer role so we know what skills you already have.
         placeholder: Enter a job title
     results:
-      title: Your current job
-      body: Select the job title that best matches what you do now. If you can’t see your job title, try searching with different words - for example, checkout operator instead of cashier.
+      title: Tell us your current job title
+      body: Tell us your current job title so we know what skills you already have.
       additional_skills:
-        title: Your previous job
-        body: Select the job title that best matches your previous role. If you can’t see your job title, try searching with different words - for example, checkout operator instead of cashier.
+        title: Tell us your previous job title
+        body: Tell us your previous job title or volunteer role so we know what skills you already have.
+        placeholder: Enter a job title
       placeholder: Enter your current job title
       no_results: 0 results found - try again using a different job title
   job_profiles:

--- a/spec/features/check_your_skills_spec.rb
+++ b/spec/features/check_your_skills_spec.rb
@@ -37,7 +37,17 @@ RSpec.feature 'Check your skills', type: :feature do
     fill_in('search', with: 'Bodyguard')
     find('.search-button').click
 
-    expect(page).to have_text('Your current job')
+    expect(page).to have_text('Tell us your current job title')
+  end
+
+  scenario 'When user tries adding the first job but finds no results' do
+    visit(check_your_skills_path)
+    fill_in('search', with: 'Some weird title nobody would find')
+    find('.search-button').click
+
+    ['Tell us your current job title', 'We can\'t find any results for this job title.'].each do |text|
+      expect(page).to have_text(text)
+    end
   end
 
   scenario 'When user adds previous job titles the results page should reflect that' do
@@ -55,7 +65,27 @@ RSpec.feature 'Check your skills', type: :feature do
     fill_in('search', with: 'Bodyguard')
     find('.search-button').click
 
-    expect(page).to have_text('Your previous job')
+    expect(page).to have_text('Tell us your previous job title')
+  end
+
+  scenario 'When user tries adding a previous job title but no results are found' do
+    hitman = create(
+      :job_profile,
+      :with_html_content,
+      name: 'Hitman5',
+      skills: [
+        create(:skill)
+      ]
+    )
+    visit(job_profile_skills_path(job_profile_id: hitman.slug))
+    click_on('Select these skills')
+    visit(check_your_skills_path)
+    fill_in('search', with: 'A weird title that doesn not exist')
+    find('.search-button').click
+
+    ['Tell us your previous job title', 'We can\'t find any results for this job title.'].each do |text|
+      expect(page).to have_text(text)
+    end
   end
 
   scenario 'User enters an incorrect word but no api key is available' do
@@ -155,7 +185,7 @@ RSpec.feature 'Check your skills', type: :feature do
     fill_in('search', with: 'Embalmer')
     find('.search-button').click
 
-    expect(page).to have_text('No results found')
+    expect(page).to have_text('We can\'t find any results for this job title.')
   end
 
   scenario 'tracks search string' do
@@ -187,7 +217,7 @@ RSpec.feature 'Check your skills', type: :feature do
     fill_in('search', with: 'Bodyguard')
     find('.search-button').click
 
-    expect(page).to have_text('Your current job')
+    expect(page).to have_text('Tell us your current job title')
   end
 
   scenario 'paginates results of search' do

--- a/spec/features/skills_builder_spec.rb
+++ b/spec/features/skills_builder_spec.rb
@@ -180,9 +180,9 @@ RSpec.feature 'Build your skills', type: :feature do
   scenario 'User can search for other job profiles' do
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     click_on('Select these skills')
-    click_on('Add more skills from another job or volunteer role')
+    click_on('Add another job or volunteer role')
 
-    expect(page).to have_text('Add more skills')
+    expect(page).to have_text('Tell us your previous job title')
   end
 
   scenario 'User can not add a job that is part of Your skills page already' do
@@ -199,7 +199,7 @@ RSpec.feature 'Build your skills', type: :feature do
 
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     click_on('Select these skills')
-    click_on('Add more skills from another job or volunteer role')
+    click_on('Add another job or volunteer role')
     fill_in('search', with: 'Hitman')
     find('.search-button').click
 
@@ -218,7 +218,7 @@ RSpec.feature 'Build your skills', type: :feature do
 
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     click_on('Select these skills')
-    click_on('Add more skills from another job or volunteer role')
+    click_on('Add another job or volunteer role')
     fill_in('search', with: 'Hitman')
     find('.search-button').click
     click_on('Classic-hitman')
@@ -268,7 +268,7 @@ RSpec.feature 'Build your skills', type: :feature do
     )
 
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
-    expect(page).not_to have_link('Add more skills from another job or volunteer role')
+    expect(page).not_to have_link('Add another job or volunteer role')
   end
 
   scenario 'User can not search for job profiles anymore when one has 5 profiles persisted on the session' do


### PR DESCRIPTION
### Context

Targetted pages:

- Current job skills search
- Previous job skills search
- Previous job skills search has changes to h1
and is now consistent in prototype - wasn’t mentioned in description above
- Breadcrumbs can remain the same as they are for now as this can be addressed in Sophie’s ticket

### Ticket

https://dfedigital.atlassian.net/browse/GET-913