### PR TITLE
GET-956 Add tracking event for email link click on sign in 

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -7,6 +7,7 @@ Passwordless::SessionsController.class_eval do
     BCrypt::Password.create(params[:token])
 
     sign_in passwordless_session
+    track_event(:progress, 'return_journey', 'events.return_to_saved_link')
 
     redirect_to main_app.task_list_path
   rescue Passwordless::Errors::TokenAlreadyClaimedError,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,7 +45,7 @@ class UsersController < ApplicationController
     passwordless_session = build_passwordless_session(user)
     user.register_existing_user(passwordless_session, request.base_url)
 
-    track_event(:progress, 'return_journey', 'events.return_to_saved')
+    track_event(:progress, 'return_journey', 'events.return_to_saved_button')
   end
 
   def set_redirect_path_for_registration

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,8 +86,10 @@ en-GB:
     it_training: Computer skills training
     save:
       progress: Saved progress
-    return_to_saved:
-      progress: Returned to progress
+    return_to_saved_button:
+      progress: Returned to progress button
+    return_to_saved_link:
+      progress: Returned to progress link
 
   contact_us:
     title: Free local advice

--- a/spec/features/user_registration_spec.rb
+++ b/spec/features/user_registration_spec.rb
@@ -293,7 +293,7 @@ RSpec.feature 'User registration' do
       [
         {
           key: :progress,
-          label: 'Returned to progress',
+          label: 'Returned to progress button',
           value: 'return_journey'
         }
       ]

--- a/spec/features/user_sign_in_spec.rb
+++ b/spec/features/user_sign_in_spec.rb
@@ -341,7 +341,7 @@ RSpec.feature 'User sign in' do
     expect(page).to have_current_path(return_to_saved_results_path)
   end
 
-  scenario 'User sign in is tracked if successful' do
+  scenario 'User sign in button click is tracked if successful' do
     tracking_service = instance_spy(TrackingService)
     allow(TrackingService).to receive(:new).and_return(tracking_service)
 
@@ -353,14 +353,14 @@ RSpec.feature 'User sign in' do
       [
         {
           key: :progress,
-          label: 'Returned to progress',
+          label: 'Returned to progress button',
           value: 'return_journey'
         }
       ]
     )
   end
 
-  scenario 'Non existing user sign in is not tracked' do
+  scenario 'Non existing user sign in button click is not tracked' do
     tracking_service = instance_spy(TrackingService)
     allow(TrackingService).to receive(:new).and_return(tracking_service)
 
@@ -369,7 +369,7 @@ RSpec.feature 'User sign in' do
     expect(tracking_service).not_to have_received(:track_events)
   end
 
-  scenario 'User sign in is not tracked if invalid' do
+  scenario 'User sign in button click is not tracked if invalid' do
     tracking_service = instance_spy(TrackingService)
     allow(TrackingService).to receive(:new).and_return(tracking_service)
 
@@ -378,5 +378,45 @@ RSpec.feature 'User sign in' do
     click_on('Send link')
 
     expect(tracking_service).not_to have_received(:track_events)
+  end
+
+  scenario 'User sign in email link click is tracked if successful' do
+    tracking_service = instance_spy(TrackingService)
+    allow(TrackingService).to receive(:new).and_return(tracking_service)
+
+    register_user
+    sign_in_user
+
+    expect(tracking_service).to have_received(:track_events).with(
+      props:
+      [
+        {
+          key: :progress,
+          label: 'Returned to progress link',
+          value: 'return_journey'
+        }
+      ]
+    )
+  end
+
+  scenario 'user sign in email expired link click is not tracked' do
+    tracking_service = instance_spy(TrackingService)
+    allow(TrackingService).to receive(:new).and_return(tracking_service)
+
+    register_user
+    sign_in_user
+
+    visit(token_sign_in_path(token: Passwordless::Session.last.token))
+
+    expect(tracking_service).to have_received(:track_events).with(
+      props:
+      [
+        {
+          key: :progress,
+          label: 'Returned to progress link',
+          value: 'return_journey'
+        }
+      ]
+    ).at_most(:once)
   end
 end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-956

* Change label to have button for existing event
* Add event on clicking email link on sign in 