### PR TITLE
Bust pipeline cache, use new cache task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,5 +139,5 @@ group :test do
 
   # Web request caching for tests
   gem 'vcr', '~> 5.0', require: false
-  gem 'webmock', '~> 3.6', require: false
+  gem 'webmock', '~> 3.8', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -434,7 +434,7 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
-    webmock (3.6.0)
+    webmock (3.8.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -505,7 +505,7 @@ DEPENDENCIES
   vcr (~> 5.0)
   web-console (>= 3.3.0)
   webdrivers (~> 4.0)
-  webmock (~> 3.6)
+  webmock (~> 3.8)
   webpacker (~> 4.0)
   wombat (~> 2.8)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ stages:
           echo "##vso[task.prependpath]$(HOME)/.rvm/rubies/ruby-2.6.5/bin"
         displayName: 'Install dependencies'
 
-      - task: CacheBeta@0
+      - task: Cache@2
         inputs:
           key: $(Build.SourcesDirectory)/Gemfile.lock
           path: $(BUNDLE_CACHE_FOLDER)
@@ -72,15 +72,10 @@ stages:
 
       - script: |
           gem install bundler
-          bundle config force_ruby_platform true
+          bundle config --global build.sassc --disable-march-tune-native
+          bundle config --global force_ruby_platform true
           bundle install --jobs=4 --retry=3 --path $(BUNDLE_CACHE_FOLDER) --without development
         displayName: 'bundle install'
-
-      - script: |
-          chmod -R +x $(BUNDLE_CACHE_FOLDER)/ruby/2.6.0/bin
-        condition: eq(variables.CACHE_RESTORED_BUNDLE, 'true')
-        displayName: Restore executable bundle bit
-       # Temporary fix for https://github.com/microsoft/azure-pipelines-tasks/issues/10841
 
       - script: |
           bundle exec rubocop --format clang


### PR DESCRIPTION
* The pipeline cache wasn't being renewed as the key was the gemfile lock.
Bust the cache so now it reads the bundle config
* Use new cache task and remove workaround as its no longer needed
