### PR TITLE
Get 927 tabbed panel

### DIFF
--- a/app/views/job_profiles/_no_results.html.erb
+++ b/app/views/job_profiles/_no_results.html.erb
@@ -1,4 +1,3 @@
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-7"><%= t('title', scope: scope) %></h1>
 <p class="govuk-body-l"><%= t('body', scope: scope) %></p>
 <%= render "shared/search/results_form", search_path: { action: :results }, scope: scope %>
 <p class="govuk-body">0 results found</p>
@@ -6,7 +5,7 @@
 <p class="govuk-body">You could try:</p>
 <ul class="govuk-list govuk-list--bullet">
   <li>checking your spelling</li>
-  <li>using a different name for this type of work</li>
+  <li>using a different name for this type of work – for example, checkout operator instead of cashier</li>
   <li>searching for a different type of work</li>
   <li>going back and looking at your job matches instead</li>
 </ul>

--- a/app/views/job_profiles/_search_form.html.erb
+++ b/app/views/job_profiles/_search_form.html.erb
@@ -1,8 +1,7 @@
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-7"><%= t(:title, scope: 'job_profiles.index') %></h1>
-<p class="govuk-body-l"><%= t(:body, scope: 'job_profiles.index') %></p>
+<p class="govuk-body"><%= t(:body, scope: 'job_profiles.index') %></p>
 <%= render "shared/search/results_form", search_path: results_job_profiles_path, scope: 'job_profiles.index' %>
-<p class="govuk-body">Select the job title that best matches what you're looking for.</p>
-<p class="govuk-body">If you can't see the job title you're looking for, try searching with different words - for example, checkout operator instead of cashier.</p>
 <p class="govuk-body">
   <%= "#{pluralize(@results.total_count, 'result', locale: I18n.locale.to_s)} found" %>
 </p>
+<p class="govuk-body">If you can’t see the job title you want, try searching with different words. For example, search for checkout operator instead of cashier.</p>
+<p class="govuk-body">Select a job title to build an action plan that will help you change jobs.</p>

--- a/app/views/job_profiles/index.html.erb
+++ b/app/views/job_profiles/index.html.erb
@@ -19,7 +19,7 @@
           <%= link_to('Your matches', params[:search].present? ? skills_matcher_index_path(search: params[:search]) : skills_matcher_index_path, class: 'govuk-link') %>
         </li>
         <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-          <%= link_to('Search by job title', '#job-profiles-search', class: 'govuk-tabs__tab') %>
+          <%= link_to('Search by job title', '#job-profiles-search', class: 'govuk-tabs__tab govuk-tabs__tab-mobile') %>
         </li>
       </ul>
       <section class="govuk-tabs__panel" id="job-profiles-search">

--- a/app/views/job_profiles/index.html.erb
+++ b/app/views/job_profiles/index.html.erb
@@ -11,8 +11,28 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds" >
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-8"><%= t('.title') %></h1>
     <%= error_summary(@job_profile_search) %>
-    <%= render "shared/search/form", search_path: job_profiles_path, scope: 'job_profiles.index' %>
+    <div class="govuk-tabs" data-module="govuk-tabs">
+      <ul class="govuk-tabs__list">
+        <li class="govuk-tabs__list-item">
+          <%= link_to('Your matches', params[:search].present? ? skills_matcher_index_path(search: params[:search]) : skills_matcher_index_path, class: 'govuk-link') %>
+        </li>
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+          <%= link_to('Search by job title', '#job-profiles-search', class: 'govuk-tabs__tab') %>
+        </li>
+      </ul>
+      <section class="govuk-tabs__panel" id="job-profiles-search">
+        <p class="govuk-body"><%= t('.body') %></p>
+        <%= form_tag job_profiles_path, method: 'get' do %>
+          <%= form_group_tag @job_profile_search, :term do %>
+            <%= errors_tag @job_profile_search, :term %>
+            <%= text_field(nil, :search, class: 'govuk-input search-input govuk-!-width-one-half', placeholder: t('.placeholder'), aria: { label: 'Search' }, data: { cy: 'search-field'}) %>
+            <%= button_tag('Search', class: 'govuk-button search-button', name: nil, aria: { label: 'Search button' }, data: { cy: 'search-field-submit-btn', module: 'govuk-button' }) %>
+          <% end %>
+        <% end %>
+      </section>
+    </div>
   </div>
   <div class="govuk-grid-column-one-third">
     <%= render "shared/contact_us" %>

--- a/app/views/job_profiles/results.html.erb
+++ b/app/views/job_profiles/results.html.erb
@@ -11,18 +11,31 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds" >
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-8"><%= t(:title, scope: 'job_profiles.index') %></h1>
     <%= error_summary(@job_profile_search) %>
-    <% if @job_profiles.blank? %>
-      <%= render 'no_results', scope: 'job_profiles.index' %>
-    <% else %>
-      <%= render "search_form" %>
-      <ul class="govuk-list">
-        <%= render @job_profiles %>
+    <div class="govuk-tabs" data-module="govuk-tabs">
+      <ul class="govuk-tabs__list">
+        <li class="govuk-tabs__list-item">
+          <%= link_to('Your matches', params[:search].present? ? skills_matcher_index_path(search: params[:search]) : skills_matcher_index_path, class: 'govuk-link') %>
+        </li>
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+          <%= link_to('Search by job title', '#job-profiles-search', class: 'govuk-tabs__tab') %>
+        </li>
       </ul>
-      <div class="govuk-grid-column-full govuk-!-padding-top-6 govuk-!-margin-bottom-4 govuk-!-margin-top-6 pagination__section">
-        <%= paginate @results %>
-      </div>
-    <% end %>
+      <section class="govuk-tabs__panel" id="job-profiles-search">
+        <% if @job_profiles.blank? %>
+          <%= render 'no_results', scope: 'job_profiles.index' %>
+        <% else %>
+          <%= render "search_form" %>
+          <ul class="govuk-list">
+            <%= render @job_profiles %>
+          </ul>
+          <div class="<%= @results.size  > 1 ? 'govuk-!-padding-top-6 govuk-!-margin-top-6 pagination__section govuk-!-margin-bottom-4' : '' %>">
+            <%= paginate @results %>
+          </div>
+        <% end %>
+      </section>
+    </div>
   </div>
   <div class="govuk-grid-column-one-third">
     <%= render "shared/contact_us" %>

--- a/app/views/job_profiles/results.html.erb
+++ b/app/views/job_profiles/results.html.erb
@@ -19,7 +19,7 @@
           <%= link_to('Your matches', params[:search].present? ? skills_matcher_index_path(search: params[:search]) : skills_matcher_index_path, class: 'govuk-link') %>
         </li>
         <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-          <%= link_to('Search by job title', '#job-profiles-search', class: 'govuk-tabs__tab') %>
+          <%= link_to('Search by job title', '#job-profiles-search', class: 'govuk-tabs__tab govuk-tabs__tab-mobile') %>
         </li>
       </ul>
       <section class="govuk-tabs__panel" id="job-profiles-search">

--- a/app/views/skills_matcher/_sort_form.html.erb
+++ b/app/views/skills_matcher/_sort_form.html.erb
@@ -2,5 +2,6 @@
   <%= form_tag nil, method: :get, local: true do |f| %>
     <%= label_tag :sort, 'Sort by', for: 'sort-select', class: 'govuk-label' %>
     <%= select_tag :sort, @options, class: 'govuk-select', id: 'sort-select' %>
+    <%= hidden_field_tag :search, params[:search] if params[:search].present? %>
   <% end %>
 </div>

--- a/app/views/skills_matcher/index.html.erb
+++ b/app/views/skills_matcher/index.html.erb
@@ -15,7 +15,7 @@
     <div class="govuk-tabs" data-module="govuk-tabs">
       <ul class="govuk-tabs__list">
         <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-          <%= link_to('Your matches', '#your-matches', class: 'govuk-tabs__tab') %>
+          <%= link_to('Your matches', '#your-matches', class: 'govuk-tabs__tab govuk-tabs__tab-mobile') %>
         </li>
         <li class="govuk-tabs__list-item">
           <%= link_to('Search by job title', params[:search].present? ? job_profiles_path(search: params[:search]) : job_profiles_path, class: 'govuk-link') %>

--- a/app/views/skills_matcher/index.html.erb
+++ b/app/views/skills_matcher/index.html.erb
@@ -29,7 +29,7 @@
           <ul class="govuk-list">
             <%= render @job_profiles %>
           </ul>
-          <div class="govuk-!-padding-top-6 govuk-!-margin-bottom-4 govuk-!-margin-top-6 pagination__section">
+          <div class="<%= @results.size  > 1 ? 'govuk-!-padding-top-6 govuk-!-margin-top-6 pagination__section govuk-!-margin-bottom-4' : '' %>">
             <%= paginate @results %>
           </div>
         <% else %>

--- a/app/views/skills_matcher/index.html.erb
+++ b/app/views/skills_matcher/index.html.erb
@@ -43,6 +43,3 @@
     <%= render 'shared/save_or_return_to_your_results' %>
   </div>
 </div>
-
-
-

--- a/app/views/skills_matcher/index.html.erb
+++ b/app/views/skills_matcher/index.html.erb
@@ -12,25 +12,37 @@
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
-    <p class="govuk-body">You may already have many of the skills for these types of work. Select a job title to find out if you need to do more training.</p>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-    <p class="govuk-body govuk-!-margin-bottom-1">If you have a particular job in mind, find out how well your skills match to it.</p>
-    <p class="govuk-body"><%= link_to 'Search for a job title', job_profiles_path, class: 'govuk-link' %></p>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-    <% if @results.present? %>
-      <%= render 'sort_form' %>
-      <ul class="govuk-list">
-        <%= render @job_profiles %>
+    <div class="govuk-tabs" data-module="govuk-tabs">
+      <ul class="govuk-tabs__list">
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+          <%= link_to('Your matches', '#your-matches', class: 'govuk-tabs__tab') %>
+        </li>
+        <li class="govuk-tabs__list-item">
+          <%= link_to('Search by job title', params[:search].present? ? job_profiles_path(search: params[:search]) : job_profiles_path, class: 'govuk-link') %>
+        </li>
       </ul>
-      <div class="govuk-grid-column-full govuk-!-padding-top-6 govuk-!-margin-bottom-4 govuk-!-margin-top-6 pagination__section">
-        <%= paginate @results %>
-      </div>
-    <% else %>
-      <%= render 'no_results' %>
-    <% end %>
+      <section class="govuk-tabs__panel" id="your-matches">
+        <p class="govuk-body">Here are some types of work you could do using many of your current skills. Select a job title to build an action plan that will help you change jobs.</p>
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        <% if @results.present? %>
+          <%= render 'sort_form' %>
+          <ul class="govuk-list">
+            <%= render @job_profiles %>
+          </ul>
+          <div class="govuk-!-padding-top-6 govuk-!-margin-bottom-4 govuk-!-margin-top-6 pagination__section">
+            <%= paginate @results %>
+          </div>
+        <% else %>
+          <%= render 'no_results' %>
+        <% end %>
+      </section>
+    </div>
   </div>
   <div class="govuk-grid-column-one-third">
     <%= render "shared/contact_us" %>
     <%= render 'shared/save_or_return_to_your_results' %>
   </div>
 </div>
+
+
+

--- a/app/views/skills_matcher/index.html.erb
+++ b/app/views/skills_matcher/index.html.erb
@@ -15,7 +15,7 @@
     <div class="govuk-tabs" data-module="govuk-tabs">
       <ul class="govuk-tabs__list">
         <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-          <%= link_to('Your matches', '#your-matches', class: 'govuk-tabs__tab govuk-tabs__tab-mobile') %>
+          <%= link_to('Your matches', '#your-matches', class: 'govuk-tabs__tab') %>
         </li>
         <li class="govuk-tabs__list-item">
           <%= link_to('Search by job title', params[:search].present? ? job_profiles_path(search: params[:search]) : job_profiles_path, class: 'govuk-link') %>

--- a/app/webpacker/styles/_course.scss
+++ b/app/webpacker/styles/_course.scss
@@ -8,3 +8,9 @@
     margin-bottom: 40px;
   }
 }
+
+.govuk-tabs__tab-mobile {
+  @include govuk-media-query($until: tablet) {
+    margin-top: govuk-spacing(2);
+  }
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,9 +11,9 @@ en-GB:
     task_list: Get help to retrain
     task_list_home: 'Home: Get help to retrain'
     check_your_skills: Check your existing skills
-    job_matches: Your job matches
+    job_matches: Your work matches
     search_results: Search results
-    job_profiles_search: Search for a type of work
+    job_profiles_search: Your work matches
     job_profile: Job profile details
     your_skills: Your skills
     training_courses_near_you: Find and apply to training courses near you
@@ -125,8 +125,8 @@ en-GB:
       no_results: 0 results found - try again using a different job title
   job_profiles:
     index:
-      title: Search for a type of work you're interested in
-      body: Enter a job title to find out how well your skills match to it.
+      title: Types of work that match your skills
+      body: Enter any job title to find out how well your skills match to it.
       placeholder: Enter a job title
     vacancies:
       one: is

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -185,7 +185,7 @@ RSpec.feature 'Skills matcher', type: :feature do
     visit_skills_for_current_job_profile
 
     visit skills_matcher_index_path
-    click_on('Search for a job title')
+    click_on('Search by job title')
 
     fill_in('search', with: 'Escapologist')
     find('.search-button').click
@@ -199,7 +199,7 @@ RSpec.feature 'Skills matcher', type: :feature do
     create(:job_profile, :with_html_content, :growing, name: 'Florist')
 
     visit skills_matcher_index_path
-    click_on('Search for a job title')
+    click_on('Search by job title')
 
     fill_in('search', with: 'florist')
     find('.search-button').click
@@ -247,13 +247,31 @@ RSpec.feature 'Skills matcher', type: :feature do
     )
   end
 
+  scenario 'The search query string param is passed along to your matches page if present' do
+    visit_skills_for_current_job_profile
+    visit(results_job_profiles_path(search: 'therapy'))
+
+    click_on('Your matches')
+
+    expect(page).to have_current_path(skills_matcher_index_path(search: 'therapy'))
+  end
+
+  scenario 'The search query string param is not passed along to your matches page if absent' do
+    visit_skills_for_current_job_profile
+    visit(job_profiles_path)
+
+    click_on('Your matches')
+
+    expect(page).to have_current_path(skills_matcher_index_path)
+  end
+
   scenario 'search for specific job title shows skills match' do
     visit_skills_for_current_job_profile
 
     create(:job_profile, :with_html_content, name: 'Florist', skills: [skill3])
 
     visit skills_matcher_index_path
-    click_on('Search for a job title')
+    click_on('Search by job title')
 
     fill_in('search', with: 'florist')
     find('.search-button').click
@@ -269,7 +287,7 @@ RSpec.feature 'Skills matcher', type: :feature do
     create(:job_profile, :with_html_content, name: 'Florist')
 
     visit skills_matcher_index_path
-    click_on('Search for a job title')
+    click_on('Search by job title')
 
     fill_in('search', with: 'florist')
     find('.search-button').click
@@ -285,7 +303,7 @@ RSpec.feature 'Skills matcher', type: :feature do
     create(:job_profile, :with_html_content, name: 'Fluffer', slug: 'fluffer')
 
     visit skills_matcher_index_path
-    click_on('Search for a job title')
+    click_on('Search by job title')
 
     fill_in('search', with: 'fluffer')
     find('.search-button').click
@@ -294,13 +312,37 @@ RSpec.feature 'Skills matcher', type: :feature do
     expect(page).to have_current_path(job_profile_path('fluffer'))
   end
 
+  scenario 'search query string param is passed to job profiles search page if present' do
+    visit_skills_for_current_job_profile
+
+    create(:job_profile, :with_html_content, name: 'Fluffer', slug: 'fluffer')
+
+    visit skills_matcher_index_path(search: 'therapy')
+
+    click_on('Search by job title')
+
+    expect(page).to have_current_path(results_job_profiles_path(search: 'therapy'))
+  end
+
+  scenario 'no search query string param is passed to job profiles search page if missing' do
+    visit_skills_for_current_job_profile
+
+    create(:job_profile, :with_html_content, name: 'Fluffer', slug: 'fluffer')
+
+    visit skills_matcher_index_path
+
+    click_on('Search by job title')
+
+    expect(page).to have_current_path(job_profiles_path)
+  end
+
   scenario 'tracks search string in job profile search' do
     tracking_service = instance_spy(TrackingService)
     allow(TrackingService).to receive(:new).and_return(tracking_service)
     visit_skills_for_current_job_profile
 
     visit(skills_matcher_index_path)
-    click_on('Search for a job title')
+    click_on('Search by job title')
 
     fill_in('search', with: 'fluffer')
     find('.search-button').click

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -164,7 +164,7 @@ RSpec.feature 'Skills matcher', type: :feature do
 
     find("option[value='growth']").click
 
-    expect(page).to have_current_path(skills_matcher_index_path(sort: 'growth', search: 'therapy'))
+    expect(page).to have_current_path('/job-matches?sort=growth&search=therapy')
   end
 
   scenario 'does not pass along the search query string when sorting if absent', :js do

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -335,8 +335,6 @@ RSpec.feature 'Skills matcher', type: :feature do
   scenario 'search query string param is passed to job profiles search page if present' do
     visit_skills_for_current_job_profile
 
-    create(:job_profile, :with_html_content, name: 'Fluffer', slug: 'fluffer')
-
     visit skills_matcher_index_path(search: 'therapy')
 
     click_on('Search by job title')
@@ -346,8 +344,6 @@ RSpec.feature 'Skills matcher', type: :feature do
 
   scenario 'no search query string param is passed to job profiles search page if missing' do
     visit_skills_for_current_job_profile
-
-    create(:job_profile, :with_html_content, name: 'Fluffer', slug: 'fluffer')
 
     visit skills_matcher_index_path
 

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -157,6 +157,26 @@ RSpec.feature 'Skills matcher', type: :feature do
     expect(page).to have_select('sort-select', selected: 'Recent job growth')
   end
 
+  scenario 'passes along the search query string when sorting if present', :js do
+    visit_skills_for_current_job_profile(true)
+
+    visit skills_matcher_index_path(search: 'therapy')
+
+    find("option[value='growth']").click
+
+    expect(page).to have_current_path(skills_matcher_index_path(sort: 'growth', search: 'therapy'))
+  end
+
+  scenario 'does not pass along the search query string when sorting if absent', :js do
+    visit_skills_for_current_job_profile(true)
+
+    visit skills_matcher_index_path
+
+    find("option[value='growth']").click
+
+    expect(page).to have_current_path(skills_matcher_index_path(sort: 'growth'))
+  end
+
   scenario 'paginates results of search' do
     create_list(:job_profile, 12, name: 'Hacker', skills: [skill1])
     visit_skills_for_current_job_profile


### PR DESCRIPTION
### Context

Add tabs to skills matcher page

Also, add tabs to job profiles search page. The way
the original GDS component works needs a bit of tweaking
as follows:

The inactive tab has the link to the destination page and
not an anchor link as the component would expect. To achieve
that the inactive tab must not have the govuk-tabs__tab class,
otherwise, it will error as it's expecting something like:
'#element-id' which would not work well in our case.

### Screenshots

![Screen Shot 2020-03-01 at 17 09 08](https://user-images.githubusercontent.com/1955084/75653856-499a1900-5c56-11ea-9a03-1244ee5d6d9d.png)
![Screen Shot 2020-03-01 at 17 09 15](https://user-images.githubusercontent.com/1955084/75653858-4a32af80-5c56-11ea-81b0-be94ea3d9138.png)
![Screen Shot 2020-03-01 at 17 09 23](https://user-images.githubusercontent.com/1955084/75653860-4acb4600-5c56-11ea-9bf3-9a6ad85a133e.png)
![Screen Shot 2020-03-01 at 17 09 30](https://user-images.githubusercontent.com/1955084/75653863-4acb4600-5c56-11ea-9dfd-937404cfc277.png)


### Ticket

https://dfedigital.atlassian.net/browse/GET-927

