### PR TITLE
Get 523 enable bing

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,6 +37,9 @@
     "BING_SPELL_CHECK_API_KEY": {
       "required": false
     },
+    "BING_SPELL_CHECK_API_ENDPOINT": {
+      "required": false
+    },
     "AZURE_CLIENT_ID": {
       "required": true
     },

--- a/app/services/spell_check_service.rb
+++ b/app/services/spell_check_service.rb
@@ -1,8 +1,6 @@
 class SpellCheckService
   SpellCheckServiceError = Class.new(StandardError)
 
-  API_ENDPOINT = 'https://api.cognitive.microsoft.com/bing/v7.0/spellcheck'.freeze
-
   attr_reader :response, :api_key
 
   def initialize(api_key: Rails.configuration.bing_spell_check_api_key)
@@ -51,7 +49,7 @@ class SpellCheckService
   end
 
   def uri
-    @uri ||= URI.parse(API_ENDPOINT)
+    @uri ||= URI.parse(Rails.configuration.bing_spell_check_api_endpoint)
   end
 
   def request

--- a/app/services/spell_check_service.rb
+++ b/app/services/spell_check_service.rb
@@ -1,14 +1,18 @@
 class SpellCheckService
   SpellCheckServiceError = Class.new(StandardError)
 
-  attr_reader :response, :api_key
+  attr_reader :response, :api_key, :api_endpoint
 
-  def initialize(api_key: Rails.configuration.bing_spell_check_api_key)
+  def initialize(
+    api_key: Rails.configuration.bing_spell_check_api_key,
+    api_endpoint: Rails.configuration.bing_spell_check_api_endpoint
+  )
     @api_key = api_key
+    @api_endpoint = api_endpoint
   end
 
   def scan(search_term: nil)
-    return unless api_key.present? && search_term
+    return unless api_key.present? && api_endpoint.present? && search_term
 
     bing_spell_check(search_term: search_term)
   rescue StandardError => e
@@ -49,7 +53,7 @@ class SpellCheckService
   end
 
   def uri
-    @uri ||= URI.parse(Rails.configuration.bing_spell_check_api_endpoint)
+    @uri ||= URI.parse(api_endpoint)
   end
 
   def request

--- a/azure/config/dev1.parameters.json
+++ b/azure/config/dev1.parameters.json
@@ -75,6 +75,22 @@
         "secretName": "dev-notifyApiKey"
       }
     },
+    "bingSpellCheckApiKey": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "dev-bingSpellCheckApiKey"
+      }
+    },
+    "bingSpellCheckApiEndpoint": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "dev-bingSpellCheckApiEndpoint"
+      }
+    },
     "findAJobApiId": {
       "reference": {
         "keyVault": {

--- a/azure/config/dev2.parameters.json
+++ b/azure/config/dev2.parameters.json
@@ -75,6 +75,22 @@
         "secretName": "dev-notifyApiKey"
       }
     },
+    "bingSpellCheckApiKey": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "dev-bingSpellCheckApiKey"
+      }
+    },
+    "bingSpellCheckApiEndpoint": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "dev-bingSpellCheckApiEndpoint"
+      }
+    },
     "azureClientId": {
       "reference": {
         "keyVault": {

--- a/azure/config/prod.parameters.json
+++ b/azure/config/prod.parameters.json
@@ -99,6 +99,22 @@
         "secretName": "prod-notifyApiKey"
       }
     },
+    "bingSpellCheckApiKey": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/eaff0b89-17c5-4a97-9a00-f77551fe2c27/resourceGroups/s108p01-shared/providers/Microsoft.KeyVault/vaults/s108p01-shared-kv-01"
+        },
+        "secretName": "prod-bingSpellCheckApiKey"
+      }
+    },
+    "bingSpellCheckApiEndpoint": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/eaff0b89-17c5-4a97-9a00-f77551fe2c27/resourceGroups/s108p01-shared/providers/Microsoft.KeyVault/vaults/s108p01-shared-kv-01"
+        },
+        "secretName": "prod-bingSpellCheckApiEndpoint"
+      }
+    },
     "findAJobApiId": {
       "reference": {
         "keyVault": {

--- a/azure/config/qa.parameters.json
+++ b/azure/config/qa.parameters.json
@@ -87,6 +87,22 @@
         "secretName": "qa-notifyApiKey"
       }
     },
+    "bingSpellCheckApiKey": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
+        },
+        "secretName": "qa-bingSpellCheckApiKey"
+      }
+    },
+    "bingSpellCheckApiEndpoint": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
+        },
+        "secretName": "qa-bingSpellCheckApiEndpoint"
+      }
+    },
     "findAJobApiId": {
       "reference": {
         "keyVault": {

--- a/azure/config/uat.parameters.json
+++ b/azure/config/uat.parameters.json
@@ -99,6 +99,22 @@
         "secretName": "uat-notifyApiKey"
       }
     },
+    "bingSpellCheckApiKey": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
+        },
+        "secretName": "uat-bingSpellCheckApiKey"
+      }
+    },
+    "bingSpellCheckApiEndpoint": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/8587596c-6d6d-4a81-a326-dbf70212fe97/resourceGroups/s108t01-shared/providers/Microsoft.KeyVault/vaults/s108t01-shared-kv-01"
+        },
+        "secretName": "uat-bingSpellCheckApiEndpoint"
+      }
+    },
     "findAJobApiId": {
       "reference": {
         "keyVault": {

--- a/azure/config/ut.parameters.json
+++ b/azure/config/ut.parameters.json
@@ -72,6 +72,22 @@
         "secretName": "ut-notifyApiKey"
       }
     },
+    "bingSpellCheckApiKey": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "ut-bingSpellCheckApiKey"
+      }
+    },
+    "bingSpellCheckApiEndpoint": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/f35bd249-3028-48bd-9aab-d00e9d1a56b7/resourceGroups/s108d01-shared/providers/Microsoft.KeyVault/vaults/s108d01-shared-kv-01"
+        },
+        "secretName": "ut-bingSpellCheckApiEndpoint"
+      }
+    },
     "findAJobApiId": {
       "reference": {
         "keyVault": {

--- a/azure/template.json
+++ b/azure/template.json
@@ -681,6 +681,10 @@
               {
                 "name": "BING_SPELL_CHECK_API_KEY",
                 "value": "[parameters('bingSpellCheckApiKey')]"
+              },
+              {
+                "name": "BING_SPELL_CHECK_API_ENDPOINT",
+                "value": "[parameters('bingSpellCheckApiEndpoint')]"
               }
             ]
           },

--- a/azure/template.json
+++ b/azure/template.json
@@ -179,6 +179,13 @@
         "description:": "Bing Spell Check Service - API KEY"
       }
     },
+    "bingSpellCheckApiEndpoint": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description:": "Bing Spell Check Service - API ENDPOINT"
+      }
+    },
     "azureClientId": {
       "type": "string",
       "defaultValue": "",

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,7 @@ module GetHelpToRetrain
     config.environment_name = ENV['ENVIRONMENT_NAME'] || 'development'
     config.host_name = Socket.gethostname
     config.bing_spell_check_api_key = ENV['BING_SPELL_CHECK_API_KEY']
+    config.bing_spell_check_api_endpoint = ENV['BING_SPELL_CHECK_API_ENDPOINT']
     config.azure_client_id = ENV['AZURE_CLIENT_ID']
     config.azure_client_secret = ENV['AZURE_CLIENT_SECRET']
     config.azure_scopes = ENV['AZURE_SCOPES']

--- a/spec/services/spell_check_service_spec.rb
+++ b/spec/services/spell_check_service_spec.rb
@@ -20,9 +20,13 @@ RSpec.describe SpellCheckService do
   let(:search_term) { 'hallo wrld' }
   let(:status) { 200 }
 
+  before do
+    allow(Rails.configuration).to receive(:bing_spell_check_api_endpoint).and_return('https://s111-bingspellcheck.cognitiveservices.azure.com/bing/v7.0/spellcheck')
+  end
+
   describe '.call' do
     before do
-      stub_request(:get, SpellCheckService::API_ENDPOINT)
+      stub_request(:get, Rails.configuration.bing_spell_check_api_endpoint)
         .with(headers: request_headers,
               query: URI.encode_www_form(mkt: 'en-gb', mode: 'spell', text: search_term))
         .to_return(body: response_body, status: status)
@@ -309,6 +313,16 @@ RSpec.describe SpellCheckService do
     subject(:service) { described_class.new(api_key: nil) }
 
     it 'returns nil' do
+      expect(service.scan(search_term: search_term)).to be nil
+    end
+  end
+
+  context 'when the API endpoint is missing' do
+    subject(:service) { described_class.new(api_key: nil) }
+
+    it 'returns nil' do
+      allow(Rails.configuration).to receive(:bing_spell_check_api_endpoint).and_return(nil)
+
       expect(service.scan(search_term: search_term)).to be nil
     end
   end

--- a/spec/services/spell_check_service_spec.rb
+++ b/spec/services/spell_check_service_spec.rb
@@ -1,7 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe SpellCheckService do
-  subject(:service) { described_class.new(api_key: 'test') }
+  subject(:service) {
+    described_class.new(
+      api_key: 'test',
+      api_endpoint: api_endpoint
+    )
+  }
+
+  let(:api_endpoint) {
+    'https://s111-bingspellcheck.cognitiveservices.azure.com/bing/v7.0/spellcheck'
+  }
 
   let(:request_headers) {
     {
@@ -20,13 +29,9 @@ RSpec.describe SpellCheckService do
   let(:search_term) { 'hallo wrld' }
   let(:status) { 200 }
 
-  before do
-    allow(Rails.configuration).to receive(:bing_spell_check_api_endpoint).and_return('https://s111-bingspellcheck.cognitiveservices.azure.com/bing/v7.0/spellcheck')
-  end
-
   describe '.call' do
     before do
-      stub_request(:get, Rails.configuration.bing_spell_check_api_endpoint)
+      stub_request(:get, api_endpoint)
         .with(headers: request_headers,
               query: URI.encode_www_form(mkt: 'en-gb', mode: 'spell', text: search_term))
         .to_return(body: response_body, status: status)
@@ -310,7 +315,7 @@ RSpec.describe SpellCheckService do
   end
 
   context 'when the API key is missing' do
-    subject(:service) { described_class.new(api_key: nil) }
+    subject(:service) { described_class.new(api_key: nil, api_endpoint: 'http://validpoint.com') }
 
     it 'returns nil' do
       expect(service.scan(search_term: search_term)).to be nil

--- a/spec/services/spell_check_service_spec.rb
+++ b/spec/services/spell_check_service_spec.rb
@@ -318,11 +318,9 @@ RSpec.describe SpellCheckService do
   end
 
   context 'when the API endpoint is missing' do
-    subject(:service) { described_class.new(api_key: nil) }
+    subject(:service) { described_class.new(api_key: 'test', api_endpoint: nil) }
 
     it 'returns nil' do
-      allow(Rails.configuration).to receive(:bing_spell_check_api_endpoint).and_return(nil)
-
       expect(service.scan(search_term: search_term)).to be nil
     end
   end


### PR DESCRIPTION
### Context

Re-enable Bing Spell Check service.

Also add a new key for bing spell check api endpoint,
as with cognitive services enabled on all our
subscriptions the API also changes per subscription.

### Screenshots

![Screen Shot 2020-03-02 at 07 34 11](https://user-images.githubusercontent.com/1955084/75654682-2d977700-5c58-11ea-850d-3c28cff21be8.png)

### Ticket

https://dfedigital.atlassian.net/browse/GET-523