### PR TITLE
Implement CourseDetails API endpoint

### DIFF
--- a/app/services/find_a_course_service.rb
+++ b/app/services/find_a_course_service.rb
@@ -1,11 +1,12 @@
 class FindACourseService
   APIError = Class.new(StandardError)
+  ResponseError = Class.new(StandardError)
 
   attr_reader :api_key, :api_base_url
 
   def initialize(
     api_key: Rails.configuration.find_a_course_api_key,
-    api_base_url: Rails.configuration.find_a_course_base_url
+    api_base_url: Rails.configuration.find_a_course_api_base_url
   )
     @api_key = api_key
     @api_base_url = api_base_url
@@ -15,7 +16,50 @@ class FindACourseService
     # Search course endpoint
   end
 
-  def details
-    # Search for the course details
+  def details(course_id:, course_run_id:)
+    return {} unless [api_key, api_base_url, course_id, course_run_id].all?(&:present?)
+
+    find_course_details_for(course_id: course_id, course_run_id: course_run_id)
+  end
+
+  private
+
+  def build_uri(path:)
+    URI.join(api_base_url, path)
+  end
+
+  def headers(content_type:)
+    {
+      'Content-Type' => content_type,
+      'Ocp-Apim-Subscription-Key' => api_key
+    }
+  end
+
+  def response_body(uri, request)
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 5) do |http|
+      response = http.request(request)
+
+      raise ResponseError, "#{response.code} - #{response.message}" unless response.is_a?(Net::HTTPSuccess)
+
+      response.body
+    end
+  rescue StandardError => e
+    Rails.logger.error("Find a Course Service API error: #{e.inspect}")
+    raise APIError, e
+  end
+
+  def find_course_details_for(course_id:, course_run_id:)
+    uri = build_uri(path: 'courserundetail')
+
+    uri.query = URI.encode_www_form('CourseId' => course_id, 'CourseRunId' => course_run_id)
+
+    request = Net::HTTP::Get.new(
+      uri.request_uri,
+      headers(
+        content_type: 'application/x-www-form-urlencoded'
+      )
+    )
+
+    JSON.parse(response_body(uri, request))
   end
 end

--- a/spec/services/find_a_course_service_spec.rb
+++ b/spec/services/find_a_course_service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe FindACourseService do
   let(:service) {
     described_class.new(
       api_key: 'test',
-      api_base_url: 'https://valid-url.com'
+      api_base_url: 'https://pp.api.nationalcareers.service.gov.uk/coursedirectory/findacourse/'
     )
   }
 
@@ -13,6 +13,162 @@ RSpec.describe FindACourseService do
   end
 
   describe '#details' do
-    xit 'Must do something'
+    let(:api_endpoint) {
+      'https://pp.api.nationalcareers.service.gov.uk/coursedirectory/findacourse/courserundetail'
+    }
+
+    let(:request_headers) {
+      {
+        'Content-Type' => 'application/x-www-form-urlencoded',
+        'Ocp-Apim-Subscription-Key' => 'test'
+      }
+    }
+
+    let(:response_body) {
+      {
+        provider: {
+          providerName: 'OUTSOURCE VOCATIONAL LEARNING LIMITED'
+        },
+        course: {
+          advancedLearnerLoan: true,
+          awardOrgCode: 'EDEXCEL'
+        }
+      }.with_indifferent_access
+    }
+
+    context 'when the api key is missing' do
+      let(:service) {
+        described_class.new(
+          api_key: nil,
+          api_base_url: 'https://valid-url.com'
+        )
+      }
+
+      it 'returns {}' do
+        expect(service.details(course_id: '111-1', course_run_id: '222-2')).to be_empty
+      end
+    end
+
+    context 'when the api base url is missing' do
+      let(:service) {
+        described_class.new(
+          api_key: 'test',
+          api_base_url: nil
+        )
+      }
+
+      it 'returns {}' do
+        expect(service.details(course_id: '111-1', course_run_id: '222-2')).to be_empty
+      end
+    end
+
+    context 'when the course_id is missing' do
+      let(:service) {
+        described_class.new(
+          api_key: 'test',
+          api_base_url: 'some-valid-url'
+        )
+      }
+
+      it 'returns {}' do
+        expect(
+          service.details(course_id: nil, course_run_id: '222-2')
+        ).to be_empty
+      end
+    end
+
+    context 'when the course_run_id is missing' do
+      let(:service) {
+        described_class.new(
+          api_key: 'test',
+          api_base_url: 'test'
+        )
+      }
+
+      it 'returns {}' do
+        expect(
+          service.details(course_id: '111-11', course_run_id: nil)
+        ).to be_empty
+      end
+    end
+
+    context 'when valid arguments are passed it' do
+      before do
+        stub_request(:get, api_endpoint)
+          .with(headers: request_headers,
+                query: URI.encode_www_form(CourseId: '111-11', CourseRunId: '222-2'))
+          .to_return(body: response_body.to_json, status: 200)
+      end
+
+      it 'returns the course details' do
+        expect(
+          service.details(course_id: '111-11', course_run_id: '222-2')
+        ).to eq(response_body)
+      end
+    end
+
+    context 'when the api key is wrong' do
+      let(:service) {
+        described_class.new(
+          api_key: 'wrong-key',
+          api_base_url: 'https://pp.api.nationalcareers.service.gov.uk/coursedirectory/findacourse/'
+        )
+      }
+
+      let(:request_headers) {
+        {
+          'Content-Type' => 'application/x-www-form-urlencoded',
+          'Ocp-Apim-Subscription-Key' => 'wrong-key'
+        }
+      }
+
+      it 'raises the error' do
+        stub_request(:get, api_endpoint)
+          .with(headers: request_headers,
+                query: URI.encode_www_form(CourseId: '111-11', CourseRunId: '222-2'))
+          .to_return(status: 401)
+
+        expect {
+          service.details(course_id: '111-11', course_run_id: '222-2')
+        }.to raise_exception(described_class::APIError)
+      end
+    end
+
+    context 'when there is an NCS service internal error' do
+      it 'raises the error' do
+        stub_request(:get, api_endpoint)
+          .with(headers: request_headers,
+                query: URI.encode_www_form(CourseId: '111-11', CourseRunId: '222-2'))
+          .to_return(status: 500)
+
+        expect {
+          service.details(course_id: '111-11', course_run_id: '222-2')
+        }.to raise_exception(described_class::APIError)
+      end
+    end
+
+    context 'when forbidden from accessing a resource' do
+      it 'raises the error' do
+        stub_request(:get, api_endpoint)
+          .with(headers: request_headers,
+                query: URI.encode_www_form(CourseId: '111-11', CourseRunId: '222-2'))
+          .to_return(status: 403)
+
+        expect {
+          service.details(course_id: '111-11', course_run_id: '222-2')
+        }.to raise_exception(described_class::APIError)
+      end
+    end
+
+    context 'when there is a NET::HTTP error' do
+      it 'raises the error' do
+        stub_request(:get, api_endpoint)
+          .to_raise(Net::ReadTimeout)
+
+        expect {
+          service.details(course_id: '111-11', course_run_id: '222-2')
+        }.to raise_exception(described_class::APIError)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context
Also, handle different error codes returned from
the NCS service.

### Ticket
https://dfedigital.atlassian.net/browse/GET-1058
