### PR TITLE
GET-1057 Add search endpoint for find a course service

### DIFF
--- a/app/services/find_a_course_service.rb
+++ b/app/services/find_a_course_service.rb
@@ -12,8 +12,16 @@ class FindACourseService
     @api_base_url = api_base_url
   end
 
-  def search
-    # Search course endpoint
+  def search(options: {})
+    return {} unless api_key && api_base_url
+
+    uri = build_uri(path: 'coursesearch')
+    headers = headers(content_type: 'application/json-patch+json')
+
+    request = Net::HTTP::Post.new(uri, headers)
+    request.body = build_search(options).to_json
+
+    JSON.parse(response_body(uri, request))
   end
 
   def details(course_id:, course_run_id:)
@@ -61,5 +69,19 @@ class FindACourseService
     )
 
     JSON.parse(response_body(uri, request))
+  end
+
+  def build_search(options) # rubocop:disable Metrics/MethodLength
+    {
+      'subjectKeyword' => options[:keyword],
+      'distance' => options[:distance],
+      'qualificationLevels' => options[:qualification_levels],
+      'studyModes' => options[:study_modes],
+      'deliveryModes' => options[:delivery_modes],
+      'postcode' => options[:postcode],
+      'sortBy' => options[:sort_by],
+      'limit' => options[:limit],
+      'start' => options[:start]
+    }.select { |_k, v| v.present? }
   end
 end

--- a/spec/fixtures/files/find_a_course_search_response.json
+++ b/spec/fixtures/files/find_a_course_search_response.json
@@ -1,0 +1,215 @@
+{
+  "facets": {
+    "Region": [{
+      "count": 166,
+      "value": ""
+    }],
+    "ProviderName": [{
+      "count": 45,
+      "value": "BEXLEY LONDON BOROUGH COUNCIL"
+    }, {
+      "count": 19,
+      "value": "BRENT LONDON BOROUGH COUNCIL"
+    }, {
+      "count": 16,
+      "value": "HAVERING LONDON BOROUGH COUNCIL"
+    }, {
+      "count": 15,
+      "value": "SOUTH BANK COLLEGES"
+    }, {
+      "count": 10,
+      "value": "HARINGEY LONDON BOROUGH COUNCIL"
+    }, {
+      "count": 9,
+      "value": "SURREY COUNTY COUNCIL"
+    }, {
+      "count": 8,
+      "value": "BEST PRACTICE TRAINING & DEVELOPMENT LIMITED"
+    }, {
+      "count": 8,
+      "value": "HERTFORD REGIONAL COLLEGE"
+    }, {
+      "count": 7,
+      "value": "BUCKINGHAMSHIRE COUNTY COUNCIL"
+    }, {
+      "count": 6,
+      "value": "FIRST RUNG LIMITED"
+    }, {
+      "count": 4,
+      "value": "WAKEFIELD CITY COUNCIL"
+    }, {
+      "count": 3,
+      "value": "HAVERING COLLEGE OF FURTHER AND HIGHER EDUCATION"
+    }, {
+      "count": 3,
+      "value": "NORTH EAST SURREY COLLEGE OF TECHNOLOGY (NESCOT)"
+    }, {
+      "count": 3,
+      "value": "WEST THAMES COLLEGE"
+    }, {
+      "count": 2,
+      "value": "HILLINGDON LONDON BOROUGH COUNCIL"
+    }, {
+      "count": 2,
+      "value": "SLOUGH BOROUGH COUNCIL"
+    }, {
+      "count": 1,
+      "value": "HAMMERSMITH AND FULHAM LONDON BOROUGH COUNCIL"
+    }, {
+      "count": 1,
+      "value": "NEWHAM TRAINING AND EDUCATION CENTRE"
+    }, {
+      "count": 1,
+      "value": "RICHMOND UPON THAMES COLLEGE"
+    }, {
+      "count": 1,
+      "value": "THE WINDSOR FOREST COLLEGES GROUP"
+    }, {
+      "count": 1,
+      "value": "THE WKCIC GROUP"
+    }, {
+      "count": 1,
+      "value": "WORKING MEN'S COLLEGE CORPORATION"
+    }],
+    "AttendancePattern": [{
+      "count": 106,
+      "value": "1"
+    }, {
+      "count": 56,
+      "value": "2"
+    }, {
+      "count": 4,
+      "value": "3"
+    }],
+    "StudyMode": [{
+      "count": 166,
+      "value": "2"
+    }],
+    "DeliveryMode": [{
+      "count": 166,
+      "value": "1"
+    }],
+    "QualificationLevel": [{
+      "count": 45,
+      "value": "1"
+    }, {
+      "count": 43,
+      "value": "E"
+    }, {
+      "count": 40,
+      "value": "2"
+    }, {
+      "count": 38,
+      "value": "X"
+    }]
+  },
+  "results": [{
+    "searchScore": 0.70710677,
+    "distance": 3.32,
+    "venueLocation": {
+      "latitude": 51.542198,
+      "longitude": -0.260254
+    },
+    "courseId": "3b1dbda2-2eff-4baa-9647-14eb0de1dc53",
+    "courseRunId": "49158449-bae2-4bfb-ae0f-698781c619c7",
+    "qualificationCourseTitle": "Non regulated Adult skills formula funded provision, Level 2, Maths, 45 to 68 hrs",
+    "learnAimRef": "Z0004429",
+    "qualificationLevel": "2",
+    "updatedOn": "2019-11-14T15:31:53.875Z",
+    "venueName": "Stonebridge Centre",
+    "venueAddress": "STONEBRIDGE CENTRE, 1 MORLAND GARDENS, LONDON, NW10 8DY",
+    "venueAttendancePattern": "2",
+    "venueAttendancePatternDescription": "Evening",
+    "providerName": "BRENT LONDON BOROUGH COUNCIL",
+    "region": "",
+    "venueStudyMode": "2",
+    "venueStudyModeDescription": "Part-time",
+    "deliveryMode": "1",
+    "deliveryModeDescription": "Classroom based",
+    "startDate": "2020-01-07T00:00:00Z",
+    "venueTown": "LONDON",
+    "cost": 0,
+    "costDescription": "",
+    "courseText": "For students who want to enhance their maths skills",
+    "ukprn": "10000863",
+    "courseDescription": "For students who want to enhance their maths skills",
+    "courseName": "Mathematics Level 2",
+    "flexibleStartDate": false,
+    "durationUnit": "Weeks",
+    "durationValue": 12,
+    "national": null
+  }, {
+    "searchScore": 0.70710677,
+    "distance": 3.5,
+    "venueLocation": {
+      "latitude": 51.522605,
+      "longitude": -0.210116
+    },
+    "courseId": "80ad7954-07fe-4ac1-aa7e-3fe0406e406c",
+    "courseRunId": "cd06ddbe-9057-4773-8507-e94d16322885",
+    "qualificationCourseTitle": "Education assessment in Maths",
+    "learnAimRef": "Z0007842",
+    "qualificationLevel": "X",
+    "updatedOn": "2019-09-20T09:12:38.981Z",
+    "venueName": "Best Practice Kensington and Chelsea",
+    "venueAddress": "Venture Community Association, 103A Wornington Road, London, London, W10 5YB",
+    "venueAttendancePattern": "1",
+    "venueAttendancePatternDescription": "Daytime",
+    "providerName": "BEST PRACTICE TRAINING & DEVELOPMENT LIMITED",
+    "region": "",
+    "venueStudyMode": "2",
+    "venueStudyModeDescription": "Part-time",
+    "deliveryMode": "1",
+    "deliveryModeDescription": "Classroom based",
+    "startDate": null,
+    "venueTown": "London",
+    "cost": 0,
+    "costDescription": "We will register all learners with ESFA to access Adult Education Budget funding.",
+    "courseText": "DIGITAL EMPLOYABILITY SKILLS.&#xD;&#xA;Increase your confidence and digital skills to move closer to work!&#xD;&#xA;&#xD;&#xA;Working in partnership with local authorities, DWP and local employers, we provide focused support to help unemployed and employed individuals of all ages and backgrounds.&#xD;&#xA;&#xD;&#xA;Courses run in multiple locations including East &amp; North London, Hertfordshire, East Midlands, North West and North East.&#xD;&#xA;&#xD;&#xA;The programmes are delivered by expert tutors and mentors &#x2013; giving every learner the support they need to move towards employment.",
+    "ukprn": "10023705",
+    "courseDescription": "DIGITAL EMPLOYABILITY SKILLS.&#xD;&#xA;Increase your confidence and digital skills to move closer to work!&#xD;&#xA;&#xD;&#xA;Working in partnership with local authorities, DWP and local employers, we provide focused support to help unemployed and employed individuals of all ages and backgrounds.&#xD;&#xA;&#xD;&#xA;Courses run in multiple locations including East &amp; North London, Hertfordshire, East Midlands, North West and North East.&#xD;&#xA;&#xD;&#xA;The programmes are delivered by expert tutors and mentors &#x2013; giving every learner the support they need to move towards employment.",
+    "courseName": "Digital Employability Skills",
+    "flexibleStartDate": true,
+    "durationUnit": "Weeks",
+    "durationValue": 12,
+    "national": null
+  }, {
+    "searchScore": 0.70710677,
+    "distance": 3.81,
+    "venueLocation": {
+      "latitude": 51.535237,
+      "longitude": -0.136056
+    },
+    "courseId": "c0842fbb-0c96-415c-b731-fd5548135b58",
+    "courseRunId": "97498a06-82d5-41e3-8991-f304f2344c9e",
+    "qualificationCourseTitle": "Non regulated Adult skills formula funded provision, Entry Level, Foundations for Learning and Life, 21 to 44 hrs, PW A",
+    "learnAimRef": "Z0003480",
+    "qualificationLevel": "E",
+    "updatedOn": "2019-07-05T14:05:28.703Z",
+    "venueName": "WMC Crowndale Rd",
+    "venueAddress": "44 Crowndale Road, LONDON, NW1 1TR",
+    "venueAttendancePattern": "1",
+    "venueAttendancePatternDescription": "Daytime",
+    "providerName": "WORKING MEN'S COLLEGE CORPORATION",
+    "region": "",
+    "venueStudyMode": "2",
+    "venueStudyModeDescription": "Part-time",
+    "deliveryMode": "1",
+    "deliveryModeDescription": "Classroom based",
+    "startDate": "2019-05-02T00:00:00Z",
+    "venueTown": "LONDON",
+    "cost": null,
+    "costDescription": "Please contact The Working Mens College on 020 7255 4759 or email enrol@wmcollege.ac.uk for up to date fees",
+    "courseText": "Explore maths in fun and creative ways. Learners will develop confidence and improve skills with numbers, shapes, time and more in small groups with a creative feel. Learners will use practical activities and crafts in additional to workbooks and interactive websites to develop useful everyday numeracy skills. (SLMATHS01C)",
+    "ukprn": "10007636",
+    "courseDescription": "Explore maths in fun and creative ways. Learners will develop confidence and improve skills with numbers, shapes, time and more in small groups with a creative feel. Learners will use practical activities and crafts in additional to workbooks and interactive websites to develop useful everyday numeracy skills. (SLMATHS01C)",
+    "courseName": "Creative Maths",
+    "flexibleStartDate": false,
+    "durationUnit": "Months",
+    "durationValue": 10,
+    "national": null
+  }],
+  "total": 166,
+  "limit": 3,
+  "start": 20
+}

--- a/spec/services/find_a_course_service_spec.rb
+++ b/spec/services/find_a_course_service_spec.rb
@@ -9,7 +9,175 @@ RSpec.describe FindACourseService do
   }
 
   describe '#search' do
-    xit 'Must do something'
+    let(:find_a_course_search_response) do
+      Rails.root.join('spec', 'fixtures', 'files', 'find_a_course_search_response.json').read
+    end
+
+    let(:find_a_course_empty_search_response) do
+      {
+        'facets' => {
+          'Region' => [],
+          'ProviderName' => [],
+          'AttendancePattern' => [],
+          'StudyMode' => [],
+          'DeliveryMode' => [],
+          'QualificationLevel' => []
+        },
+        'results' => [],
+        'total' => 0,
+        'limit' => 1,
+        'start' => 20
+      }
+    end
+
+    it 'does not perform query if there is no api key' do
+      service = described_class.new(
+        api_base_url: 'test',
+        api_key: nil
+      )
+
+      service.search
+      expect(a_request(:post, /findacourse/)).not_to have_been_made
+    end
+
+    it 'does not perform query if there is no api base url' do
+      service = described_class.new(
+        api_base_url: nil,
+        api_key: 'test'
+      )
+
+      service.search
+      expect(a_request(:post, /findacourse/)).not_to have_been_made
+    end
+
+    it 'returns nothing if there is no api key' do
+      service = described_class.new(
+        api_base_url: 'test',
+        api_key: nil
+      )
+
+      expect(service.search).to be_empty
+    end
+
+    it 'returns nothing if there is no api base url' do
+      service = described_class.new(
+        api_base_url: nil,
+        api_key: 'test'
+      )
+
+      expect(service.search).to be_empty
+    end
+
+    it 'raises error if the api response is not successful' do
+      options = { keyword: 'maths' }
+      stub_request(:post, /findacourse/)
+        .to_return(status: 500)
+
+      expect { service.search(options: options) }.to raise_exception(described_class::APIError)
+    end
+
+    it 'raises error if the query is not authorised' do
+      options = { keyword: 'maths' }
+      service = described_class.new(
+        api_base_url: 'https://findacourse.com',
+        api_key: 'wrong-key'
+      )
+
+      stub_request(:post, /findacourse/)
+        .to_return(status: 403)
+
+      expect { service.search(options: options) }.to raise_exception(described_class::APIError)
+    end
+
+    it 'raises error if there is a NET::HTTP error' do
+      options = { keyword: 'maths' }
+      stub_request(:post, /findacourse/)
+        .to_raise(Net::ReadTimeout)
+
+      expect { service.search(options: options) }.to raise_exception(described_class::APIError)
+    end
+
+    it 'returns response for all options' do
+      options = {
+        keyword: 'maths',
+        distance: 20.0,
+        qualification_levels: %w[1 2 X E],
+        study_modes: [2, 3],
+        delivery_modes: [1, 2],
+        postcode: 'nw11 8qe',
+        sort_by: 4,
+        limit: 1,
+        start: 20
+      }
+
+      stub_request(:post, /findacourse/)
+        .with(
+          body: {
+            'subjectKeyword' => 'maths',
+            'distance' => 20.0,
+            'qualificationLevels' => %w[1 2 X E],
+            'studyModes' => [2, 3],
+            'deliveryModes' => [1, 2],
+            'postcode' => 'nw11 8qe',
+            'sortBy' => 4,
+            'limit' => 1,
+            'start' => 20
+          }.to_json
+        )
+        .to_return(body: find_a_course_search_response)
+
+      expect(service.search(options: options)).to eq(
+        JSON.parse(find_a_course_search_response)
+      )
+    end
+
+    it 'returns 0 courses if none present' do
+      options = {
+        keyword: 'physics',
+        distance: 0.0,
+        qualification_levels: ['1'],
+        study_modes: [2],
+        delivery_modes: [1],
+        postcode: 'nw11 8qe',
+        sort_by: 4,
+        limit: 1,
+        start: 20
+      }
+
+      stub_request(:post, /findacourse/)
+        .with(
+          body: {
+            'subjectKeyword' => 'physics',
+            'distance' => 0.0,
+            'qualificationLevels' => ['1'],
+            'studyModes' => [2],
+            'deliveryModes' => [1],
+            'postcode' => 'nw11 8qe',
+            'sortBy' => 4,
+            'limit' => 1,
+            'start' => 20
+          }.to_json
+        )
+        .to_return(body: find_a_course_empty_search_response.to_json)
+
+      expect(service.search(options: options)).to eq(
+        find_a_course_empty_search_response
+      )
+    end
+
+    it 'ignores nil values when doing query' do
+      options = { keyword: 'maths', sort_by: 1 }
+      stub_request(:post, /findacourse/)
+        .with(
+          body: {
+            'subjectKeyword' => 'maths',
+            'sortBy' => 1
+          }.to_json
+        )
+        .to_return(body: find_a_course_empty_search_response.to_json)
+
+      expect(service.search(options: options)).to eq(find_a_course_empty_search_response)
+    end
   end
 
   describe '#details' do


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-1057

* Find a course search accepts options and returns json response
* Options can be empty for some fields
* catch errors if there is an error from the API or from teh request

