### PR TITLE
Render the formatted start date on the UI

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -51,7 +51,7 @@
         <% if @decorated_course_details.start_date.present? %>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">Course start date</th>
-            <td class="govuk-table__cell"><%= @decorated_course_details.start_date %></td>
+            <td class="govuk-table__cell"><%= @decorated_course_details.formatted_start_date %></td>
           </tr>
         <% end %>
         <% if @decorated_course_details.price.present? %>


### PR DESCRIPTION
### Context

Turns out the unformatted date was shown on the UI.

