### PR TITLE
GET-1062 On API courses, do not check location eligibility on postcode

### DIFF
--- a/app/controllers/user_personal_data_controller.rb
+++ b/app/controllers/user_personal_data_controller.rb
@@ -34,9 +34,9 @@ class UserPersonalDataController < ApplicationController
 
     user_session.postcode = postcode
 
-    return redirect_to(location_ineligible_path) unless search.find_courses.any?
+    return redirect_to task_list_path if Flipflop.csv_courses? || search.find_courses.any?
 
-    redirect_to task_list_path
+    redirect_to(location_ineligible_path)
   rescue CourseGeospatialSearch::GeocoderAPIError
     redirect_to postcode_search_error_path
   end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-1062

Do not check location eligibility when under API courses flag,
as we now support all regions. Maintain all other behaviour regarding
saving postcode to session, and tracking postcode.
