### PR TITLE
Persist distance filter on the session

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,4 +1,5 @@
-class CoursesController < ApplicationController
+# TODO: Remove rubocop suppression when we decomission the CSV Courses implementation
+class CoursesController < ApplicationController # rubocop:disable Metrics/ClassLength
   DISTANCE = [
     ['Up to 10 miles', '10'],
     ['Up to 20 miles', '20'],
@@ -49,8 +50,8 @@ class CoursesController < ApplicationController
     track_event(:courses_index_search, postcode) if postcode.present?
     search
     filter_options
+    persist_valid_filters_on_session
 
-    user_session.postcode = postcode if postcode && @search.valid?
     @courses =
       Kaminari
       .paginate_array(csv_course_search, total_count: @search.count)
@@ -63,8 +64,21 @@ class CoursesController < ApplicationController
     @postcode ||= courses_params[:postcode] || user_session.postcode
   end
 
+  def distance
+    @distance ||= courses_params[:distance] || user_session.distance
+  end
+
   def courses_params
-    params.permit(:postcode, :topic_id, :hours, :delivery_type, :distance, :page)
+    params.permit(
+      :postcode,
+      :topic_id,
+      :hours,
+      :delivery_type,
+      :distance,
+      :page,
+      :course_id,
+      :course_run_id
+    )
   end
 
   def course_search
@@ -89,19 +103,30 @@ class CoursesController < ApplicationController
   end
 
   def filter_options
-    @distance_options = helpers.options_for_select(DISTANCE, courses_params[:distance] || '20')
+    @distance_options = helpers.options_for_select(DISTANCE, distance || '20')
     @delivery_type_options = helpers.options_for_select(DELIVERY_TYPES, courses_params[:delivery_type] || 'all')
     @hours_options = helpers.options_for_select(HOURS, courses_params[:hours] || 'all')
   end
 
   def course_details_api_response
-    FindACourseService.new.details(
-      course_id: params[:course_id],
-      course_run_id: params[:course_run_id]
+    find_a_course_service.details(
+      course_id: courses_params[:course_id],
+      course_run_id: courses_params[:course_run_id]
     )
   end
 
   def course_details
     CourseDetails.new(course_details_api_response)
+  end
+
+  def find_a_course_service
+    @find_a_course_service ||= FindACourseService.new
+  end
+
+  def persist_valid_filters_on_session
+    return unless @search.valid?
+
+    user_session.postcode = postcode if postcode
+    user_session.distance = distance if distance
   end
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,10 +1,6 @@
-# TODO: Remove rubocop suppression when we decomission the CSV Courses implementation
-class CoursesController < ApplicationController # rubocop:disable Metrics/ClassLength
+class CoursesController < ApplicationController
   DISTANCE = [
-    ['Up to 10 miles', '10'],
-    ['Up to 20 miles', '20'],
-    ['Up to 30 miles', '30'],
-    ['Up to 40 miles', '40']
+    ['Up to 10 miles', '10'], ['Up to 20 miles', '20'], ['Up to 30 miles', '30'], ['Up to 40 miles', '40']
   ].freeze
 
   DELIVERY_TYPES = [
@@ -109,7 +105,7 @@ class CoursesController < ApplicationController # rubocop:disable Metrics/ClassL
   end
 
   def course_details_api_response
-    find_a_course_service.details(
+    FindACourseService.new.details(
       course_id: courses_params[:course_id],
       course_run_id: courses_params[:course_run_id]
     )
@@ -117,10 +113,6 @@ class CoursesController < ApplicationController # rubocop:disable Metrics/ClassL
 
   def course_details
     CourseDetails.new(course_details_api_response)
-  end
-
-  def find_a_course_service
-    @find_a_course_service ||= FindACourseService.new
   end
 
   def persist_valid_filters_on_session

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -5,6 +5,7 @@ class UserSession # rubocop:disable Metrics/ClassLength
     job_profile_skills
     job_profile_ids
     postcode
+    distance
     target_job_id
     training
     job_hunting

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -1,4 +1,4 @@
-class UserSession
+class UserSession # rubocop:disable Metrics/ClassLength
   attr_reader :session
 
   KEYS_TO_RESTORE = %w[
@@ -29,6 +29,14 @@ class UserSession
 
   def postcode=(value)
     session[:postcode] = value
+  end
+
+  def distance
+    session[:distance]
+  end
+
+  def distance=(value)
+    session[:distance] = value
   end
 
   def skills_matcher_sort

--- a/spec/features/find_courses_near_me_spec.rb
+++ b/spec/features/find_courses_near_me_spec.rb
@@ -139,6 +139,30 @@ RSpec.feature 'Find training courses', type: :feature do
     expect(page).to have_select('distance', selected: 'Up to 40 miles')
   end
 
+  scenario 'Selected distance gets gets remembered on user return' do
+    find_a_course_service = instance_double(
+      FindACourseService,
+      search: {
+        'total' => 1,
+        'results' => [{ 'courseName' => 'My Course', 'courseId' => '123', 'courseRunId' => '456' }]
+      },
+      details: {
+        'courseName' => 'My Course', 'provider' => { 'postcode' => 'NW11 8QE' }
+      }
+    )
+
+    allow(FindACourseService).to receive(:new).and_return(find_a_course_service)
+
+    capture_user_location('NW6 1JF')
+    visit(courses_path(topic_id: 'maths'))
+    select('Up to 40 miles', from: 'distance')
+    click_on('Apply filters')
+    click_on('My Course')
+    click_on('Training courses near you')
+
+    expect(page).to have_select('distance', selected: 'Up to 40 miles')
+  end
+
   scenario 'Users see selected course hour filter when returning results' do
     capture_user_location('NW6 1JF')
     visit(courses_path(topic_id: 'maths'))

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe UserSession do
     it 'merges old data into new session for selected keys' do
       old_session = {
         'postcode' => 'NW118QE',
+        'distance' => '30',
         'target_job_id' => 100,
         'session_id' => 2,
         'training' => ['english_skills'],
@@ -20,6 +21,7 @@ RSpec.describe UserSession do
 
       expect(new_session).to eq(
         'postcode' => 'NW118QE',
+        'distance' => '30',
         'target_job_id' => 100,
         'session_id' => 1,
         'training' => ['english_skills'],

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe UserSession do
     end
   end
 
+  describe '#distance' do
+    it 'returns distance value if set' do
+      user_session.distance = '20'
+
+      expect(user_session.distance).to eq('20')
+    end
+
+    it 'returns nil if no distance set' do
+      expect(user_session.distance).to be_nil
+    end
+  end
+
   describe '#skills_matcher_sort' do
     it 'returns order if set' do
       user_session.skills_matcher_sort = 'growth'


### PR DESCRIPTION
### Context
Persist distance filter on the session

Add course_id and course_run_id among permitted
params.

Ensure the distance key is restored on the session when using the save and return journey.

### Ticket
https://dfedigital.atlassian.net/browse/GET-1046

