### PR TITLE
Add the courses near me error page for search

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -4,17 +4,11 @@ class CoursesController < ApplicationController
   ].freeze
 
   DELIVERY_TYPES = [
-    %w[All all],
-    ['Classroom based', '1'],
-    %w[Online 2],
-    ['Work based', '3']
+    %w[All all], ['Classroom based', '1'], %w[Online 2], ['Work based', '3']
   ].freeze
 
   HOURS = [
-    %w[All all],
-    ['Full time', '1'],
-    ['Part time', '2'],
-    %w[Flexible 3]
+    %w[All all], ['Full time', '1'], ['Part time', '2'], %w[Flexible 3]
   ].freeze
 
   def index
@@ -44,17 +38,14 @@ class CoursesController < ApplicationController
     redirect_to course_postcode_search_error_path
   end
 
-  # TODO: Move FindACourseService::APIError rescue to index when we decomission the the CSV Courses feature
-  def find_csv_courses # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def find_csv_courses
     track_event(:courses_index_search, postcode) if postcode.present?
     search
     filter_options
     persist_valid_filters_on_session
 
-    @courses =
-      Kaminari
-      .paginate_array(csv_course_search, total_count: @search.count)
-      .page(courses_params[:page])
+    @courses = Kaminari .paginate_array(csv_course_search, total_count: @search.count)
+                        .page(courses_params[:page])
   rescue CourseSearch::GeocoderAPIError
     redirect_to course_postcode_search_error_path
   rescue FindACourseService::APIError

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -23,6 +23,8 @@ class CoursesController < ApplicationController
 
   def show
     @decorated_course_details = CourseDetailsDecorator.new(course_details)
+  rescue FindACourseService::APIError
+    redirect_to courses_near_me_error_path
   end
 
   private

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -42,7 +42,8 @@ class CoursesController < ApplicationController
     redirect_to course_postcode_search_error_path
   end
 
-  def find_csv_courses
+  # TODO: Move FindACourseService::APIError rescue to index when we decomission the the CSV Courses feature
+  def find_csv_courses # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     track_event(:courses_index_search, postcode) if postcode.present?
     search
     filter_options
@@ -54,6 +55,8 @@ class CoursesController < ApplicationController
       .page(courses_params[:page])
   rescue CourseSearch::GeocoderAPIError
     redirect_to course_postcode_search_error_path
+  rescue FindACourseService::APIError
+    redirect_to courses_near_me_error_path
   end
 
   def postcode

--- a/app/views/errors/courses_near_me_error.html.erb
+++ b/app/views/errors/courses_near_me_error.html.erb
@@ -1,0 +1,12 @@
+<% page_title :errors_courses_near_me_error %>
+
+<main role="main" class="govuk-main-wrapper" id="main-content">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Sorry, there is a problem with this service</h1>
+      <p class="govuk-body">The <%= link_to 'Find a course', 'https://nationalcareers.service.gov.uk/find-a-course/', class: 'govuk-link' %> service is not working right now.</p>
+      <p class="govuk-body-m">You can continue using this service to check your existing skills and explore the types of jobs you could apply to do.</p>
+      <%= link_to 'Continue', action_plan_path, class: 'govuk-button', role: 'button', data: { module: 'govuk-button' } %>
+    </div>
+  </div>
+</main>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,7 @@ en-GB:
     errors_internal_server_error: Get help to retrain - Internal server error
     errors_postcode_search_error: Get help to retrain - Postcode search error
     errors_jobs_near_me_error: Get help to retrain - Jobs near me error
+    errors_courses_near_me_error: Get help to retrain - Courses near me error
     errors_return_to_saved_results_error: Get help to retrain - Return to saved results error
     errors_save_results_error: Get help to retrain - Save your results error
     save_your_results: Get help to retrain - Save your results

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,8 @@ Rails.application.routes.draw do
         'courses/:topic_id/:course_id/:course_run_id',
         to: 'courses#show', as: :course_details, via: :get, constraints: { topic_id: /maths|english/ }
       )
+
+      get 'courses-near-me-error', to: 'errors#courses_near_me_error'
     end
 
     resources :check_your_skills, path: 'check-your-skills', only: %i[index] do

--- a/spec/features/find_courses_near_me_spec.rb
+++ b/spec/features/find_courses_near_me_spec.rb
@@ -368,6 +368,17 @@ RSpec.feature 'Find training courses', type: :feature do
     expect(page).to have_css('nav.govuk-breadcrumbs', text: 'Action plan')
   end
 
+  scenario 'User gets relevant messaging if there is an API error' do
+    find_a_course_service = instance_double(FindACourseService)
+    allow(FindACourseService).to receive(:new).and_return(find_a_course_service)
+    allow(find_a_course_service).to receive(:search).and_raise(FindACourseService::APIError)
+
+    capture_user_location('NW6 8ET')
+    visit(courses_path(topic_id: 'maths'))
+
+    expect(page).to have_text(/Sorry, there is a problem with this service/)
+  end
+
   private
 
   def capture_user_location(postcode)

--- a/spec/features/find_courses_near_me_spec.rb
+++ b/spec/features/find_courses_near_me_spec.rb
@@ -379,6 +379,17 @@ RSpec.feature 'Find training courses', type: :feature do
     expect(page).to have_text(/Sorry, there is a problem with this service/)
   end
 
+  scenario 'User deep linking to a course details page gets relevant messaging if there is an API error' do
+    find_a_course_service = instance_double(FindACourseService)
+    allow(FindACourseService).to receive(:new).and_return(find_a_course_service)
+    allow(find_a_course_service).to receive(:details).and_raise(FindACourseService::APIError)
+
+    capture_user_location('NW6 8ET')
+    visit(course_details_path(topic_id: 'maths', course_id: '111-11', course_run_id: '222-2'))
+
+    expect(page).to have_text(/Sorry, there is a problem with this service/)
+  end
+
   private
 
   def capture_user_location(postcode)

--- a/spec/routing/courses_spec.rb
+++ b/spec/routing/courses_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe 'routes for Courses', type: :routing do
-  xit 'successfully routes to courses#index for existing course' do
+  it 'successfully routes to courses#index for existing course' do
     create(:course, :maths)
 
     expect(get('/courses/maths')).to route_to(controller: 'courses', action: 'index', topic_id: 'maths')
   end
 
-  xit 'does not route to courses#index for non-existing course' do
+  it 'does not route to courses#index for non-existing course' do
     expect(get('/courses/history')).not_to be_routable
   end
 
@@ -16,10 +16,18 @@ RSpec.describe 'routes for Courses', type: :routing do
       disable_feature!(:csv_courses)
     end
 
-    xit 'does not route to courses#show' do
+    xit 'does not route to courses#show - csv files feature' do
       course_lookup = create(:course_lookup, subject: 'english')
 
       expect(get("/courses/english/#{course_lookup.opportunity.id}")).not_to be_routable
+    end
+
+    it 'does not route to courses#show' do
+      expect(get('/courses/english/111-11/222-2')).not_to be_routable
+    end
+
+    it 'does not route to errors#courses_near_me_error' do
+      expect(get('/courses-near-me-error')).not_to be_routable
     end
   end
 
@@ -28,12 +36,24 @@ RSpec.describe 'routes for Courses', type: :routing do
       enable_feature!(:csv_courses)
     end
 
-    xit 'does not route to courses#show' do
+    xit 'does route to courses#show - csv files feature' do
       course_lookup = create(:course_lookup, subject: 'english')
 
       expect(
         get("/courses/english/#{course_lookup.opportunity.id}")
       ).to route_to(controller: 'courses', action: 'show', opportunity_id: course_lookup.opportunity.id.to_s, topic_id: 'english')
+    end
+
+    it 'does route to courses#show' do
+      expect(
+        get('/courses/english/111-11/222-2')
+      ).to route_to(controller: 'courses', action: 'show', course_id: '111-11', course_run_id: '222-2', topic_id: 'english')
+    end
+
+    it 'does route to errors#courses_near_me_error' do
+      expect(
+        get('/courses-near-me-error')
+      ).to route_to(controller: 'errors', action: 'courses_near_me_error')
     end
   end
 end


### PR DESCRIPTION
### Context
If the NCS API is down we want to make sure users are
still able to use the service and get a relevant error
message when trying to find a relevant course.

### Ticket
https://dfedigital.atlassian.net/browse/GET-1061

