### PR TITLE
Add back find a course keys to heroku app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -35,10 +35,10 @@
       "required": true
     },
     "FIND_A_COURSE_API_KEY": {
-      "required": false
+      "required": true
     },
     "FIND_A_COURSE_API_BASE_URL": {
-      "required": false
+      "required": true
     },
     "BING_SPELL_CHECK_API_KEY": {
       "required": false


### PR DESCRIPTION
The keys have now been added to the main review app settings, so we can officially start requiring them again