### PR TITLE
GET-979 Spike new cookies modal

### DIFF
--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -1,0 +1,16 @@
+class CookiesController < ApplicationController
+  def create
+    if cookies_params[:cookies] == 'all'
+      user_session.cookies = true
+    elsif cookies_params[:cookies] == 'partial'
+      user_session.cookies = false
+    end
+    redirect_to(request.env["HTTP_REFERER"])
+  end
+
+  private
+
+  def cookies_params
+    params.permit(:cookies, :authenticity_token)
+  end
+end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -11,6 +11,7 @@ class UserSession # rubocop:disable Metrics/ClassLength
     job_hunting
     it_training
     skills_matcher_sort
+    cookies
   ].freeze
 
   def self.merge_sessions(new_session:, previous_session_data:)
@@ -38,6 +39,14 @@ class UserSession # rubocop:disable Metrics/ClassLength
 
   def distance=(value)
     session[:distance] = value
+  end
+
+  def cookies
+    session[:cookies]
+  end
+
+  def cookies=(value)
+    session[:cookies] = value
   end
 
   def skills_matcher_sort

--- a/app/services/tracking_service.rb
+++ b/app/services/tracking_service.rb
@@ -21,6 +21,7 @@ class TrackingService
   end
 
   def track_events(props:)
+    return unless client_tracking_data[:ga_cookie].present?
     raise MissingAttributesError, 'Event props must be present' unless props.present?
 
     return unless ga_tracking_id

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,9 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-    <%= render 'shared/cookies_banner' unless current_page?(cookies_policy_path) %>
+    <% if !current_page?(cookies_policy_path) %>
+      <%= render 'shared/cookies_banner' if cookies['_get_help_to_retrain_session'].blank? || user_session.cookies.nil? %>
+    <% end %>
     <div id="govuk-header-container">
       <header class="govuk-header" role="banner" data-module="govuk-header" id="govuk-header">
         <div class="govuk-header__container govuk-width-container">

--- a/app/views/shared/_cookies_banner.html.erb
+++ b/app/views/shared/_cookies_banner.html.erb
@@ -1,9 +1,21 @@
 <div id="cookies-banner" class="cookies-modal">
   <div class="cookies-modal-content" id="cookies-modal">
-    <div class="govuk-width-container">
+    <div class="govuk-width-container js-enabledd">
       <div class="govuk-main-wrapper govuk-!-padding-top-1 govuk-!-padding-bottom-1" role="region" aria-label="cookie banner">
         <p class="govuk-body">This service uses cookies to personalise your experience and to collect information about how you use the site. You can find out more about cookies by clicking the cookies settings button.</p>
-        <%= link_to 'Accept cookies', '#', id: 'accept-cookies', class: 'govuk-button govuk-button--secondary govuk-!-margin-right-5', role: 'button', data: { module: 'govuk-button' } %>
+        <%= form_with local: true, url: set_cookies_path do %>
+          <%= submit_tag('all', name: 'cookies', value: 'all', role: 'button', class: 'govuk-button govuk-button--secondary govuk-!-margin-right-5', role: 'button', data: { module: 'govuk-button' }) %>
+          <%= submit_tag('partial', name: 'cookies', value: 'partial', role: 'button', class: 'govuk-button govuk-button--secondary govuk-!-margin-right-5', role: 'button', data: { module: 'govuk-button' }) %>
+        <% end %>
+        <%= link_to 'Cookie settings', cookies_policy_path, class: 'govuk-button govuk-button--secondary', data: { module: 'govuk-button' } %>
+      </div>
+    </div>
+    <div class="govuk-width-container js-disabled">
+      <div class="govuk-main-wrapper govuk-!-padding-top-1 govuk-!-padding-bottom-1" role="region" aria-label="cookie banner">
+        <p class="govuk-body">This service uses cookies to personalise your experience and to collect information about how you use the site. You can find out more about cookies by clicking the cookies settings button. this is JS disabled!!</p>
+        <%= form_with local: true, url: set_cookies_path do %>
+          <%= submit_tag('all', name: 'cookies', value: 'all', role: 'button', class: 'govuk-button govuk-button--secondary govuk-!-margin-right-5', role: 'button', data: { module: 'govuk-button' }) %>
+        <% end %>
         <%= link_to 'Cookie settings', cookies_policy_path, class: 'govuk-button govuk-button--secondary', data: { module: 'govuk-button' } %>
       </div>
     </div>

--- a/app/views/shared/tracking/_google_analytics.html.erb
+++ b/app/views/shared/tracking/_google_analytics.html.erb
@@ -1,4 +1,4 @@
-<% if Rails.configuration.google_analytics_tracking_id.present? %>
+<% if Rails.configuration.google_analytics_tracking_id.present? && user_session.cookies %>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=<%= Rails.configuration.google_analytics_tracking_id %>"></script>
   <script>

--- a/app/webpacker/packs/cookies-banner.js
+++ b/app/webpacker/packs/cookies-banner.js
@@ -1,12 +1,10 @@
 function CookiesBanner () {
   this.start = function () {
-    var cookiesModal = document.querySelector('#cookies-banner');
+    var cookiesModal = document.querySelector('.js-enabledd');
 
     if (typeof(cookiesModal) !== 'undefined' && cookiesModal != null) {
-      if (getCookie('seen_cookie_message') !== 'true') {
         displayCookiesModal(cookiesModal);
         trapFocus(cookiesModal);
-      }
     }
   }
 
@@ -24,43 +22,22 @@ function CookiesBanner () {
   }
 
   function displayCookiesModal(modalElement) {
-    modalElement.insertBefore(document.querySelector('#govuk-header'), document.querySelector('#cookies-modal'));
-    document.querySelector('.govuk-header__container').classList.add('govuk-!-padding-bottom-2');
-
     modalElement.style.display = 'block';
-
-    var cookiesAccept = document.querySelector('#accept-cookies');
-
-    if (typeof(cookiesAccept) !== 'undefined' && cookiesAccept != null) {
-      handleAcceptCookies(modalElement, cookiesAccept);
-    }
-  }
-
-  function handleAcceptCookies(modalElement, acceptElement) {
-    acceptElement.onclick = function(e) {
-      e.preventDefault();
-
-      document.querySelector('#govuk-header-container').appendChild(
-        document.querySelector('#govuk-header')
-      );
-      document.querySelector('.govuk-header__container').classList.remove('govuk-!-padding-bottom-2');
-
-      modalElement.style.display = 'none';
-      setCookie('seen_cookie_message', 'true', 30);
-    }
+    var cookiesModalDisabled = document.querySelector('.js-disabled');
+    cookiesModalDisabled.style.display = 'none';
   }
 
   function trapFocus(element) {
     var focusableElements = element.querySelectorAll('a[href]:not([disabled])');
-    var firstElement = focusableElements[0];  
+    var firstElement = focusableElements[0];
     var lastElement = focusableElements[focusableElements.length - 1];
     var KEYCODE_TAB = 9;
 
     element.addEventListener('keydown', function(e) {
       var isTabPressed = (e.keyCode === KEYCODE_TAB);
 
-      if (!isTabPressed) { 
-        return; 
+      if (!isTabPressed) {
+        return;
       }
 
       if ( e.shiftKey ) /* shift + tab */ {

--- a/app/webpacker/styles/_cookies.scss
+++ b/app/webpacker/styles/_cookies.scss
@@ -1,5 +1,4 @@
 .cookies-modal {
-  display: none;
   position: fixed;
   z-index: 1000;
   left: 0;
@@ -16,4 +15,8 @@
 
 .cookies-modal-content {
   background-color: govuk-colour("white");
+}
+
+.js-enabledd {
+  display: none;
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,8 @@ Rails.application.routes.draw do
     get 'your-information', to: 'user_personal_data#index'
     post 'your-information', to: 'user_personal_data#create'
 
+    post 'set-cookies', to: 'cookies#create'
+
     resources :user_personal_data, only: %i[index create]
 
     resources :feedback_surveys, only: %i[create]


### PR DESCRIPTION
move tracking and cookies banner acceptance to session/backend.
Also show different behaviour on js enabled vs disabled

jira-ticket: https://dfedigital.atlassian.net/browse/GET-979

