### PR TITLE
Forcing word wrapping on courses description

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -64,7 +64,7 @@
     </table>
     <% if @decorated_course_details.course_description.present? %>
       <h2 class="govuk-heading-m">Course description</h2>
-      <p class="govuk-body description-wrap">
+      <p class="govuk-body text-wrap">
         <%= @decorated_course_details.course_description %>
       </p>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -64,7 +64,7 @@
     </table>
     <% if @decorated_course_details.course_description.present? %>
       <h2 class="govuk-heading-m">Course description</h2>
-      <p class="govuk-body">
+      <p class="govuk-body description-wrap">
         <%= @decorated_course_details.course_description %>
       </p>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/app/webpacker/styles/_course.scss
+++ b/app/webpacker/styles/_course.scss
@@ -21,6 +21,6 @@
   }
 }
 
-.description-wrap {
+.text-wrap {
   word-wrap: break-word;
 }

--- a/app/webpacker/styles/_course.scss
+++ b/app/webpacker/styles/_course.scss
@@ -20,3 +20,7 @@
     width: 0 !important;
   }
 }
+
+.description-wrap {
+  word-wrap: break-word;
+}


### PR DESCRIPTION
### Context
We noticed that for cases where a course description
has a very long url present it doesn't wrap properly,
so we need to force it.

### Screenshot

![Screen Shot 2020-03-18 at 12 37 34](https://user-images.githubusercontent.com/1955084/76961503-5c2e7680-6915-11ea-8c22-9d6336bac1b4.png)

### Ticket

https://dfedigital.atlassian.net/browse/GET-1079