### PR TITLE
Render the decorated course description

### DIFF
--- a/app/decorators/course_details_decorator.rb
+++ b/app/decorators/course_details_decorator.rb
@@ -36,8 +36,7 @@ class CourseDetailsDecorator < SimpleDelegator
   end
 
   def course_description
-    return unless description.present?
-    return if description.size <= 15
+    return if description.nil? || description.size <= 15
 
     description
   end

--- a/app/decorators/course_details_decorator.rb
+++ b/app/decorators/course_details_decorator.rb
@@ -36,6 +36,7 @@ class CourseDetailsDecorator < SimpleDelegator
   end
 
   def course_description
+    return unless description.present?
     return if description.size <= 15
 
     description

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -62,10 +62,10 @@
         <% end %>
       </tbody>
     </table>
-    <% if @decorated_course_details.description.present? %>
+    <% if @decorated_course_details.course_description.present? %>
       <h2 class="govuk-heading-m">Course description</h2>
       <p class="govuk-body">
-        <%= @decorated_course_details.description %>
+        <%= @decorated_course_details.course_description %>
       </p>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <% end %>

--- a/spec/decorators/course_details_decorator_spec.rb
+++ b/spec/decorators/course_details_decorator_spec.rb
@@ -251,6 +251,22 @@ RSpec.describe CourseDetailsDecorator do
         ).to eq('Very short description')
       end
     end
+
+    context 'when description is nil' do
+      let(:course_description) { nil }
+
+      let(:find_a_course_search_response) do
+        {
+          'course' => {
+            'courseDescription' => course_description
+          }
+        }
+      end
+
+      it 'returns nil' do
+        expect(decorated_course_details.course_description).to be nil
+      end
+    end
   end
 
   describe '#formatted_start_date' do

--- a/spec/features/find_courses_near_me_spec.rb
+++ b/spec/features/find_courses_near_me_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature 'Find training courses', type: :feature do
     expect(page).to have_select('distance', selected: 'Up to 40 miles')
   end
 
-  scenario 'Selected distance gets gets remembered on user return' do
+  scenario 'Selected distance gets remembered on user return' do
     find_a_course_service = instance_double(
       FindACourseService,
       search: {


### PR DESCRIPTION
### Context

It looks like we were not using the decorated course description when rendering.

### Screenshot

![Screen Shot 2020-03-18 at 12 52 39](https://user-images.githubusercontent.com/1955084/76962543-520d7780-6917-11ea-9bfe-2318c9beee28.png)


### Ticket
https://dfedigital.atlassian.net/browse/GET-1078

