### PR TITLE
Use strip_links for job profiles section

### DIFF
--- a/app/decorators/job_profile_decorator.rb
+++ b/app/decorators/job_profile_decorator.rb
@@ -4,6 +4,7 @@ class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLengt
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::NumberHelper
   include ActionView::Context
+  include ActionView::Helpers
 
   # rubocop:disable Metrics/LineLength
   HOW_TO_BECOME_XPATH = "//h2[contains(@class, 'job-profile-heading')]".freeze
@@ -77,7 +78,7 @@ class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLengt
     mutate_apprenticeship_content if key == :apprenticeship
     mutate_html_body
 
-    html_body_with_no_links = @doc.to_html.gsub(%r{<a.*?>(.+?)</a>}, '\1').html_safe
+    html_body_with_no_links = strip_links(@doc.to_html).html_safe
 
     return html_body_with_no_links if key == :apprenticeship
 

--- a/spec/decorators/job_profile_decorator_spec.rb
+++ b/spec/decorators/job_profile_decorator_spec.rb
@@ -327,6 +327,7 @@ RSpec.describe JobProfileDecorator do
             <ul class="list-reqs">
               <li><a href="google.com">4 or 5 GCSEs at grades 9 to 4 (A* to C) and college qualifications like A levels</a></li>
             </ul>
+            <p class=\"govuk-body-m\">You can find out more about careers in management consultancy from the <a href=\"https://www.mca.org.uk/career-development/careers-advice/\">Management Consultancies\nAssociation</a> and the <a href=\"http://www.managers.org.uk\">Chartered Management\nInstitute</a>.</p>
           </div>
         </section>'
       end


### PR DESCRIPTION
### Context

The original regex expression we were using to
identify all a tags and remove them was not capturing
all edge cases.

Rails has a method strip_links that does exactly this
so we are using it instead.

### Screenshots

![Screen Shot 2020-03-18 at 15 57 03](https://user-images.githubusercontent.com/1955084/76980396-08ca2180-6931-11ea-86f5-91a485cb7dcc.png)

### Ticket
https://dfedigital.atlassian.net/browse/GET-1055

