### PR TITLE
Courses details formatting

### DIFF
--- a/app/decorators/course_details_decorator.rb
+++ b/app/decorators/course_details_decorator.rb
@@ -42,6 +42,13 @@ class CourseDetailsDecorator < SimpleDelegator
     description
   end
 
+  def course_qualification_level
+    return 'Unknown' if qualification_level == 'X'
+    return 'Entry Level' if qualification_level == 'E'
+
+    "Level #{qualification_level}"
+  end
+
   private
 
   def full_street_address

--- a/app/decorators/course_details_decorator.rb
+++ b/app/decorators/course_details_decorator.rb
@@ -1,5 +1,6 @@
 class CourseDetailsDecorator < SimpleDelegator
   include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::NumberHelper
 
   def provider_full_address
     [
@@ -24,7 +25,7 @@ class CourseDetailsDecorator < SimpleDelegator
     return unless cost.present?
     return 'Free' if cost.zero?
 
-    "£#{cost}"
+    "£#{number_with_precision(cost, precision: 2)}"
   end
 
   def course_url

--- a/app/decorators/course_details_decorator.rb
+++ b/app/decorators/course_details_decorator.rb
@@ -49,6 +49,7 @@ class CourseDetailsDecorator < SimpleDelegator
     when 'x' then 'Unknown'
     when 'e' then 'Entry Level'
     when ('1'..'8') then "Level #{qualification_level}"
+    else qualification_level
     end
   end
 
@@ -59,6 +60,7 @@ class CourseDetailsDecorator < SimpleDelegator
     when 'classroombased' then 'Classroom based'
     when 'workbased' then 'Work based'
     when 'online' then 'Online'
+    else delivery_mode
     end
   end
 
@@ -69,6 +71,8 @@ class CourseDetailsDecorator < SimpleDelegator
     when 'parttime' then 'Part-time'
     when 'fulltime' then 'Full-time'
     when 'flexible' then 'Flexible'
+    when 'undefined' then nil
+    else study_mode
     end
   end
 

--- a/app/decorators/course_details_decorator.rb
+++ b/app/decorators/course_details_decorator.rb
@@ -49,6 +49,10 @@ class CourseDetailsDecorator < SimpleDelegator
     "Level #{qualification_level}"
   end
 
+  def course_delivery_mode
+    delivery_mode.underscore.tr('_', ' ').humanize
+  end
+
   private
 
   def full_street_address

--- a/app/decorators/course_details_decorator.rb
+++ b/app/decorators/course_details_decorator.rb
@@ -54,6 +54,8 @@ class CourseDetailsDecorator < SimpleDelegator
   end
 
   def course_study_mode
+    return if study_mode.nil? || study_mode.downcase == 'undefined'
+
     study_mode.underscore.tr('_', '-').humanize
   end
 

--- a/app/decorators/course_details_decorator.rb
+++ b/app/decorators/course_details_decorator.rb
@@ -53,6 +53,10 @@ class CourseDetailsDecorator < SimpleDelegator
     delivery_mode.underscore.tr('_', ' ').humanize
   end
 
+  def course_study_mode
+    study_mode.underscore.tr('_', '-').humanize
+  end
+
   private
 
   def full_street_address

--- a/app/decorators/course_details_decorator.rb
+++ b/app/decorators/course_details_decorator.rb
@@ -43,20 +43,33 @@ class CourseDetailsDecorator < SimpleDelegator
   end
 
   def course_qualification_level
-    return 'Unknown' if qualification_level == 'X'
-    return 'Entry Level' if qualification_level == 'E'
+    return unless qualification_level.present?
 
-    "Level #{qualification_level}"
+    case qualification_level.downcase
+    when 'x' then 'Unknown'
+    when 'e' then 'Entry Level'
+    when ('1'..'8') then "Level #{qualification_level}"
+    end
   end
 
   def course_delivery_mode
-    delivery_mode.underscore.tr('_', ' ').humanize
+    return unless delivery_mode.present?
+
+    case delivery_mode.downcase
+    when 'classroombased' then 'Classroom based'
+    when 'workbased' then 'Work based'
+    when 'online' then 'Online'
+    end
   end
 
   def course_study_mode
-    return if study_mode.nil? || study_mode.downcase == 'undefined'
+    return unless study_mode.present?
 
-    study_mode.underscore.tr('_', '-').humanize
+    case study_mode.downcase
+    when 'parttime' then 'Part-time'
+    when 'fulltime' then 'Full-time'
+    when 'flexible' then 'Flexible'
+    end
   end
 
   private

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -33,7 +33,7 @@
         <% if @decorated_course_details.study_mode.present? %>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">Course hours</th>
-            <td class="govuk-table__cell"><%= @decorated_course_details.study_mode %></td>
+            <td class="govuk-table__cell"><%= @decorated_course_details.course_study_mode %></td>
           </tr>
         <% end %>
         <% if @decorated_course_details.delivery_mode.present? %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -30,7 +30,7 @@
             <td class="govuk-table__cell"><%= @decorated_course_details.course_qualification_level %></td>
           </tr>
         <% end %>
-        <% if @decorated_course_details.study_mode.present? %>
+        <% if @decorated_course_details.course_study_mode.present? %>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">Course hours</th>
             <td class="govuk-table__cell"><%= @decorated_course_details.course_study_mode %></td>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -27,7 +27,7 @@
         <% if @decorated_course_details.qualification_level.present? %>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">Qualification level</th>
-            <td class="govuk-table__cell"><%= @decorated_course_details.qualification_level %></td>
+            <td class="govuk-table__cell"><%= @decorated_course_details.course_qualification_level %></td>
           </tr>
         <% end %>
         <% if @decorated_course_details.study_mode.present? %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -39,7 +39,7 @@
         <% if @decorated_course_details.delivery_mode.present? %>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">Course type</th>
-            <td class="govuk-table__cell"><%= @decorated_course_details.delivery_mode %></td>
+            <td class="govuk-table__cell"><%= @decorated_course_details.course_delivery_mode %></td>
           </tr>
         <% end %>
         <% if @decorated_course_details.attendance_pattern.present? %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -24,7 +24,7 @@
             <td class="govuk-table__cell"><%= @decorated_course_details.qualification_name %></td>
           </tr>
         <% end %>
-        <% if @decorated_course_details.qualification_level.present? %>
+        <% if @decorated_course_details.course_qualification_level.present? %>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">Qualification level</th>
             <td class="govuk-table__cell"><%= @decorated_course_details.course_qualification_level %></td>
@@ -36,7 +36,7 @@
             <td class="govuk-table__cell"><%= @decorated_course_details.course_study_mode %></td>
           </tr>
         <% end %>
-        <% if @decorated_course_details.delivery_mode.present? %>
+        <% if @decorated_course_details.course_delivery_mode.present? %>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">Course type</th>
             <td class="govuk-table__cell"><%= @decorated_course_details.course_delivery_mode %></td>

--- a/spec/decorators/course_details_decorator_spec.rb
+++ b/spec/decorators/course_details_decorator_spec.rb
@@ -374,16 +374,32 @@ RSpec.describe CourseDetailsDecorator do
   end
 
   describe '#course_delivery_mode' do
-    let(:find_a_course_search_response) do
-      {
-        'deliveryMode' => 'ClassroomBased'
-      }
+    context 'when deliveryMode comes in as camelized' do
+      let(:find_a_course_search_response) do
+        {
+          'deliveryMode' => 'ClassroomBased'
+        }
+      end
+
+      it 'returns a transformed delivery_mode value' do
+        expect(
+          decorated_course_details.course_delivery_mode
+        ).to eq 'Classroom based'
+      end
     end
 
-    it 'returns a transformed delivery_mode value' do
-      expect(
-        decorated_course_details.course_delivery_mode
-      ).to eq 'Classroom based'
+    context 'when deliveryMode in not camelized' do
+      let(:find_a_course_search_response) do
+        {
+          'deliveryMode' => 'Online'
+        }
+      end
+
+      it 'returns the same value' do
+        expect(
+          decorated_course_details.course_delivery_mode
+        ).to eq 'Online'
+      end
     end
   end
 

--- a/spec/decorators/course_details_decorator_spec.rb
+++ b/spec/decorators/course_details_decorator_spec.rb
@@ -386,4 +386,34 @@ RSpec.describe CourseDetailsDecorator do
       ).to eq 'Classroom based'
     end
   end
+
+  describe '#course_study_mode' do
+    context 'when studyMode comes in as camelized' do
+      let(:find_a_course_search_response) do
+        {
+          'studyMode' => 'PartTime'
+        }
+      end
+
+      it 'returns a transformed study_mode value' do
+        expect(
+          decorated_course_details.course_study_mode
+        ).to eq 'Part-time'
+      end
+    end
+
+    context 'when studyMode comes in not camelized' do
+      let(:find_a_course_search_response) do
+        {
+          'studyMode' => 'Flexible'
+        }
+      end
+
+      it 'returns the same value' do
+        expect(
+          decorated_course_details.course_study_mode
+        ).to eq 'Flexible'
+      end
+    end
+  end
 end

--- a/spec/decorators/course_details_decorator_spec.rb
+++ b/spec/decorators/course_details_decorator_spec.rb
@@ -322,4 +322,54 @@ RSpec.describe CourseDetailsDecorator do
       end
     end
   end
+
+  describe '#course_qualification_level' do
+    context 'when qualification_level is returned X from the NCS API' do
+      let(:find_a_course_search_response) do
+        {
+          'qualification' => {
+            'qualificationLevel' => 'X'
+          }
+        }
+      end
+
+      it 'returns Unknown' do
+        expect(
+          decorated_course_details.course_qualification_level
+        ).to eq 'Unknown'
+      end
+    end
+
+    context 'when qualification_level is returned E from the NCS API' do
+      let(:find_a_course_search_response) do
+        {
+          'qualification' => {
+            'qualificationLevel' => 'E'
+          }
+        }
+      end
+
+      it 'returns Entry Level' do
+        expect(
+          decorated_course_details.course_qualification_level
+        ).to eq 'Entry Level'
+      end
+    end
+
+    context 'when qualification_level is returned as a number from the NCS API' do
+      let(:find_a_course_search_response) do
+        {
+          'qualification' => {
+            'qualificationLevel' => '7'
+          }
+        }
+      end
+
+      it 'returns Level followed by the qualification level number' do
+        expect(
+          decorated_course_details.course_qualification_level
+        ).to eq 'Level 7'
+      end
+    end
+  end
 end

--- a/spec/decorators/course_details_decorator_spec.rb
+++ b/spec/decorators/course_details_decorator_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe CourseDetailsDecorator do
       it 'returns nil' do
         expect(
           decorated_course_details.course_qualification_level
-        ).to be nil
+        ).to eq '99'
       end
     end
 
@@ -397,10 +397,10 @@ RSpec.describe CourseDetailsDecorator do
         }
       end
 
-      it 'returns nil' do
+      it 'returns the actual value' do
         expect(
           decorated_course_details.course_qualification_level
-        ).to be nil
+        ).to eq '99XY'
       end
     end
 
@@ -472,7 +472,7 @@ RSpec.describe CourseDetailsDecorator do
       it 'returns nil' do
         expect(
           decorated_course_details.course_delivery_mode
-        ).to be nil
+        ).to eq 'Something not documented'
       end
     end
 
@@ -544,7 +544,7 @@ RSpec.describe CourseDetailsDecorator do
       it 'returns nil' do
         expect(
           decorated_course_details.course_study_mode
-        ).to be nil
+        ).to eq 'Some weird value'
       end
     end
 

--- a/spec/decorators/course_details_decorator_spec.rb
+++ b/spec/decorators/course_details_decorator_spec.rb
@@ -431,5 +431,33 @@ RSpec.describe CourseDetailsDecorator do
         ).to eq 'Flexible'
       end
     end
+
+    context 'when studyMode comes in as Undefined' do
+      let(:find_a_course_search_response) do
+        {
+          'studyMode' => 'Undefined'
+        }
+      end
+
+      it 'returns nil' do
+        expect(
+          decorated_course_details.course_study_mode
+        ).to be nil
+      end
+    end
+
+    context 'when studyMode comes in as nil' do
+      let(:find_a_course_search_response) do
+        {
+          'studyMode' => nil
+        }
+      end
+
+      it 'returns nil' do
+        expect(
+          decorated_course_details.course_study_mode
+        ).to be nil
+      end
+    end
   end
 end

--- a/spec/decorators/course_details_decorator_spec.rb
+++ b/spec/decorators/course_details_decorator_spec.rb
@@ -372,4 +372,18 @@ RSpec.describe CourseDetailsDecorator do
       end
     end
   end
+
+  describe '#course_delivery_mode' do
+    let(:find_a_course_search_response) do
+      {
+        'deliveryMode' => 'ClassroomBased'
+      }
+    end
+
+    it 'returns a transformed delivery_mode value' do
+      expect(
+        decorated_course_details.course_delivery_mode
+      ).to eq 'Classroom based'
+    end
+  end
 end

--- a/spec/decorators/course_details_decorator_spec.rb
+++ b/spec/decorators/course_details_decorator_spec.rb
@@ -131,8 +131,8 @@ RSpec.describe CourseDetailsDecorator do
         }
       end
 
-      it 'returns the price with the currency symbol attached' do
-        expect(decorated_course_details.price).to eq '£210.0'
+      it 'returns the price with 2 decimal places and the currency symbol attached' do
+        expect(decorated_course_details.price).to eq '£210.00'
       end
     end
   end

--- a/spec/decorators/course_details_decorator_spec.rb
+++ b/spec/decorators/course_details_decorator_spec.rb
@@ -371,24 +371,84 @@ RSpec.describe CourseDetailsDecorator do
         ).to eq 'Level 7'
       end
     end
+
+    context 'when qualification_level is outside the 1..8 range' do
+      let(:find_a_course_search_response) do
+        {
+          'qualification' => {
+            'qualificationLevel' => '99'
+          }
+        }
+      end
+
+      it 'returns nil' do
+        expect(
+          decorated_course_details.course_qualification_level
+        ).to be nil
+      end
+    end
+
+    context 'when qualification_level is not a documented value' do
+      let(:find_a_course_search_response) do
+        {
+          'qualification' => {
+            'qualificationLevel' => '99XY'
+          }
+        }
+      end
+
+      it 'returns nil' do
+        expect(
+          decorated_course_details.course_qualification_level
+        ).to be nil
+      end
+    end
+
+    context 'when qualification_level is nil' do
+      let(:find_a_course_search_response) do
+        {
+          'qualification' => nil
+        }
+      end
+
+      it 'returns nil' do
+        expect(
+          decorated_course_details.course_qualification_level
+        ).to be nil
+      end
+    end
   end
 
   describe '#course_delivery_mode' do
-    context 'when deliveryMode comes in as camelized' do
+    context 'when deliveryMode is ClassroomBased' do
       let(:find_a_course_search_response) do
         {
           'deliveryMode' => 'ClassroomBased'
         }
       end
 
-      it 'returns a transformed delivery_mode value' do
+      it 'returns Classroom based' do
         expect(
           decorated_course_details.course_delivery_mode
         ).to eq 'Classroom based'
       end
     end
 
-    context 'when deliveryMode in not camelized' do
+    context 'when deliveryMode is WorkBased' do
+      let(:find_a_course_search_response) do
+        {
+          'deliveryMode' => 'WorkBased'
+        }
+      end
+
+      it 'returns Work based' do
+        expect(
+          decorated_course_details.course_delivery_mode
+        ).to eq 'Work based'
+      end
+    end
+
+    context 'when deliveryMode is Online' do
       let(:find_a_course_search_response) do
         {
           'deliveryMode' => 'Online'
@@ -401,34 +461,90 @@ RSpec.describe CourseDetailsDecorator do
         ).to eq 'Online'
       end
     end
+
+    context 'when deliveryMode is an undocumented value' do
+      let(:find_a_course_search_response) do
+        {
+          'deliveryMode' => 'Something not documented'
+        }
+      end
+
+      it 'returns nil' do
+        expect(
+          decorated_course_details.course_delivery_mode
+        ).to be nil
+      end
+    end
+
+    context 'when deliveryMode is nil' do
+      let(:find_a_course_search_response) do
+        {
+          'deliveryMode' => nil
+        }
+      end
+
+      it 'returns nil' do
+        expect(
+          decorated_course_details.course_delivery_mode
+        ).to be nil
+      end
+    end
   end
 
   describe '#course_study_mode' do
-    context 'when studyMode comes in as camelized' do
+    context 'when studyMode is PartTime' do
       let(:find_a_course_search_response) do
         {
           'studyMode' => 'PartTime'
         }
       end
 
-      it 'returns a transformed study_mode value' do
+      it 'returns Part-time' do
         expect(
           decorated_course_details.course_study_mode
         ).to eq 'Part-time'
       end
     end
 
-    context 'when studyMode comes in not camelized' do
+    context 'when studyMode is FullTime' do
+      let(:find_a_course_search_response) do
+        {
+          'studyMode' => 'FullTime'
+        }
+      end
+
+      it 'returns Full-time' do
+        expect(
+          decorated_course_details.course_study_mode
+        ).to eq 'Full-time'
+      end
+    end
+
+    context 'when studyMode is Flexible' do
       let(:find_a_course_search_response) do
         {
           'studyMode' => 'Flexible'
         }
       end
 
-      it 'returns the same value' do
+      it 'returns Flexible' do
         expect(
           decorated_course_details.course_study_mode
         ).to eq 'Flexible'
+      end
+    end
+
+    context 'when studyMode is an undocumented value' do
+      let(:find_a_course_search_response) do
+        {
+          'studyMode' => 'Some weird value'
+        }
+      end
+
+      it 'returns nil' do
+        expect(
+          decorated_course_details.course_study_mode
+        ).to be nil
       end
     end
 


### PR DESCRIPTION
### Context
Following formatting rules are introduced:

1. Add a 0 to prices like "£362.0"
2. Map QualificationLevel

 ```ruby
     E = Entry Level
     X = Unknown
     1 - Level 1
     2 - Level 2
      ...
```

3. Map CourseHours

```ruby
    PartTime = Part-time
    FullTime = Full-time
    Flexible = Flexible
```

4. Map CourseType

```ruby
    ClassroomBased = Classroom based
    WorkBased = Work based
    Online = Online
```

5. Don’t show CourseHours row if CourseHours = undefined

### Screenshots

![Screen Shot 2020-03-19 at 13 45 06](https://user-images.githubusercontent.com/1955084/77073844-cca5c800-69e7-11ea-8660-b1abbedde74b.png)

### Ticket
https://dfedigital.atlassian.net/browse/GET-1084