### PR TITLE
Add the accordion component for job profiles page

### DIFF
--- a/app/decorators/job_profile_decorator.rb
+++ b/app/decorators/job_profile_decorator.rb
@@ -78,11 +78,7 @@ class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLengt
     mutate_apprenticeship_content if key == :apprenticeship
     mutate_html_body
 
-    html_body_with_no_links = strip_links(@doc.to_html).html_safe
-
-    return html_body_with_no_links if key == :apprenticeship
-
-    separator_line.concat(html_body_with_no_links)
+    strip_links(@doc.to_html).html_safe
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
@@ -144,17 +140,15 @@ class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLengt
   end
 
   def mutate_html_body
-    mutate_h2_tags
     mutate_h3_tags
     mutate_h4_tags
+    remove_h2_tags
     mutate_p_tags
     mutate_ul_tags
   end
 
-  def mutate_h2_tags
-    @doc.xpath('h2').each do |h2|
-      h2['class'] = 'govuk-heading-m'
-    end
+  def remove_h2_tags
+    @doc.xpath('h2').map(&:remove)
   end
 
   def mutate_h3_tags

--- a/app/decorators/job_profile_decorator.rb
+++ b/app/decorators/job_profile_decorator.rb
@@ -20,7 +20,7 @@ class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLengt
     working_environment: "//section[@id='WhatYouWillDo']//section[contains(@class, 'job-profile-subsection') and contains(@id, 'workingenvironment')]",
     career_path: "//section[@id='CareerPathAndProgression']",
     restrictions_and_requirements: "//section[@id='Skills']//section[contains(@class, 'job-profile-subsection') and (contains(@id, 'restrictions'))]",
-    career_tips: "//section[contains(@class, 'job-profile-subsection') and contains (@id, 'moreinfo')]//div[@class='job-profile-subsection-content']",
+    more_information: "//section[contains(@class, 'job-profile-subsection') and contains (@id, 'moreinfo')]//div[@class='job-profile-subsection-content']",
     other_routes: "//section[contains(@class, 'job-profile-subsection') and contains (@id, 'otherroutes')]"
   }.freeze
   # rubocop:enable Metrics/LineLength
@@ -78,7 +78,7 @@ class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLengt
     @fragment_section = Nokogiri::HTML(doc.to_html)
 
     mutate_apprenticeship_content if key == :apprenticeship
-    mutate_html_body
+    mutate_html_body_for(key)
 
     strip_links(@fragment_section.to_html).html_safe
   end
@@ -141,18 +141,22 @@ class JobProfileDecorator < SimpleDelegator # rubocop:disable Metrics/ClassLengt
     entry_requirements.remove
   end
 
-  def mutate_html_body
+  def mutate_html_body_for(key)
     mutate_h3_tags
     mutate_h4_tags
-    remove_h2_tags
+    mutate_h2_tags(key)
     mutate_p_tags
     mutate_ul_tags
   end
 
-  def remove_h2_tags
+  def mutate_h2_tags(key)
     h2_instances = @fragment_section.xpath('//h2')
 
-    h2_instances.first.remove if h2_instances.present?
+    return unless h2_instances.present?
+
+    h2_instances.first.remove unless key == :more_information && h2_instances.count > 1
+
+    h2_instances.each { |h2_tag| h2_tag['class'] = 'govuk-heading-s' }
   end
 
   def mutate_h3_tags

--- a/app/views/courses/_search_filter.html.erb
+++ b/app/views/courses/_search_filter.html.erb
@@ -1,13 +1,13 @@
-<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-courses">
   <div class="govuk-accordion__section ">
     <div class="govuk-accordion__section-header">
       <h2 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+        <span class="govuk-accordion__section-button" id="accordion-courses-heading-1">
           Filters
         </span>
       </h2>
     </div>
-    <div id="accordion-default-content-1" class="govuk-accordion__section-content govuk-!-padding-top-0" aria-labelledby="accordion-default-heading-1">
+    <div id="accordion-courses-content-1" class="govuk-accordion__section-content govuk-!-padding-top-0" aria-labelledby="accordion-courses-heading-1">
       <%= form_tag courses_path do %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-one-half">

--- a/app/views/courses/_search_filter.html.erb
+++ b/app/views/courses/_search_filter.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-courses">
+<div class="govuk-accordion govuk-accordion-courses" data-module="govuk-accordion" id="accordion-courses">
   <div class="govuk-accordion__section ">
     <div class="govuk-accordion__section-header">
       <h2 class="govuk-accordion__section-heading">

--- a/app/views/job_profiles/_apply_to_become.html.erb
+++ b/app/views/job_profiles/_apply_to_become.html.erb
@@ -1,4 +1,4 @@
-<div class="action-plan-section govuk-!-margin-bottom-2">
+<div class="govuk-!-margin-bottom-2">
   <h2 class="govuk-heading-m govuk-!-margin-top-4">Becoming <%= @job_profile.become %></h2>
   <% if @job_vacancy_count.present? %>
     <% if @job_vacancy_count > 0 %>

--- a/app/views/job_profiles/_apprenticeship.html.erb
+++ b/app/views/job_profiles/_apprenticeship.html.erb
@@ -4,12 +4,12 @@
   <div class="govuk-accordion__section ">
     <div class="govuk-accordion__section-header">
       <h2 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= item_order %>">
+        <span class="govuk-accordion__section-button" id="accordion-<%= @job_profile.slug %>-heading-<%= item_order %>">
           Apprenticeship
         </span>
       </h2>
     </div>
-    <div id="accordion-default-content-<%= item_order %>" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-<%= item_order %>">
+    <div id="accordion-<%= @job_profile.slug %>-content-<%= item_order %>" class="govuk-accordion__section-content" aria-labelledby="accordion-<%= @job_profile.slug %>-heading-<%= item_order %>">
       <p class="govuk-body-m">You can do an apprenticeship at any age. You may be able to earn the same money and work at the same level as you do now.</p>
       <%= apprenticeship_section.html_safe %>
     </div>

--- a/app/views/job_profiles/_dynamic_section.html.erb
+++ b/app/views/job_profiles/_dynamic_section.html.erb
@@ -1,17 +1,16 @@
-<% apprenticeship_section = @job_profile.section(:apprenticeship) %>
+<% body = @job_profile.section(key) %>
 
-<% if apprenticeship_section.present? %>
+<% if body.present? %>
   <div class="govuk-accordion__section ">
     <div class="govuk-accordion__section-header">
       <h2 class="govuk-accordion__section-heading">
         <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= item_order %>">
-          Apprenticeship
+          <%= title %>
         </span>
       </h2>
     </div>
     <div id="accordion-default-content-<%= item_order %>" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-<%= item_order %>">
-      <p class="govuk-body-m">You can do an apprenticeship at any age. You may be able to earn the same money and work at the same level as you do now.</p>
-      <%= apprenticeship_section.html_safe %>
+      <%= body.html_safe %>
     </div>
-  </div>  
+  </div>
 <% end %>

--- a/app/views/job_profiles/_dynamic_section.html.erb
+++ b/app/views/job_profiles/_dynamic_section.html.erb
@@ -4,12 +4,12 @@
   <div class="govuk-accordion__section govuk-accordion__section-custom">
     <div class="govuk-accordion__section-header">
       <h2 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= item_order %>">
+        <span class="govuk-accordion__section-button" id="accordion-<%= @job_profile.slug %>-heading-<%= item_order %>">
           <%= title %>
         </span>
       </h2>
     </div>
-    <div id="accordion-default-content-<%= item_order %>" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-<%= item_order %>">
+    <div id="accordion-<%= @job_profile.slug %>-content-<%= item_order %>" class="govuk-accordion__section-content" aria-labelledby="accordion-<%= @job_profile.slug %>-heading-<%= item_order %>">
       <%= body.html_safe %>
     </div>
   </div>

--- a/app/views/job_profiles/_dynamic_section.html.erb
+++ b/app/views/job_profiles/_dynamic_section.html.erb
@@ -1,7 +1,7 @@
 <% body = @job_profile.section(key) %>
 
 <% if body.present? %>
-  <div class="govuk-accordion__section ">
+  <div class="govuk-accordion__section">
     <div class="govuk-accordion__section-header">
       <h2 class="govuk-accordion__section-heading">
         <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= item_order %>">

--- a/app/views/job_profiles/_dynamic_section.html.erb
+++ b/app/views/job_profiles/_dynamic_section.html.erb
@@ -1,7 +1,7 @@
 <% body = @job_profile.section(key) %>
 
 <% if body.present? %>
-  <div class="govuk-accordion__section">
+  <div class="govuk-accordion__section govuk-accordion__section-custom">
     <div class="govuk-accordion__section-header">
       <h2 class="govuk-accordion__section-heading">
         <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= item_order %>">

--- a/app/views/job_profiles/_highlights.html.erb
+++ b/app/views/job_profiles/_highlights.html.erb
@@ -27,4 +27,3 @@
     </div>
   <% end %>
 </div>
-<hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-4 govuk-!-margin-top-5">

--- a/app/views/job_profiles/_relevant_sections.html.erb
+++ b/app/views/job_profiles/_relevant_sections.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-<%= @job_profile.slug %>">
   <%= render partial: 'skills_section',  locals: { item_order: 1 } %>
   <%= render partial: 'dynamic_section', locals: { item_order: 2, key: :day_to_day_tasks, title: 'Day-to-day tasks' } %>
   <%= render partial: 'dynamic_section', locals: { item_order: 3, key: :working_environment, title: 'Working environment' } %>

--- a/app/views/job_profiles/_relevant_sections.html.erb
+++ b/app/views/job_profiles/_relevant_sections.html.erb
@@ -6,7 +6,7 @@
   <%= render partial: 'apprenticeship',  locals: { item_order: 5 } %>
   <%= render partial: 'dynamic_section', locals: { item_order: 6, key: :career_path, title: 'Career path and progression' } %>
   <%= render partial: 'dynamic_section', locals: { item_order: 7, key: :other_routes, title: 'Other routes' } %>
-  <%= render partial: 'dynamic_section', locals: { item_order: 8, key: :career_tips, title: 'Career tips' } %>
+  <%= render partial: 'dynamic_section', locals: { item_order: 8, key: :more_information, title: 'More Information' } %>
   <%= render partial: 'dynamic_section', locals: { item_order: 9, key: :work, title: 'Work' } %>
   <%= render partial: 'dynamic_section', locals: { item_order: 10, key: :restrictions_and_requirements, title: 'Restrictions and requirements' } %>
 </div>

--- a/app/views/job_profiles/_relevant_sections.html.erb
+++ b/app/views/job_profiles/_relevant_sections.html.erb
@@ -1,11 +1,16 @@
-<%= render 'skills_section' %>
-<%= @job_profile.section(:day_to_day_tasks).html_safe %>
-<%= @job_profile.section(:working_environment).html_safe %>
-<%= @job_profile.section(:direct_application).html_safe %>
-<%= render 'apprenticeship' %>
-<%= @job_profile.section(:career_path).html_safe %>
-<%= @job_profile.section(:other_routes).html_safe %>
-<%= @job_profile.section(:career_tips).html_safe %>
-<%= @job_profile.section(:work).html_safe %>
-<%= @job_profile.section(:restrictions_and_requirements).html_safe %>
-<%= render 'apply_to_become' %>
+<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+  <div class="govuk-accordion__controls">
+    <button type="button" class="govuk-accordion__open-all" aria-expanded="false">Open all<span class="govuk-visually-hidden"> sections</span></button>
+  </div>
+  <%= render partial: 'skills_section',  locals: { item_order: 1 } %>
+  <%= render partial: 'dynamic_section', locals: { item_order: 2, key: :day_to_day_tasks, title: 'Day-to-day tasks' } %>
+  <%= render partial: 'dynamic_section', locals: { item_order: 3, key: :working_environment, title: 'Working environment' } %>
+  <%= render partial: 'dynamic_section', locals: { item_order: 4, key: :direct_application, title: 'Direct application' } %>
+  <%= render partial: 'apprenticeship',  locals: { item_order: 5 } %>
+  <%= render partial: 'dynamic_section', locals: { item_order: 6, key: :career_path, title: 'Career path and progression' } %>
+  <%= render partial: 'dynamic_section', locals: { item_order: 7, key: :other_routes, title: 'Other routes' } %>
+  <%= render partial: 'dynamic_section', locals: { item_order: 8, key: :career_tips, title: 'Career tips' } %>
+  <%= render partial: 'dynamic_section', locals: { item_order: 9, key: :work, title: 'Work' } %>
+  <%= render partial: 'dynamic_section', locals: { item_order: 10, key: :restrictions_and_requirements, title: 'Restrictions and requirements' } %>
+  <%= render 'apply_to_become' %>
+</div>

--- a/app/views/job_profiles/_relevant_sections.html.erb
+++ b/app/views/job_profiles/_relevant_sections.html.erb
@@ -1,7 +1,4 @@
 <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-  <div class="govuk-accordion__controls">
-    <button type="button" class="govuk-accordion__open-all" aria-expanded="false">Open all<span class="govuk-visually-hidden"> sections</span></button>
-  </div>
   <%= render partial: 'skills_section',  locals: { item_order: 1 } %>
   <%= render partial: 'dynamic_section', locals: { item_order: 2, key: :day_to_day_tasks, title: 'Day-to-day tasks' } %>
   <%= render partial: 'dynamic_section', locals: { item_order: 3, key: :working_environment, title: 'Working environment' } %>

--- a/app/views/job_profiles/_relevant_sections.html.erb
+++ b/app/views/job_profiles/_relevant_sections.html.erb
@@ -9,5 +9,5 @@
   <%= render partial: 'dynamic_section', locals: { item_order: 8, key: :career_tips, title: 'Career tips' } %>
   <%= render partial: 'dynamic_section', locals: { item_order: 9, key: :work, title: 'Work' } %>
   <%= render partial: 'dynamic_section', locals: { item_order: 10, key: :restrictions_and_requirements, title: 'Restrictions and requirements' } %>
-  <%= render 'apply_to_become' %>
 </div>
+<%= render 'apply_to_become' %>

--- a/app/views/job_profiles/_skills_section.html.erb
+++ b/app/views/job_profiles/_skills_section.html.erb
@@ -1,12 +1,12 @@
 <div class="govuk-accordion__section ">
   <div class="govuk-accordion__section-header">
     <h2 class="govuk-accordion__section-heading">
-      <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= item_order %>">
+      <span class="govuk-accordion__section-button" id="accordion-<%= @job_profile.slug %>-heading-<%= item_order %>">
         Skills and knowledge
       </span>
     </h2>
   </div>
-  <div id="accordion-default-content-<%= item_order %>" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-<%= item_order %>">
+  <div id="accordion-<%= @job_profile.slug %>-content-<%= item_order %>" class="govuk-accordion__section-content" aria-labelledby="accordion-<%= @job_profile.slug %>-heading-<%= item_order %>">
     <p class="govuk-body-m">Employers may ask for these skills for this type of work.</p>
     <% if @existing_skills.any? %>
       <h3 class="govuk-heading-s">Skills you have</h3>

--- a/app/views/job_profiles/_skills_section.html.erb
+++ b/app/views/job_profiles/_skills_section.html.erb
@@ -1,17 +1,27 @@
-<h2 class="govuk-heading-m">Skills and knowledge</h2>
-<p class="govuk-body-m">Employers may ask for these skills for this type of work.</p>
-<% if @existing_skills.any? %>
-  <h3 class="govuk-heading-s">Skills you have</h3>
-  <ul class="govuk-list govuk-list--bullet">
-    <%= render partial: "skills/skill", collection: @existing_skills, as: :name %>
-  </ul>
-<% end %>
-<% if @skills_to_develop.any? %>
-  <h3 class="govuk-heading-s">Skills you may need to develop</h3>
-  <ul class="govuk-list govuk-list--bullet">
-    <%= render partial: "skills/skill", collection: @skills_to_develop, as: :name %>
-  </ul>
-<% end %>
-<p class="govuk-body-m">
-  You may not need all of these skills to apply for this type of work. Select this type of work and we’ll help you create an action plan to fill any skills gaps and change jobs. Many people can train for free and you maybe able to get help with training costs such as travel and childcare expenses.
-</p>
+<div class="govuk-accordion__section ">
+  <div class="govuk-accordion__section-header">
+    <h2 class="govuk-accordion__section-heading">
+      <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= item_order %>">
+        Skills and knowledge
+      </span>
+    </h2>
+  </div>
+  <div id="accordion-default-content-<%= item_order %>" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-<%= item_order %>">
+    <p class="govuk-body-m">Employers may ask for these skills for this type of work.</p>
+    <% if @existing_skills.any? %>
+      <h3 class="govuk-heading-s">Skills you have</h3>
+      <ul class="govuk-list govuk-list--bullet">
+        <%= render partial: "skills/skill", collection: @existing_skills, as: :name %>
+      </ul>
+    <% end %>
+    <% if @skills_to_develop.any? %>
+      <h3 class="govuk-heading-s">Skills you may need to develop</h3>
+      <ul class="govuk-list govuk-list--bullet">
+        <%= render partial: "skills/skill", collection: @skills_to_develop, as: :name %>
+      </ul>
+    <% end %>
+    <p class="govuk-body-m">
+      You may not need all of these skills to apply for this type of work. Select this type of work and we’ll help you create an action plan to fill any skills gaps and change jobs. Many people can train for free and you maybe able to get help with training costs such as travel and childcare expenses.
+    </p>
+  </div>
+</div>

--- a/app/views/pages/_advice_on_finding_work.html.erb
+++ b/app/views/pages/_advice_on_finding_work.html.erb
@@ -1,12 +1,12 @@
 <div class="govuk-accordion__section">
   <div class="govuk-accordion__section-header">
     <h2 class="govuk-accordion__section-heading">
-      <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= item_order %>">
+      <span class="govuk-accordion__section-button" id="accordion-<%= key %>-heading-<%= item_order %>">
         Get more advice on finding work
       </span>
     </h2>
   </div>
-  <div id="accordion-default-content-<%= item_order %>" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-<%= item_order %>">
+  <div id="accordion-<%= key %>-content-<%= item_order %>" class="govuk-accordion__section-content" aria-labelledby="accordion-<%= key %>-heading-<%= item_order %>">
     <p class="govuk-body">For more advice on how to look for and apply for jobs, visit the National Careers Service. Selecting this option will take you to another government service.</p>
     <%= link_to 'Go to National Careers Service', 'https://nationalcareers.service.gov.uk/get-a-job', class: 'govuk-link' %>
   </div>

--- a/app/views/pages/_advice_on_finding_work.html.erb
+++ b/app/views/pages/_advice_on_finding_work.html.erb
@@ -1,16 +1,13 @@
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
-
-<h2 class="govuk-heading-l">Get more advice on finding work</h2>
-<p class="govuk-body">For more advice on how to look for and apply for jobs, visit the National Careers Service. Selecting this option will take you to another government service.</p>
-<%= link_to 'Go to National Careers Service', 'https://nationalcareers.service.gov.uk/get-a-job', class: 'govuk-link' %>
-
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
-
-<div class="govuk-!-margin-bottom-2">
-  <%= link_to '#', class: 'govuk-link govuk-link--no-visited-state govuk-body-s' do %>
-    <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
-      <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
-    </svg>
-    Back to top
-  <% end %>
+<div class="govuk-accordion__section">
+  <div class="govuk-accordion__section-header">
+    <h2 class="govuk-accordion__section-heading">
+      <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= item_order %>">
+        Get more advice on finding work
+      </span>
+    </h2>
+  </div>
+  <div id="accordion-default-content-<%= item_order %>" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-<%= item_order %>">
+    <p class="govuk-body">For more advice on how to look for and apply for jobs, visit the National Careers Service. Selecting this option will take you to another government service.</p>
+    <%= link_to 'Go to National Careers Service', 'https://nationalcareers.service.gov.uk/get-a-job', class: 'govuk-link' %>
+  </div>
 </div>

--- a/app/views/pages/cover_letter_advice.html.erb
+++ b/app/views/pages/cover_letter_advice.html.erb
@@ -54,12 +54,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
               Show your enthusiasm
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+        <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
           <p class="govuk-body">Show how keen you are to get this job and work for this employer. Many employers skim-read covering letters, so the opening paragraph is your opportunity to impress them with how much you know about their work.</p>
           <p class="govuk-body">Explain why you believe you're the right person for the company, and what makes you highly motivated to work for them. Show you're familiar with their products and services, and recent news about them. You could also explain that you're enthusiastic about working for them because you share their work values, culture and style.</p>
         </div>
@@ -68,12 +68,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
               Take the employer's point of view
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+        <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
           <p class="govuk-body">Imagine you're the employer and ask yourself:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>what would make a candidate stand out?</li>
@@ -89,12 +89,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
               Identify your unique selling points
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
+        <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
           <p class="govuk-body">Be positive about who you are and what you have to offer, like your ability to learn quickly, your experience if you're older, or your ideas, enthusiasm and willingness to learn if you've recently finished college. Highlight to the employer what special skills, knowledge or expertise you can bring.</p>
         </div>
       </div>
@@ -102,12 +102,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-5">
               Promote your transferable skills
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
+        <div id="accordion-default-content-5" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-5">
           <p class="govuk-body">Think about a job you've done before and the job you want to get into, and try to identify the skills you need for both, like working to deadlines, managing budgets and working well with a wide range of people.</p>
         </div>
       </div>
@@ -115,12 +115,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-5">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-6">
               Sign off
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-5" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-5">
+        <div id="accordion-default-content-6" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-6">
           <p class="govuk-body">Lastly, you should finish your letter by bringing it all together.</p>
           <p class="govuk-body">You should:</p>
           <ul class="govuk-list govuk-list--bullet">
@@ -132,7 +132,7 @@
         </div>
       </div>
 
-      <%= render partial: 'advice_on_finding_work', locals: { item_order: 6 } %>
+      <%= render partial: 'advice_on_finding_work', locals: { item_order: 7 } %>
     </div>
 
     <div class="govuk-!-margin-bottom-2">

--- a/app/views/pages/cover_letter_advice.html.erb
+++ b/app/views/pages/cover_letter_advice.html.erb
@@ -109,18 +109,8 @@
         </div>
         <div id="accordion-default-content-5" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-5">
           <p class="govuk-body">Think about a job you've done before and the job you want to get into, and try to identify the skills you need for both, like working to deadlines, managing budgets and working well with a wide range of people.</p>
-        </div>
-      </div>
-
-      <div class="govuk-accordion__section">
-        <div class="govuk-accordion__section-header">
-          <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-6">
-              Sign off
-            </span>
-          </h2>
-        </div>
-        <div id="accordion-default-content-6" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-6">
+          <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
+          <h2 class="govuk-heading-l">Sign off</h2>
           <p class="govuk-body">Lastly, you should finish your letter by bringing it all together.</p>
           <p class="govuk-body">You should:</p>
           <ul class="govuk-list govuk-list--bullet">
@@ -132,7 +122,7 @@
         </div>
       </div>
 
-      <%= render partial: 'advice_on_finding_work', locals: { item_order: 7 } %>
+      <%= render partial: 'advice_on_finding_work', locals: { item_order: 6 } %>
     </div>
 
     <div class="govuk-!-margin-bottom-2">

--- a/app/views/pages/cover_letter_advice.html.erb
+++ b/app/views/pages/cover_letter_advice.html.erb
@@ -14,8 +14,6 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
-
     <p class="govuk-body">Your CV and covering letter are your chance to sell yourself to employers.</p>
     <p class="govuk-body">To create a good first impression, make sure your covering letter:</p>
     <ul class="govuk-list govuk-list--bullet">
@@ -25,67 +23,121 @@
     </ul>
     <p class="govuk-body">A good covering letter will show that you've done your research, you know what the job involves and what the employer's looking for.</p>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
+    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+              Covering letters - the main rules
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+          <p class="govuk-body">Your covering letter should be short and to the point. Write it on a computer as it makes it easier to make any changes or corrections before you send it.</p>
+          <p class="govuk-body">Highlight your most relevant skills and achievements, and explain any gaps in your CV, like periods of unemployment, time spent in prison, travelling or being a carer. For each of these explain what you learned from the experience.</p>
+          <p class="govuk-body">Make specific reference to the employer - don't send out identical covering letters with no organisation details. Use the right language and tone, and the same font and text size as on your CV. Always check for spelling and grammatical errors.</p>
+          <p class="govuk-body">If you mention your disability at the application stage it can give you an opportunity to talk about the transferable skills you've developed as a result of dealing with your disability. But you don't need to mention your disability if you don't want to.</p>
+          <p class="govuk-body">It's important to address your letter to the person named in the advert, if there is one. If there isn't, find out the name of the recruiter or the head of the department you want to work for.</p>
+          <p class="govuk-body">You also need to:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>spell any names correctly and address them with their preferred title, whether it's Dr, Mr, Mrs, or Ms</li>
+            <li>explain why you're writing</li>
+            <li>be clear about what you're applying for by including the full title of the job, the reference number, and where you saw it advertised</li>
+            <li>research the company and the job to find out the main skills the employer is looking for</li>
+            <li>give evidence to show that you have the right personal qualities, experience, qualifications, and skills for the role</li>
+            <li>include real examples of when you've used these skills, and highlight any major achievements, like completing training courses</li>
+            <li>present your skills in a way that shows how giving you the job will benefit the organisation</li>
+          </ul>
+        </div>
+      </div>
 
-    <h2 class="govuk-heading-l">Covering letters - the main rules</h2>
-    <p class="govuk-body">Your covering letter should be short and to the point. Write it on a computer as it makes it easier to make any changes or corrections before you send it.</p>
-    <p class="govuk-body">Highlight your most relevant skills and achievements, and explain any gaps in your CV, like periods of unemployment, time spent in prison, travelling or being a carer. For each of these explain what you learned from the experience.</p>
-    <p class="govuk-body">Make specific reference to the employer - don't send out identical covering letters with no organisation details. Use the right language and tone, and the same font and text size as on your CV. Always check for spelling and grammatical errors.</p>
-    <p class="govuk-body">If you mention your disability at the application stage it can give you an opportunity to talk about the transferable skills you've developed as a result of dealing with your disability. But you don't need to mention your disability if you don't want to.</p>
-    <p class="govuk-body">It's important to address your letter to the person named in the advert, if there is one. If there isn't, find out the name of the recruiter or the head of the department you want to work for.</p>
-    <p class="govuk-body">You also need to:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>spell any names correctly and address them with their preferred title, whether it's Dr, Mr, Mrs, or Ms</li>
-      <li>explain why you're writing</li>
-      <li>be clear about what you're applying for by including the full title of the job, the reference number, and where you saw it advertised</li>
-      <li>research the company and the job to find out the main skills the employer is looking for</li>
-      <li>give evidence to show that you have the right personal qualities, experience, qualifications, and skills for the role</li>
-      <li>include real examples of when you've used these skills, and highlight any major achievements, like completing training courses</li>
-      <li>present your skills in a way that shows how giving you the job will benefit the organisation</li>
-    </ul>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+              Show your enthusiasm
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+          <p class="govuk-body">Show how keen you are to get this job and work for this employer. Many employers skim-read covering letters, so the opening paragraph is your opportunity to impress them with how much you know about their work.</p>
+          <p class="govuk-body">Explain why you believe you're the right person for the company, and what makes you highly motivated to work for them. Show you're familiar with their products and services, and recent news about them. You could also explain that you're enthusiastic about working for them because you share their work values, culture and style.</p>
+        </div>
+      </div>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+              Take the employer's point of view
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+          <p class="govuk-body">Imagine you're the employer and ask yourself:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>what would make a candidate stand out?</li>
+            <li>what would be my ideal candidate?</li>
+            <li>why would I hire the person who sent this covering letter?</li>
+          </ul>
+          <p class="govuk-body">Cover all the essential points clearly - remember employers are busy and might not have the time to read a long letter.</p>
+          <p class="govuk-body">Use the same language that the employer uses on their website, in job adverts and any other communications. Use the same tone as the employer, but remember to keep it professional.</p>
+          <p class="govuk-body">Present your skills in a way that shows how giving you the job will benefit their company. You can do this by cutting down on the number of times you use the word 'I' and increasing the number of times you use 'you' and 'your organisation'.</p>
+        </div>
+      </div>
 
-    <h2 class="govuk-heading-l">Show your enthusiasm</h2>
-    <p class="govuk-body">Show how keen you are to get this job and work for this employer. Many employers skim-read covering letters, so the opening paragraph is your opportunity to impress them with how much you know about their work.</p>
-    <p class="govuk-body">Explain why you believe you're the right person for the company, and what makes you highly motivated to work for them. Show you're familiar with their products and services, and recent news about them. You could also explain that you're enthusiastic about working for them because you share their work values, culture and style.</p>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
+              Identify your unique selling points
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
+          <p class="govuk-body">Be positive about who you are and what you have to offer, like your ability to learn quickly, your experience if you're older, or your ideas, enthusiasm and willingness to learn if you've recently finished college. Highlight to the employer what special skills, knowledge or expertise you can bring.</p>
+        </div>
+      </div>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
+              Promote your transferable skills
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
+          <p class="govuk-body">Think about a job you've done before and the job you want to get into, and try to identify the skills you need for both, like working to deadlines, managing budgets and working well with a wide range of people.</p>
+        </div>
+      </div>
 
-    <h2 class="govuk-heading-l">Take the employer's point of view</h2>
-    <p class="govuk-body">Imagine you're the employer and ask yourself:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>what would make a candidate stand out?</li>
-      <li>what would be my ideal candidate?</li>
-      <li>why would I hire the person who sent this covering letter?</li>
-    </ul>
-    <p class="govuk-body">Cover all the essential points clearly - remember employers are busy and might not have the time to read a long letter.</p>
-    <p class="govuk-body">Use the same language that the employer uses on their website, in job adverts and any other communications. Use the same tone as the employer, but remember to keep it professional.</p>
-    <p class="govuk-body">Present your skills in a way that shows how giving you the job will benefit their company. You can do this by cutting down on the number of times you use the word 'I' and increasing the number of times you use 'you' and 'your organisation'.</p>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-5">
+              Sign off
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-5" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-5">
+          <p class="govuk-body">Lastly, you should finish your letter by bringing it all together.</p>
+          <p class="govuk-body">You should:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>invite the employer to get more details about you from your attached or enclosed CV</li>
+            <li>say you're looking forward to hearing from them, if you're replying to an advertised vacancy</li>
+            <li>say you'll wait for their call, or that you'll contact them in a week or two, if you're applying on the off-chance of a job</li>
+            <li>explain how you'd like to be contacted, for example by phone, email or post, and make sure your contact details are correct on your covering letter and CV</li>
+          </ul>
+        </div>
+      </div>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
+      <%= render partial: 'advice_on_finding_work', locals: { item_order: 6 } %>
+    </div>
 
-    <h2 class="govuk-heading-l">Identify your unique selling points</h2>
-    <p class="govuk-body">Be positive about who you are and what you have to offer, like your ability to learn quickly, your experience if you're older, or your ideas, enthusiasm and willingness to learn if you've recently finished college. Highlight to the employer what special skills, knowledge or expertise you can bring.</p>
-
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
-
-    <h2 class="govuk-heading-l">Promote your transferable skills</h2>
-    <p class="govuk-body">Think about a job you've done before and the job you want to get into, and try to identify the skills you need for both, like working to deadlines, managing budgets and working well with a wide range of people.</p>
-
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
-
-    <h2 class="govuk-heading-l">Sign off</h2>
-    <p class="govuk-body">Lastly, you should finish your letter by bringing it all together.</p>
-    <p class="govuk-body">You should:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>invite the employer to get more details about you from your attached or enclosed CV</li>
-      <li>say you're looking forward to hearing from them, if you're replying to an advertised vacancy</li>
-      <li>say you'll wait for their call, or that you'll contact them in a week or two, if you're applying on the off-chance of a job</li>
-      <li>explain how you'd like to be contacted, for example by phone, email or post, and make sure your contact details are correct on your covering letter and CV</li>
-    </ul>
-
-    <%= render 'advice_on_finding_work' %>
+    <div class="govuk-!-margin-bottom-2">
+      <%= link_to 'Back to action plan', action_plan_path, class: 'govuk-link govuk-body' %>
+    </div>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/pages/cover_letter_advice.html.erb
+++ b/app/views/pages/cover_letter_advice.html.erb
@@ -23,16 +23,16 @@
     </ul>
     <p class="govuk-body">A good covering letter will show that you've done your research, you know what the job involves and what the employer's looking for.</p>
 
-    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-cover-letter-advice">
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+            <span class="govuk-accordion__section-button" id="accordion-cover-letter-advice-heading-1">
               Covering letters - the main rules
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+        <div id="accordion-cover-letter-advice-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-cover-letter-advice-heading-1">
           <p class="govuk-body">Your covering letter should be short and to the point. Write it on a computer as it makes it easier to make any changes or corrections before you send it.</p>
           <p class="govuk-body">Highlight your most relevant skills and achievements, and explain any gaps in your CV, like periods of unemployment, time spent in prison, travelling or being a carer. For each of these explain what you learned from the experience.</p>
           <p class="govuk-body">Make specific reference to the employer - don't send out identical covering letters with no organisation details. Use the right language and tone, and the same font and text size as on your CV. Always check for spelling and grammatical errors.</p>
@@ -54,12 +54,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+            <span class="govuk-accordion__section-button" id="accordion-cover-letter-advice-heading-2">
               Show your enthusiasm
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+        <div id="accordion-cover-letter-advice-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-cover-letter-advice-heading-2">
           <p class="govuk-body">Show how keen you are to get this job and work for this employer. Many employers skim-read covering letters, so the opening paragraph is your opportunity to impress them with how much you know about their work.</p>
           <p class="govuk-body">Explain why you believe you're the right person for the company, and what makes you highly motivated to work for them. Show you're familiar with their products and services, and recent news about them. You could also explain that you're enthusiastic about working for them because you share their work values, culture and style.</p>
         </div>
@@ -68,12 +68,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
+            <span class="govuk-accordion__section-button" id="accordion-cover-letter-advice-heading-3">
               Take the employer's point of view
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
+        <div id="accordion-cover-letter-advice-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-cover-letter-advice-heading-3">
           <p class="govuk-body">Imagine you're the employer and ask yourself:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>what would make a candidate stand out?</li>
@@ -89,12 +89,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
+            <span class="govuk-accordion__section-button" id="accordion-cover-letter-advice-heading-4">
               Identify your unique selling points
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
+        <div id="accordion-cover-letter-advice-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-cover-letter-advice-heading-4">
           <p class="govuk-body">Be positive about who you are and what you have to offer, like your ability to learn quickly, your experience if you're older, or your ideas, enthusiasm and willingness to learn if you've recently finished college. Highlight to the employer what special skills, knowledge or expertise you can bring.</p>
         </div>
       </div>
@@ -102,12 +102,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-5">
+            <span class="govuk-accordion__section-button" id="accordion-cover-letter-advice-heading-5">
               Promote your transferable skills
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-5" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-5">
+        <div id="accordion-cover-letter-advice-content-5" class="govuk-accordion__section-content" aria-labelledby="accordion-cover-letter-advice-heading-5">
           <p class="govuk-body">Think about a job you've done before and the job you want to get into, and try to identify the skills you need for both, like working to deadlines, managing budgets and working well with a wide range of people.</p>
         </div>
       </div>
@@ -115,12 +115,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-6">
+            <span class="govuk-accordion__section-button" id="accordion-cover-letter-advice-heading-6">
               Sign off
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-6" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-6">
+        <div id="accordion-cover-letter-advice-content-6" class="govuk-accordion__section-content" aria-labelledby="accordion-cover-letter-advice-heading-6">
           <p class="govuk-body">Lastly, you should finish your letter by bringing it all together.</p>
           <p class="govuk-body">You should:</p>
           <ul class="govuk-list govuk-list--bullet">
@@ -132,7 +132,7 @@
         </div>
       </div>
 
-      <%= render partial: 'advice_on_finding_work', locals: { item_order: 7 } %>
+      <%= render partial: 'advice_on_finding_work', locals: { item_order: 7, key: 'cover-letter-advice' } %>
     </div>
 
     <div class="govuk-!-margin-bottom-2">

--- a/app/views/pages/cover_letter_advice.html.erb
+++ b/app/views/pages/cover_letter_advice.html.erb
@@ -109,8 +109,18 @@
         </div>
         <div id="accordion-default-content-5" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-5">
           <p class="govuk-body">Think about a job you've done before and the job you want to get into, and try to identify the skills you need for both, like working to deadlines, managing budgets and working well with a wide range of people.</p>
-          <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
-          <h2 class="govuk-heading-l">Sign off</h2>
+        </div>
+      </div>
+
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-6">
+              Sign off
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-6" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-6">
           <p class="govuk-body">Lastly, you should finish your letter by bringing it all together.</p>
           <p class="govuk-body">You should:</p>
           <ul class="govuk-list govuk-list--bullet">
@@ -122,7 +132,7 @@
         </div>
       </div>
 
-      <%= render partial: 'advice_on_finding_work', locals: { item_order: 6 } %>
+      <%= render partial: 'advice_on_finding_work', locals: { item_order: 7 } %>
     </div>
 
     <div class="govuk-!-margin-bottom-2">

--- a/app/views/pages/cv_advice.html.erb
+++ b/app/views/pages/cv_advice.html.erb
@@ -14,63 +14,125 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
+    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+              Your personal details
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+          <p class="govuk-body">Include your name, address and contact details. You don't need to include your age, marital status or nationality. Recruiters can make a decision about your skills and abilities without this information.</p>
+          <p class="govuk-body">Make sure your email address sounds professional. You could also add a link to a professional social media site like LinkedIn. Make sure your profile shows you in a positive light and doesn't contain anything you wouldn't want an employer to see.</p>
+        </div>
+      </div>
 
-    <h2 class="govuk-heading-l">Your personal details</h2>
-    <p class="govuk-body">Include your name, address and contact details. You don't need to include your age, marital status or nationality. Recruiters can make a decision about your skills and abilities without this information.</p>
-    <p class="govuk-body">Make sure your email address sounds professional. You could also add a link to a professional social media site like LinkedIn. Make sure your profile shows you in a positive light and doesn't contain anything you wouldn't want an employer to see.</p>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+              Your personal profile
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+          <p class="govuk-body">This is a mini-advert for you and should summarise your:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>skills and qualities</li>
+            <li>work background and achievements</li>
+            <li>career aims</li>
+          </ul>
+          <p class="govuk-body">It should only be a few lines and needs to grab the reader's attention. Try not to use terms like: 'reliable', 'hard working', 'team player' or 'good communicator'. These are viewed a lot by employers, and they don't help to build up an individual picture of you.</p>
+          <p class="govuk-body">If the job involves working with people, try to show your people skills by uses phrases like: 'negotiating', 'effectively dealing with demanding customers', 'handling conflict' or 'showing empathy'. These help the reader build up a picture of your skills, knowledge and experience. Keep it short - you can go into more detail later.</p>
+          <p class="govuk-body">When describing your career aims, think about the employer you're sending the CV to. Make your careers aims sound just like the kind of opportunities they currently have.</p>
+        </div>
+      </div>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
+              Employment history and work experience
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
+          <p class="govuk-body">You'll usually put your employment history first if you've been working for a few years. If you don't have much work experience, focus on your your education and training.</p>
+          <p class="govuk-body">Start with the job you're doing now, or the last job you had, and work backwards. You need to include your employer's name, the dates you worked for them, your job title and your main tasks. On the jobs that are relevant to the role you're applying for, give examples of the skills you used and what you achieved.</p>
+          <p class="govuk-body">Use bullet pointed lists and positive language. Use 'action' words to describe what you did in your job like: 'achieved', 'designed', 'established', 'supervised', 'co-ordinated', 'created' or 'transformed'.</p>
+          <p class="govuk-body">Relate your skills and experience to the job description, person specification or what you think the employer is looking for. Also include any relevant temporary work and volunteering experience.</p>
+          <p class="govuk-body">Try not to have any gaps in your work history. If you had time out travelling, job seeking, volunteering or caring for a relative, include them with details of what you learned and the skills you gained.</p>
+        </div>
+      </div>
 
-    <h2 class="govuk-heading-l">Your personal profile</h2>
-    <p class="govuk-body">This is a mini-advert for you and should summarise your:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>skills and qualities</li>
-      <li>work background and achievements</li>
-      <li>career aims</li>
-    </ul>
-    <p class="govuk-body">It should only be a few lines and needs to grab the reader's attention. Try not to use terms like: 'reliable', 'hard working', 'team player' or 'good communicator'. These are viewed a lot by employers, and they don't help to build up an individual picture of you.</p>
-    <p class="govuk-body">If the job involves working with people, try to show your people skills by uses phrases like: 'negotiating', 'effectively dealing with demanding customers', 'handling conflict' or 'showing empathy'. These help the reader build up a picture of your skills, knowledge and experience. Keep it short - you can go into more detail later.</p>
-    <p class="govuk-body">When describing your career aims, think about the employer you're sending the CV to. Make your careers aims sound just like the kind of opportunities they currently have.</p>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
+              Education and training
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
+          <p class="govuk-body">Start with your most recent qualifications and work back to the ones you got at school. Use bullet points or a table and include:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>the university, college or school you went to</li>
+            <li>the dates the qualifications were awarded and any grades</li>
+            <li>any work-related courses, if they're relevant</li>
+          </ul>
+        </div>
+      </div>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-5">
+              Interests and achievements
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-5" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-5">
+          <p class="govuk-body">Include hobbies, interests and achievements that are relevant to the job. If you're involved in any clubs or societies, this can show that you enjoy meeting new people. Interests like sports and physical recreation activities can also show employers that you are fit and healthy.</p>
+          <p class="govuk-body">Don't just put activities that you would do alone like reading, bird-watching or playing video games, unless they relate directly to the job that you are applying for. They may leave employers wondering how sociable you are. Make your activities specific and varied.</p>
+        </div>
+      </div>
 
-    <h2 class="govuk-heading-l">Employment history and work experience</h2>
-    <p class="govuk-body">You'll usually put your employment history first if you've been working for a few years. If you don't have much work experience, focus on your your education and training.</p>
-    <p class="govuk-body">Start with the job you're doing now, or the last job you had, and work backwards. You need to include your employer's name, the dates you worked for them, your job title and your main tasks. On the jobs that are relevant to the role you're applying for, give examples of the skills you used and what you achieved.</p>
-    <p class="govuk-body">Use bullet pointed lists and positive language. Use 'action' words to describe what you did in your job like: 'achieved', 'designed', 'established', 'supervised', 'co-ordinated', 'created' or 'transformed'.</p>
-    <p class="govuk-body">Relate your skills and experience to the job description, person specification or what you think the employer is looking for. Also include any relevant temporary work and volunteering experience.</p>
-    <p class="govuk-body">Try not to have any gaps in your work history. If you had time out travelling, job seeking, volunteering or caring for a relative, include them with details of what you learned and the skills you gained.</p>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-6">
+              Additional information
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-6" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-6">
+          <p class="govuk-body">You can include this section if you need to add anything else that's relevant.</p>
+          <p class="govuk-body">You may need to explain a gap in your employment history, like travelling or family reasons. You could also include other relevant skills here, such as if you have a driving licence or can speak any foreign languages.</p>
+        </div>
+      </div>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-6">
+              References
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-6" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-6">
+          <p class="govuk-body">At least one referee should be work-related. Or, if you haven't worked for a while, you could use another responsible person who has known you for some time.</p>
+          <p class="govuk-body">You can list your referees on your CV or just put 'references available on request'. If you decide to include their details you should explain the relationship of each referee to you - for example 'Claire Turner, line manager'.</p>
+        </div>
+      </div>
 
-    <h2 class="govuk-heading-l">Education and training</h2>
-    <p class="govuk-body">Start with your most recent qualifications and work back to the ones you got at school. Use bullet points or a table and include:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>the university, college or school you went to</li>
-      <li>the dates the qualifications were awarded and any grades</li>
-      <li>any work-related courses, if they're relevant</li>
-    </ul>
+      <%= render partial: 'advice_on_finding_work', locals: { item_order: 7 } %>
+    </div>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
-
-    <h2 class="govuk-heading-l">Interests and achievements</h2>
-    <p class="govuk-body">Include hobbies, interests and achievements that are relevant to the job. If you're involved in any clubs or societies, this can show that you enjoy meeting new people. Interests like sports and physical recreation activities can also show employers that you are fit and healthy.</p>
-    <p class="govuk-body">Don't just put activities that you would do alone like reading, bird-watching or playing video games, unless they relate directly to the job that you are applying for. They may leave employers wondering how sociable you are. Make your activities specific and varied.</p>
-
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
-
-    <h2 class="govuk-heading-l">Additional information</h2>
-    <p class="govuk-body">You can include this section if you need to add anything else that's relevant.</p>
-    <p class="govuk-body">You may need to explain a gap in your employment history, like travelling or family reasons. You could also include other relevant skills here, such as if you have a driving licence or can speak any foreign languages.</p>
-
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
-
-    <h2 class="govuk-heading-l">References</h2>
-    <p class="govuk-body">At least one referee should be work-related. Or, if you haven't worked for a while, you could use another responsible person who has known you for some time.</p>
-    <p class="govuk-body">You can list your referees on your CV or just put 'references available on request'. If you decide to include their details you should explain the relationship of each referee to you - for example 'Claire Turner, line manager'.</p>
-
-    <%= render 'advice_on_finding_work' %>
+    <div class="govuk-!-margin-bottom-2">
+      <%= link_to 'Back to action plan', action_plan_path, class: 'govuk-link govuk-body' %>
+    </div>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/pages/cv_advice.html.erb
+++ b/app/views/pages/cv_advice.html.erb
@@ -14,16 +14,16 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
 
-    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-cv-advice">
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+            <span class="govuk-accordion__section-button" id="accordion-cv-advice-heading-1">
               Your personal details
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+        <div id="accordion-cv-advice-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-cv-advice-heading-1">
           <p class="govuk-body">Include your name, address and contact details. You don't need to include your age, marital status or nationality. Recruiters can make a decision about your skills and abilities without this information.</p>
           <p class="govuk-body">Make sure your email address sounds professional. You could also add a link to a professional social media site like LinkedIn. Make sure your profile shows you in a positive light and doesn't contain anything you wouldn't want an employer to see.</p>
         </div>
@@ -32,12 +32,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+            <span class="govuk-accordion__section-button" id="accordion-cv-advice-heading-2">
               Your personal profile
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+        <div id="accordion-cv-advice-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-cv-advice-heading-2">
           <p class="govuk-body">This is a mini-advert for you and should summarise your:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>skills and qualities</li>
@@ -53,12 +53,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
+            <span class="govuk-accordion__section-button" id="accordion-cv-advice-heading-3">
               Employment history and work experience
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
+        <div id="accordion-cv-advice-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-cv-advice-heading-3">
           <p class="govuk-body">You'll usually put your employment history first if you've been working for a few years. If you don't have much work experience, focus on your your education and training.</p>
           <p class="govuk-body">Start with the job you're doing now, or the last job you had, and work backwards. You need to include your employer's name, the dates you worked for them, your job title and your main tasks. On the jobs that are relevant to the role you're applying for, give examples of the skills you used and what you achieved.</p>
           <p class="govuk-body">Use bullet pointed lists and positive language. Use 'action' words to describe what you did in your job like: 'achieved', 'designed', 'established', 'supervised', 'co-ordinated', 'created' or 'transformed'.</p>
@@ -70,12 +70,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
+            <span class="govuk-accordion__section-button" id="accordion-cv-advice-heading-4">
               Education and training
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
+        <div id="accordion-cv-advice-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-cv-advice-heading-4">
           <p class="govuk-body">Start with your most recent qualifications and work back to the ones you got at school. Use bullet points or a table and include:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>the university, college or school you went to</li>
@@ -88,12 +88,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-5">
+            <span class="govuk-accordion__section-button" id="accordion-cv-advice-heading-5">
               Interests and achievements
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-5" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-5">
+        <div id="accordion-cv-advice-content-5" class="govuk-accordion__section-content" aria-labelledby="accordion-cv-advice-heading-5">
           <p class="govuk-body">Include hobbies, interests and achievements that are relevant to the job. If you're involved in any clubs or societies, this can show that you enjoy meeting new people. Interests like sports and physical recreation activities can also show employers that you are fit and healthy.</p>
           <p class="govuk-body">Don't just put activities that you would do alone like reading, bird-watching or playing video games, unless they relate directly to the job that you are applying for. They may leave employers wondering how sociable you are. Make your activities specific and varied.</p>
         </div>
@@ -102,12 +102,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-6">
+            <span class="govuk-accordion__section-button" id="accordion-cv-advice-heading-6">
               Additional information
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-6" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-6">
+        <div id="accordion-cv-advice-content-6" class="govuk-accordion__section-content" aria-labelledby="accordion-cv-advice-heading-6">
           <p class="govuk-body">You can include this section if you need to add anything else that's relevant.</p>
           <p class="govuk-body">You may need to explain a gap in your employment history, like travelling or family reasons. You could also include other relevant skills here, such as if you have a driving licence or can speak any foreign languages.</p>
         </div>
@@ -116,18 +116,18 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-7">
+            <span class="govuk-accordion__section-button" id="accordion-cv-advice-heading-7">
               References
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-7" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-7">
+        <div id="accordion-cv-advice-content-7" class="govuk-accordion__section-content" aria-labelledby="accordion-cv-advice-heading-7">
           <p class="govuk-body">At least one referee should be work-related. Or, if you haven't worked for a while, you could use another responsible person who has known you for some time.</p>
           <p class="govuk-body">You can list your referees on your CV or just put 'references available on request'. If you decide to include their details you should explain the relationship of each referee to you - for example 'Claire Turner, line manager'.</p>
         </div>
       </div>
 
-      <%= render partial: 'advice_on_finding_work', locals: { item_order: 8 } %>
+      <%= render partial: 'advice_on_finding_work', locals: { item_order: 8, key: 'cv-advice' } %>
     </div>
 
     <div class="govuk-!-margin-bottom-2">

--- a/app/views/pages/cv_advice.html.erb
+++ b/app/views/pages/cv_advice.html.erb
@@ -116,18 +116,18 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-6">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-7">
               References
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-6" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-6">
+        <div id="accordion-default-content-7" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-7">
           <p class="govuk-body">At least one referee should be work-related. Or, if you haven't worked for a while, you could use another responsible person who has known you for some time.</p>
           <p class="govuk-body">You can list your referees on your CV or just put 'references available on request'. If you decide to include their details you should explain the relationship of each referee to you - for example 'Claire Turner, line manager'.</p>
         </div>
       </div>
 
-      <%= render partial: 'advice_on_finding_work', locals: { item_order: 7 } %>
+      <%= render partial: 'advice_on_finding_work', locals: { item_order: 8 } %>
     </div>
 
     <div class="govuk-!-margin-bottom-2">

--- a/app/views/pages/interview_advice.html.erb
+++ b/app/views/pages/interview_advice.html.erb
@@ -106,7 +106,7 @@
           <p class="govuk-body">If you're asked about being made redundant from your previous job, try to stress it was a business decision and describe how you've responded positively since.</p>
           <p class="govuk-body">If you were fired for misconduct or poor performance, try to explain why your standards dropped on that occasion but that you have learnt from it and have since improved.</p>
           <p class="govuk-body">If you've been out of work for a long time and get asked about it, describe any positive steps you've taken such as voluntary work, courses, networking, industry events, keeping fit, community roles, keeping yourself up to date with your field.</p>
-          <p class="govuk-body">If you left your last job by choice and are asked about it, you could make it clear.</p>
+          <p class="govuk-body">If you left your last job by choice and are asked about it, you could make it clear you were grateful for the opportunity and learnt a lot, but you wanted a fresh challenge.</p>
         </div>
       </div>
 

--- a/app/views/pages/interview_advice.html.erb
+++ b/app/views/pages/interview_advice.html.erb
@@ -14,90 +14,147 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
-
     <p class="govuk-body">An interview is a discussion in person, by phone or online, between you and an employer.</p>
     <p class="govuk-body">The employer wants to see if you're the right person for the job. You'll get the chance to make a good impression and show the employer what you have to offer. You can also see if the job is one you want.</p>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
+    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+              Types of interview
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+          <p class="govuk-body">The most common types of interview are:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>competency-based - focussing on the skills and personal qualities you need, you'll have to relate your skills and experience to the job</li>
+            <li>technical - usually for technical jobs in areas like IT or engineering, you'll have to display your technical knowledge of a certain process or skill</li>
+            <li>face-to-face - in person</li>
+            <li>panel interview - where one person usually leads the interview and other panel members take it in turns to ask you different questions</li>
+            <li>telephone or online - this could be the first stage of the interview or the only stage, and you should prepare in the same way as for a face-to-face interview</li>
+            <li>informal chat - in some job areas like the creative industries you'll have an informal, work-focussed discussion about your experience and career aims, usually somewhere like a restaurant or a cafe</li>
+            <li>group discussion - in a group with other candidates, you'll have to show you can get along with people, put your ideas forward and be respectful of others</li>
+          </ul>
+        </div>
+      </div>
 
-    <h2 class="govuk-heading-l">Types of interview</h2>
-    <p class="govuk-body">The most common types of interview are:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>competency-based - focussing on the skills and personal qualities you need, you'll have to relate your skills and experience to the job</li>
-      <li>technical - usually for technical jobs in areas like IT or engineering, you'll have to display your technical knowledge of a certain process or skill</li>
-      <li>face-to-face - in person</li>
-      <li>panel interview - where one person usually leads the interview and other panel members take it in turns to ask you different questions</li>
-      <li>telephone or online - this could be the first stage of the interview or the only stage, and you should prepare in the same way as for a face-to-face interview</li>
-      <li>informal chat - in some job areas like the creative industries you'll have an informal, work-focussed discussion about your experience and career aims, usually somewhere like a restaurant or a cafe</li>
-      <li>group discussion - in a group with other candidates, you'll have to show you can get along with people, put your ideas forward and be respectful of others</li>
-    </ul>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+              Before the interview
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+          <p class="govuk-body">To help you prepare, you can:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>think about which areas of your CV or application form the interviewer might ask you to talk more about, and how you can relate them to the role</li>
+            <li>prepare some answers about why you want the job, what your strengths and weaknesses are, and your relevant work and life experience</li>
+            <li>think of some questions to ask about the role and the company at the end of the interview, but don't ask about pay yet</li>
+            <li>try to relax the night before the interview - doing lots of last minute work could make you more anxious and reduce your sleep time</li>
+          </ul>
+        </div>
+      </div>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
+              What to wear
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
+          <p class="govuk-body">When it comes to what to wear:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>plan what you're going to wear before the day of the interview</li>
+            <li>find out what the company's dress code is and wear clothes that suit the company that's interviewing you</li>
+            <li>don't wear clothes that you're uncomfortable in, or shoes that you'll struggle to walk in</li>
+            <li>don't wear too much strong perfume or aftershave</li>
+          </ul>
+          <h3 class="govuk-heading-m">Getting to the venue</h3>
+          <p class="govuk-body">Check in advance how to get to the interview venue, and how long it'll take. On interview day make sure you leave plenty of time to get there and aim to arrive a little early.</p>
+          <h3 class="govuk-heading-m">Get settled and ready to begin</h3>
+          <p class="govuk-body">Just before the interview starts:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>make sure your phone's turned off</li>
+            <li>ask for water if you haven't already been given some</li>
+            <li>don't let your nerves show too much - use breathing techniques and try to remember a few nerves are normal</li>
+          </ul>
+        </div>
+      </div>
 
-    <h2 class="govuk-heading-l">Before the interview</h2>
-    <p class="govuk-body">To help you prepare, you can:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>think about which areas of your CV or application form the interviewer might ask you to talk more about, and how you can relate them to the role</li>
-      <li>prepare some answers about why you want the job, what your strengths and weaknesses are, and your relevant work and life experience</li>
-      <li>think of some questions to ask about the role and the company at the end of the interview, but don't ask about pay yet</li>
-      <li>try to relax the night before the interview - doing lots of last minute work could make you more anxious and reduce your sleep time</li>
-    </ul>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
+              During the interview
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
+          <p class="govuk-body">When answering the questions:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>take your time when thinking of your answer - it's fine to say you need a moment to think</li>
+            <li>look alert and attentive, speak clearly and confidently, and don't swear or use slang</li>
+            <li>give full answers, don't just say 'yes' or 'no'</li>
+            <li>give examples of when you've used the skills they're asking for</li>
+            <li>if you're asked about your experience, talk about the Situation you were in, the Task in front of you, the Action you took, and the Result of your action (STAR technique)</li>
+            <li>be positive about your experiences - avoid negativity about yourself or any previous roles you've had</li>
+            <li>make sure you fully understand the questions you're asked - ask for more explanation if you need to</li>
+            <li>avoid mentioning salary or company benefits unless asked</li>
+            <li>don't lie - the interviewer may see through you and, even if you get the job, your employer can dismiss you if they find out you've been dishonest</li>
+            <li>if you're asked about a work skill you don't have, you could say what you'd do in a certain situation or use an example from your personal life, and also explain that you're a fast learner</li>
+            <li>don't be arrogant and assume you've got the job - employers don't like disrespectful or over-confident candidates</li>
+            <li>don't bring up topics like religion or politics where people can have strongly-held personal beliefs</li>
+          </ul>
+        </div>
+      </div>
 
-    <h3 class="govuk-heading-m">What to wear</h3>
-    <p class="govuk-body">When it comes to what to wear:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>plan what you're going to wear before the day of the interview</li>
-      <li>find out what the company's dress code is and wear clothes that suit the company that's interviewing you</li>
-      <li>don't wear clothes that you're uncomfortable in, or shoes that you'll struggle to walk in</li>
-      <li>don't wear too much strong perfume or aftershave</li>
-    </ul>
-    <h3 class="govuk-heading-m">Getting to the venue</h3>
-    <p class="govuk-body">Check in advance how to get to the interview venue, and how long it'll take. On interview day make sure you leave plenty of time to get there and aim to arrive a little early.</p>
-    <h3 class="govuk-heading-m">Get settled and ready to begin</h3>
-    <p class="govuk-body">Just before the interview starts:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>make sure your phone's turned off</li>
-      <li>ask for water if you haven't already been given some</li>
-      <li>don't let your nerves show too much - use breathing techniques and try to remember a few nerves are normal</li>
-    </ul>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-5">
+              Difficult questions
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-5" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-5">
+          <p class="govuk-body">If you're asked about being made redundant from your previous job, try to stress it was a business decision and describe how you've responded positively since.</p>
+          <p class="govuk-body">If you were fired for misconduct or poor performance, try to explain why your standards dropped on that occasion but that you have learnt from it and have since improved.</p>
+          <p class="govuk-body">If you've been out of work for a long time and get asked about it, describe any positive steps you've taken such as voluntary work, courses, networking, industry events, keeping fit, community roles, keeping yourself up to date with your field.</p>
+          <p class="govuk-body">If you left your last job by choice and are asked about it, you could make it clear you were grateful for the opportunity and learnt a lot, but you wanted a fresh challenge.</p>
+        </div>
+      </div>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-6">
+              After the interview
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-6" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-6">
+          <p class="govuk-body">When the employer contacts you after the interview:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>if you're offered the job, thank them and agree things like start date and what to bring on the first day</li>
+            <li>if you're expected to negotiate salary, find out beforehand what the usual rate is for the job but then start high and meet in the middle if necessary</li>
+            <li>ask for feedback on your performance - if you weren't successful use their comments to improve for next time</li>
+            <li>if you're offered a job and decide you don't want it, thank the employer politely, as you may want to work for them in future</li>
+          </ul>
+        </div>
+      </div>
+      
+      <%= render partial: 'advice_on_finding_work', locals: { item_order: 7 } %>
+    </div>
 
-    <h2 class="govuk-heading-l">During the interview</h3>
-    <p class="govuk-body">When answering the questions:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>take your time when thinking of your answer - it's fine to say you need a moment to think</li>
-      <li>look alert and attentive, speak clearly and confidently, and don't swear or use slang</li>
-      <li>give full answers, don't just say 'yes' or 'no'</li>
-      <li>give examples of when you've used the skills they're asking for</li>
-      <li>if you're asked about your experience, talk about the Situation you were in, the Task in front of you, the Action you took, and the Result of your action (STAR technique)</li>
-      <li>be positive about your experiences - avoid negativity about yourself or any previous roles you've had</li>
-      <li>make sure you fully understand the questions you're asked - ask for more explanation if you need to</li>
-      <li>avoid mentioning salary or company benefits unless asked</li>
-      <li>don't lie - the interviewer may see through you and, even if you get the job, your employer can dismiss you if they find out you've been dishonest</li>
-      <li>if you're asked about a work skill you don't have, you could say what you'd do in a certain situation or use an example from your personal life, and also explain that you're a fast learner</li>
-      <li>don't be arrogant and assume you've got the job - employers don't like disrespectful or over-confident candidates</li>
-      <li>don't bring up topics like religion or politics where people can have strongly-held personal beliefs</li>
-    </ul>
-
-    <h3 class="govuk-heading-m">Difficult questions</h3>
-    <p class="govuk-body">If you're asked about being made redundant from your previous job, try to stress it was a business decision and describe how you've responded positively since.</p>
-    <p class="govuk-body">If you were fired for misconduct or poor performance, try to explain why your standards dropped on that occasion but that you have learnt from it and have since improved.</p>
-    <p class="govuk-body">If you've been out of work for a long time and get asked about it, describe any positive steps you've taken such as voluntary work, courses, networking, industry events, keeping fit, community roles, keeping yourself up to date with your field.</p>
-    <p class="govuk-body">If you left your last job by choice and are asked about it, you could make it clear you were grateful for the opportunity and learnt a lot, but you wanted a fresh challenge.</p>
-
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
-
-    <h2 class="govuk-heading-l">After the interview</h3>
-    <p class="govuk-body">When the employer contacts you after the interview:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>if you're offered the job, thank them and agree things like start date and what to bring on the first day</li>
-      <li>if you're expected to negotiate salary, find out beforehand what the usual rate is for the job but then start high and meet in the middle if necessary</li>
-      <li>ask for feedback on your performance - if you weren't successful use their comments to improve for next time</li>
-      <li>if you're offered a job and decide you don't want it, thank the employer politely, as you may want to work for them in future</li>
-    </ul>
-    <%= render 'advice_on_finding_work' %>
+    <div class="govuk-!-margin-bottom-2">
+      <%= link_to 'Back to action plan', action_plan_path, class: 'govuk-link govuk-body' %>
+    </div>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/pages/interview_advice.html.erb
+++ b/app/views/pages/interview_advice.html.erb
@@ -17,16 +17,16 @@
     <p class="govuk-body">An interview is a discussion in person, by phone or online, between you and an employer.</p>
     <p class="govuk-body">The employer wants to see if you're the right person for the job. You'll get the chance to make a good impression and show the employer what you have to offer. You can also see if the job is one you want.</p>
 
-    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-interview-advice">
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+            <span class="govuk-accordion__section-button" id="accordion-interview-advice-heading-1">
               Types of interview
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+        <div id="accordion-interview-advice-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-interview-advice-heading-1">
           <p class="govuk-body">The most common types of interview are:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>competency-based - focussing on the skills and personal qualities you need, you'll have to relate your skills and experience to the job</li>
@@ -43,12 +43,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+            <span class="govuk-accordion__section-button" id="accordion-interview-advice-heading-2">
               Before the interview
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+        <div id="accordion-interview-advice-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-interview-advice-heading-2">
           <p class="govuk-body">To help you prepare, you can:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>think about which areas of your CV or application form the interviewer might ask you to talk more about, and how you can relate them to the role</li>
@@ -80,12 +80,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
+            <span class="govuk-accordion__section-button" id="accordion-interview-advice-heading-3">
               During the interview
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
+        <div id="accordion-interview-advice-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-interview-advice-heading-3">
           <p class="govuk-body">When answering the questions:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>take your time when thinking of your answer - it's fine to say you need a moment to think</li>
@@ -113,12 +113,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
+            <span class="govuk-accordion__section-button" id="accordion-interview-advice-heading-4">
               After the interview
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
+        <div id="accordion-interview-advice-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-interview-advice-heading-4">
           <p class="govuk-body">When the employer contacts you after the interview:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>if you're offered the job, thank them and agree things like start date and what to bring on the first day</li>
@@ -129,7 +129,7 @@
         </div>
       </div>
       
-      <%= render partial: 'advice_on_finding_work', locals: { item_order: 5 } %>
+      <%= render partial: 'advice_on_finding_work', locals: { item_order: 5, key: 'interview-advice' } %>
     </div>
 
     <div class="govuk-!-margin-bottom-2">

--- a/app/views/pages/interview_advice.html.erb
+++ b/app/views/pages/interview_advice.html.erb
@@ -56,18 +56,8 @@
             <li>think of some questions to ask about the role and the company at the end of the interview, but don't ask about pay yet</li>
             <li>try to relax the night before the interview - doing lots of last minute work could make you more anxious and reduce your sleep time</li>
           </ul>
-        </div>
-      </div>
 
-      <div class="govuk-accordion__section">
-        <div class="govuk-accordion__section-header">
-          <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
-              What to wear
-            </span>
-          </h2>
-        </div>
-        <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
+          <h3 class="govuk-heading-m">What to wear</h3>
           <p class="govuk-body">When it comes to what to wear:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>plan what you're going to wear before the day of the interview</li>
@@ -90,12 +80,12 @@
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
               During the interview
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
+        <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
           <p class="govuk-body">When answering the questions:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>take your time when thinking of your answer - it's fine to say you need a moment to think</li>
@@ -111,34 +101,24 @@
             <li>don't be arrogant and assume you've got the job - employers don't like disrespectful or over-confident candidates</li>
             <li>don't bring up topics like religion or politics where people can have strongly-held personal beliefs</li>
           </ul>
-        </div>
-      </div>
 
-      <div class="govuk-accordion__section">
-        <div class="govuk-accordion__section-header">
-          <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-5">
-              Difficult questions
-            </span>
-          </h2>
-        </div>
-        <div id="accordion-default-content-5" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-5">
+          <h3 class="govuk-heading-m">Difficult questions</h3>
           <p class="govuk-body">If you're asked about being made redundant from your previous job, try to stress it was a business decision and describe how you've responded positively since.</p>
           <p class="govuk-body">If you were fired for misconduct or poor performance, try to explain why your standards dropped on that occasion but that you have learnt from it and have since improved.</p>
           <p class="govuk-body">If you've been out of work for a long time and get asked about it, describe any positive steps you've taken such as voluntary work, courses, networking, industry events, keeping fit, community roles, keeping yourself up to date with your field.</p>
-          <p class="govuk-body">If you left your last job by choice and are asked about it, you could make it clear you were grateful for the opportunity and learnt a lot, but you wanted a fresh challenge.</p>
+          <p class="govuk-body">If you left your last job by choice and are asked about it, you could make it clear.</p>
         </div>
       </div>
 
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-6">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
               After the interview
             </span>
           </h2>
         </div>
-        <div id="accordion-default-content-6" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-6">
+        <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
           <p class="govuk-body">When the employer contacts you after the interview:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>if you're offered the job, thank them and agree things like start date and what to bring on the first day</li>
@@ -149,7 +129,7 @@
         </div>
       </div>
       
-      <%= render partial: 'advice_on_finding_work', locals: { item_order: 7 } %>
+      <%= render partial: 'advice_on_finding_work', locals: { item_order: 5 } %>
     </div>
 
     <div class="govuk-!-margin-bottom-2">

--- a/app/webpacker/packs/courses-accordion.js
+++ b/app/webpacker/packs/courses-accordion.js
@@ -2,8 +2,8 @@ function CoursesAccordion () {
   this.start = function () {
     var largerThanTablet = window.matchMedia('(min-width: 700px)');
     var postcodeError = document.querySelector('#course_search_postcode-error');
-    if (((largerThanTablet.matches === true) || (typeof(postcodeError) !== 'undefined' && postcodeError != null)) && (window.location.href.indexOf('/courses/') > -1)) {
-      window.sessionStorage.setItem('accordion-default-content-1', true);
+    if ((largerThanTablet.matches === true) || (typeof(postcodeError) !== 'undefined' && postcodeError != null)) {
+      window.sessionStorage.setItem('accordion-courses-content-1', true);
     }
   }
 }

--- a/app/webpacker/packs/courses-accordion.js
+++ b/app/webpacker/packs/courses-accordion.js
@@ -2,7 +2,7 @@ function CoursesAccordion () {
   this.start = function () {
     var largerThanTablet = window.matchMedia('(min-width: 700px)');
     var postcodeError = document.querySelector('#course_search_postcode-error');
-    if((largerThanTablet.matches === true) || (typeof(postcodeError) !== 'undefined' && postcodeError != null)) {
+    if (((largerThanTablet.matches === true) || (typeof(postcodeError) !== 'undefined' && postcodeError != null)) && (window.location.href.indexOf('/courses/') > -1)) {
       window.sessionStorage.setItem('accordion-default-content-1', true);
     }
   }

--- a/app/webpacker/styles/_course.scss
+++ b/app/webpacker/styles/_course.scss
@@ -1,4 +1,4 @@
-#accordion-courses > .govuk-accordion__controls {
+.govuk-accordion-courses > .govuk-accordion__controls {
   display: none;
 }
 

--- a/app/webpacker/styles/_course.scss
+++ b/app/webpacker/styles/_course.scss
@@ -1,4 +1,4 @@
-.govuk-accordion__controls {
+#accordion-courses > .govuk-accordion__controls {
   display: none;
 }
 

--- a/app/webpacker/styles/_job-profile.scss
+++ b/app/webpacker/styles/_job-profile.scss
@@ -210,6 +210,6 @@
   }
 }
 
-.govuk-accordion__section:last-child {
+.govuk-accordion__section-custom:last-child {
   border-bottom: 7px solid govuk-colour("blue");
 }

--- a/app/webpacker/styles/_job-profile.scss
+++ b/app/webpacker/styles/_job-profile.scss
@@ -209,3 +209,7 @@
     flex-basis: 10%;
   }
 }
+
+.govuk-accordion__section:last-child {
+  border-bottom: 7px solid govuk-colour("blue");
+}

--- a/spec/decorators/job_profile_decorator_spec.rb
+++ b/spec/decorators/job_profile_decorator_spec.rb
@@ -352,6 +352,45 @@ RSpec.describe JobProfileDecorator do
       end
     end
 
+    context 'when rendering the More information that has more than one headers' do
+      let(:html_body) do
+        '<section class="job-profile-subsection" id="moreinfo">
+          <div class="job-profile-subsection-content">
+            <h3>Career Tips</h3>
+            <h3>Further Information</h3>
+            <p class=\"govuk-body-m\">You can find out more about careers in management consultancy from the <a href=\"https://www.mca.org.uk/career-development/careers-advice/\">Management Consultancies\nAssociation</a> and the <a href=\"http://www.managers.org.uk\">Chartered Management\nInstitute</a>.</p>
+          </div>
+        </section>'
+      end
+
+      let(:section_key) { :more_information }
+
+      it 'does not remove any of the h2 tags' do
+        expect(
+          Nokogiri::HTML(mutated_html_body).xpath('//h2').map(&:content)
+        ).to match_array(['Career Tips', 'Further Information'])
+      end
+    end
+
+    context 'when rendering the More information that has exactly one headers' do
+      let(:html_body) do
+        '<section class="job-profile-subsection" id="moreinfo">
+          <div class="job-profile-subsection-content">
+            <h3>Career Tips</h3>
+            <p class=\"govuk-body-m\">You can find out more about careers in management consultancy from the <a href=\"https://www.mca.org.uk/career-development/careers-advice/\">Management Consultancies\nAssociation</a> and the <a href=\"http://www.managers.org.uk\">Chartered Management\nInstitute</a>.</p>
+          </div>
+        </section>'
+      end
+
+      let(:section_key) { :more_information }
+
+      it 'does remove the only h2 tag' do
+        expect(
+          Nokogiri::HTML(mutated_html_body).xpath('//h2').map(&:content)
+        ).to be_empty
+      end
+    end
+
     it 'mutates the html snippet to use our styles' do
       mutated_tags.each do |tag|
         expect(mutated_html_body).to include(tag)

--- a/spec/decorators/job_profile_decorator_spec.rb
+++ b/spec/decorators/job_profile_decorator_spec.rb
@@ -334,7 +334,6 @@ RSpec.describe JobProfileDecorator do
 
       let(:mutated_tags) do
         [
-          '<h2 class="govuk-heading-m">Some things you might need</h2>',
           '<ul class="govuk-list govuk-list--bullet">',
           '<li>4 or 5 GCSEs at grades 9 to 4 (A* to C) and college qualifications like A levels</li>'
         ]
@@ -355,6 +354,12 @@ RSpec.describe JobProfileDecorator do
       mutated_tags.each do |tag|
         expect(mutated_html_body).to include(tag)
       end
+    end
+
+    it 'removes any h2 tag from the mutated html body' do
+      expect(
+        Nokogiri::HTML(mutated_html_body).xpath('//h2')
+      ).to be_empty
     end
 
     it 'removes unwanted copy' do

--- a/spec/decorators/job_profile_decorator_spec.rb
+++ b/spec/decorators/job_profile_decorator_spec.rb
@@ -279,6 +279,8 @@ RSpec.describe JobProfileDecorator do
       '<section class="job-profile-subsection" id="Apprenticeship">
         <h3>Apprenticeship</h3>
         <div class="job-profile-subsection-content">
+          <h3>Some subsection 1</h3>
+          <h3>Some subsection 2</h3>
           <p>You could take a software developer higher apprenticeship</p>
           <p>You could also do a digital and technology solutions degree apprenticeship.</p>
           <h4>Entry requirements</h4>
@@ -356,10 +358,10 @@ RSpec.describe JobProfileDecorator do
       end
     end
 
-    it 'removes any h2 tag from the mutated html body' do
+    it 'removes only the first h2 tag from the mutated html body' do
       expect(
-        Nokogiri::HTML(mutated_html_body).xpath('//h2')
-      ).to be_empty
+        Nokogiri::HTML(mutated_html_body).xpath('//h2').map(&:content)
+      ).to match_array(['Some subsection 2'])
     end
 
     it 'removes unwanted copy' do


### PR DESCRIPTION
### Context

- Add all dynamic sections under accordion components
- Add the static sections under accordion components
- Make sure the first accordion component is not expanded
on big screens, unless user is on the courses page
- Add GDS accordion component to CV Advice page
- Add GDS accordion component to Cover letter page
- Add GDS accordion component to Interview page

### Screenshots

![Screen Shot 2020-03-23 at 15 51 10](https://user-images.githubusercontent.com/1955084/77340247-ee26ec80-6d24-11ea-85ed-e1974594895d.png)

![Screen Shot 2020-03-23 at 17 39 32](https://user-images.githubusercontent.com/1955084/77345883-292d1e00-6d2d-11ea-9605-ddcac92075c6.png)

![Screen Shot 2020-03-23 at 18 20 11](https://user-images.githubusercontent.com/1955084/77349743-6399b980-6d33-11ea-8dd7-ada18dbc8072.png)

