### PR TITLE
GET- 974 Add new cookie banner

### DIFF
--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -2,7 +2,7 @@ class CookiesController < ApplicationController
   def update
     if cookies_params[:cookies][:all]
       user_session.cookies = true
-    elsif cookies_params[:cookies][:partial]
+    elsif cookies_params[:cookies][:necessary]
       user_session.cookies = false
     end
 
@@ -12,6 +12,6 @@ class CookiesController < ApplicationController
   private
 
   def cookies_params
-    params.permit(:authenticity_token, cookies: %i[all partial])
+    params.permit(:authenticity_token, cookies: %i[all necessary])
   end
 end

--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -1,0 +1,17 @@
+class CookiesController < ApplicationController
+  def update
+    if cookies_params[:cookies][:all]
+      user_session.cookies = true
+    elsif cookies_params[:cookies][:partial]
+      user_session.cookies = false
+    end
+
+    redirect_to(url_parser.get_redirect_path || root_path)
+  end
+
+  private
+
+  def cookies_params
+    params.permit(:authenticity_token, cookies: %i[all partial])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,4 +33,10 @@ module ApplicationHelper
 
     link_to('Back', back_url, class: 'govuk-back-link')
   end
+
+  def show_cookie_banner?
+    return if current_page?(cookies_policy_path)
+
+    cookies['_get_help_to_retrain_session'].blank? || user_session.cookies.nil?
+  end
 end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -11,7 +11,6 @@ class UserSession # rubocop:disable Metrics/ClassLength
     job_hunting
     it_training
     skills_matcher_sort
-    cookies
   ].freeze
 
   def self.merge_sessions(new_session:, previous_session_data:)

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -11,6 +11,7 @@ class UserSession # rubocop:disable Metrics/ClassLength
     job_hunting
     it_training
     skills_matcher_sort
+    cookies
   ].freeze
 
   def self.merge_sessions(new_session:, previous_session_data:)
@@ -78,6 +79,14 @@ class UserSession # rubocop:disable Metrics/ClassLength
 
   def job_hunting=(value)
     session[:job_hunting] = value
+  end
+
+  def cookies
+    session[:cookies]
+  end
+
+  def cookies=(value)
+    session[:cookies] = value
   end
 
   def target_job?

--- a/app/services/tracking_service.rb
+++ b/app/services/tracking_service.rb
@@ -23,7 +23,7 @@ class TrackingService
   def track_events(props:)
     raise MissingAttributesError, 'Event props must be present' unless props.present?
 
-    return unless ga_tracking_id
+    return unless ga_tracking_id && client_tracking_data[:ga_cookie].present?
 
     send_events(props)
   rescue StandardError => e

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,8 +25,9 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-    <%= render 'shared/cookies_banner' if show_cookie_banner? %>
-    <% if !show_cookie_banner? %>
+    <% if show_cookie_banner? %>
+      <%= render 'shared/cookies_banner' %>
+    <% else %>
       <div id="govuk-header-container">
         <header class="govuk-header" role="banner" data-module="govuk-header" id="govuk-header">
           <div class="govuk-header__container govuk-width-container">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,12 +29,7 @@
       <%= render 'shared/cookies_banner' %>
     <% else %>
       <div id="govuk-header-container">
-        <header class="govuk-header" role="banner" data-module="govuk-header" id="govuk-header">
-          <div class="govuk-header__container govuk-width-container">
-            <%= render 'shared/navigation/header_logo' %>
-            <%= render 'shared/navigation/main_header' %>
-          </div>
-        </header>
+        <%= render partial: 'shared/header', locals: { container_class: nil } %>
       </div>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,15 +25,17 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-    <%= render 'shared/cookies_banner' unless current_page?(cookies_policy_path) %>
-    <div id="govuk-header-container">
-      <header class="govuk-header" role="banner" data-module="govuk-header" id="govuk-header">
-        <div class="govuk-header__container govuk-width-container">
-          <%= render 'shared/navigation/header_logo' %>
-          <%= render 'shared/navigation/main_header' %>
-        </div>
-      </header>
-    </div>
+    <%= render 'shared/cookies_banner' if show_cookie_banner? %>
+    <% if !show_cookie_banner? %>
+      <div id="govuk-header-container">
+        <header class="govuk-header" role="banner" data-module="govuk-header" id="govuk-header">
+          <div class="govuk-header__container govuk-width-container">
+            <%= render 'shared/navigation/header_logo' %>
+            <%= render 'shared/navigation/main_header' %>
+          </div>
+        </header>
+      </div>
+    <% end %>
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper govuk-!-padding-top-1 govuk-!-padding-bottom-0 govuk-main-wrapper--auto-spacing" role="main">

--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -28,29 +28,11 @@
 
     <h2 class="govuk-heading-m">Necessary cookies</h2>
     <h3 class="govuk-heading-s">Introductory cookie message</h3>
-    <p class="govuk-body">When you first use the service we show a 'cookie message'. We then store a cookie on your computer so it knows not to show this message again.</p>
-
-    <table class="govuk-table">
-      <caption class="govuk-table__caption small govuk-visually-hidden">Cookie explanation</caption>
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header" scope="col">Name</th>
-          <th class="govuk-table__header" scope="col">Purpose</th>
-          <th class="govuk-table__header" scope="col">Expires</th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">seen_cookie_message</td>
-          <td class="govuk-table__cell">Lets us know you've already seen our cookie message</td>
-          <td class="govuk-table__cell">1 month</td>
-        </tr>
-      </tbody>
-    </table>
-    <p class="govuk-body">You won't be able to progress through our service until you interact with the cookie message by choosing either to accept cookies or change the cookie settings. You will need to leave the cookie on so that the service can remember what you chose. This is a necessary cookie.</p>
+    <p class="govuk-body">When you first use the service we show a 'cookie message'. You won't be able to progress through our service until you choose either to accept all cookies or accept necessary cookies.</p>
     <h3 class="govuk-heading-s">Necessary session cookies</h3>
     <p class="govuk-body">The session stores information about:</p>
     <ul>
+      <li>whether you have seen the cookie message and your cookie preferences</li>
       <li>the postcode you enter</li>
       <li>the job profiles and skills you select</li>
       <li>the steps you have completed on the task list</li>

--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -12,20 +12,23 @@
 <div class="govuk-grid-row govuk-!-margin-top-7 govuk-body">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
-    <p class="govuk-body">‘Get help to retrain’ puts small files (known as ‘cookies’) onto your computer to collect information about how you use the site.</p>
+    <p class="govuk-body">'Get help to retrain' puts small files (known as 'cookies') onto your computer to collect information about how you use the site.</p>
     <p class="govuk-body">Cookies are used to:</p>
     <ul>
       <li>measure how you use this service so it can be updated and improved based on your needs</li>
       <li>remember who you are if you return to your saved progress so we can show you your information and information relevant to you</li>
     </ul>
-    <p class="govuk-body">‘Get help to retrain’ cookies aren’t used to identify you personally. We record tracking information anonymously, so cookies do not track your personal data, only your activity on the site.</p>
+    <p class="govuk-body">'Get help to retrain' cookies aren't used to identify you personally. We record tracking information anonymously, so cookies do not track your personal data, only your activity on the site.</p>
+    <p class="govuk-body">In order to use service, you need to accept the necessary cookies. The necessary cookies are the introductory cookie message and the necessary session cookies.</p>
+    <p class="govuk-body">You can choose not to accept the session cookie but if you do this then the service won't be able to give you as much information. For example, the service won't be able to tell you how many jobs there are in your area or suggest local courses you can do.</p>
     <p class="govuk-body"><%= link_to('Find out more about cookies on GOV.UK', 'https://www.gov.uk/help/cookie-details', class: 'govuk-link') %></p>
 
     <h2 class="govuk-heading-m">How we use cookies</h2>
-    <p class="govuk-body">We use Google Analytics and Azure Application Insights software as well as service-specific cookies to collect information about how you use ‘Get help to retrain’. We do this to help make sure the service is meeting the needs of its users and to help us make improvements.</p>
+    <p class="govuk-body">We use Google Analytics as well as service-specific cookies to collect information about how you use 'Get help to retrain'. We do this to help make sure the service is meeting the needs of its users and to help us make improvements.</p>
 
+    <h2 class="govuk-heading-m">Necessary cookies</h2>
     <h3 class="govuk-heading-s">Introductory cookie message</h3>
-    <p class="govuk-body">When you first use the service we show a ‘cookie message’. We then store a cookie on your computer so it knows not to show this message again.</p>
+    <p class="govuk-body">When you first use the service we show a 'cookie message'. We then store a cookie on your computer so it knows not to show this message again.</p>
 
     <table class="govuk-table">
       <caption class="govuk-table__caption small govuk-visually-hidden">Cookie explanation</caption>
@@ -39,13 +42,13 @@
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">seen_cookie_message</td>
-          <td class="govuk-table__cell">Lets us know you’ve already seen our cookie message</td>
+          <td class="govuk-table__cell">Lets us know you've already seen our cookie message</td>
           <td class="govuk-table__cell">1 month</td>
         </tr>
       </tbody>
     </table>
-
-    <h3 class="govuk-heading-s">Essential session cookies</h3>
+    <p class="govuk-body">You won't be able to progress through our service until you interact with the cookie message by choosing either to accept cookies or change the cookie settings. You will need to leave the cookie on so that the service can remember what you chose. This is a necessary cookie.</p>
+    <h3 class="govuk-heading-s">Necessary session cookies</h3>
     <p class="govuk-body">The session stores information about:</p>
     <ul>
       <li>the postcode you enter</li>
@@ -53,7 +56,7 @@
       <li>the steps you have completed on the task list</li>
     </ul>
 
-    <p class="govuk-body">Our service sets the following essential session cookies:</p>
+    <p class="govuk-body">Our service sets the following necessary session cookies:</p>
 
     <table class="govuk-table">
       <caption class="govuk-table__caption small govuk-visually-hidden">Cookie explanation</caption>
@@ -73,53 +76,20 @@
       </tbody>
     </table>
 
-    <p class="govuk-body">In order for you to use this service, the essential session cookies always need to be on.</p>
-
-    <h3 class="govuk-heading-s">Measuring website usage using Azure Application Insights</h3>
-    <p class="govuk-body">This software stores information about:</p>
-    <ul>
-      <li>the pages you visit on ‘Get help to retrain’</li>
-      <li>how long you spend on each page</li>
-      <li>how you got to the service</li>
-      <li>what you click on while you’re visiting the service</li>
-    </ul>
-    <p class="govuk-body">We don’t allow Azure to use or share our analytics data.</p>
-    <p class="govuk-body">Our service sets the following cookies:</p>
-
-    <table class="govuk-table">
-      <caption class="govuk-table__caption small govuk-visually-hidden">Cookie explanation</caption>
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header" scope="col">Name</th>
-          <th class="govuk-table__header" scope="col">Purpose</th>
-          <th class="govuk-table__header" scope="col">Expires</th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">ai_user</td>
-          <td class="govuk-table__cell">Used to recognise you if you return to the website within 2 years.</td>
-          <td class="govuk-table__cell">2 years</td>
-        </tr>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">ai_session</td>
-          <td class="govuk-table__cell">Used to anonymously track what you do during your visit to the service.</td>
-          <td class="govuk-table__cell">30 minutes</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <p class="govuk-body">They always need to be on.</p>
-    <p class="govuk-body">You can find more information about <%= link_to('Azure Application Insights', 'https://azure.microsoft.com/en-gb/services/monitor/', class: 'govuk-link') %>‎.</p>
-
+    <p class="govuk-body">In order for you to use this service, the necessary session cookies always need to be on.</p>
+    <h2 class="govuk-heading-m">Optional cookies</h2>
     <h3 class="govuk-heading-s">Measuring website usage using Google Analytics</h3>
     <p class="govuk-body">This software stores information about:</p>
     <ul>
-      <li>whether you’ve visited before</li>
+      <li>whether you've visited before</li>
       <li>your unique user identity</li>
+      <li>the pages you visit on 'Get help to retrain'</li>
+      <li>how long you spend on each page</li>
+      <li>how you got to the service</li>
+      <li>what you click on while you're visiting the service</li>
     </ul>
-    <p class="govuk-body">We don’t allow Google to use or share our analytics data.</p>
-    <p class="govuk-body">Our service sets the following cookies:</p>
+    <p class="govuk-body">We don't allow Google to use or share our analytics data.</p>
+    <p class="govuk-body">This site sets the following cookies:</p>
 
     <table class="govuk-table">
       <caption class="govuk-table__caption small govuk-visually-hidden">Cookie explanation</caption>
@@ -133,17 +103,16 @@
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">_ga</td>
-          <td class="govuk-table__cell">This helps us count how many people visit our service by tracking if you’ve visited before.</td>
+          <td class="govuk-table__cell">This helps us count how many people visit GOV.UK by tracking if you've visited before</td>
           <td class="govuk-table__cell">2 years</td>
         </tr>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">_gid</td>
-          <td class="govuk-table__cell">This helps us count how many people visit our service by tracking if you’ve visited before.</td>
+          <td class="govuk-table__cell">This helps us count how many people visit GOV.UK by tracking if you've visited before</td>
           <td class="govuk-table__cell">24 hours</td>
         </tr>
       </tbody>
     </table>
-
-    <p class="govuk-body">You can opt out of <%= link_to('Google Analytics', 'https://tools.google.com/dlpage/gaoptout', class: 'govuk-link') %>.</p>
+    <p class="govuk-body">You don't need to accept these cookies in order to use our service.</p>
   </div>
 </div>

--- a/app/views/shared/_cookies_banner.html.erb
+++ b/app/views/shared/_cookies_banner.html.erb
@@ -1,22 +1,17 @@
 <div id="cookies-banner" class="cookies-modal">
-  <header class="govuk-header" role="banner" data-module="govuk-header" id="govuk-header">
-    <div class="govuk-header__container govuk-width-container govuk-!-padding-bottom-2">
-      <%= render 'shared/navigation/header_logo' %>
-      <%= render 'shared/navigation/main_header' %>
-    </div>
-  </header>
+  <%= render partial: 'shared/header', locals: { container_class: ' govuk-!-padding-bottom-2' } %>
   <div class="cookies-modal-content govuk-clearfix" id="cookies-modal">
     <div class="govuk-width-container">
       <div class="govuk-grid-row">
         <div class=" govuk-grid-column-full">
           <div class="govuk-main-wrapper govuk-!-padding-top-1 govuk-!-padding-bottom-1" role="region" aria-label="cookie banner">
-        <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">This service uses cookie</p>
+        <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">This service uses cookies</p>
         <p class="govuk-body cookies-modal-summary">This service uses necessary cookies to make our service work.</p>
         <p class="govuk-body cookies-modal-details">This service uses necessary cookies to make our service work. We would also like to set optional cookies to help us improve it. We won’t set optional cookies unless you agree that we can enable them.</p>
 
         <%= form_with local: true, url: update_cookie_preferences_path do %>
           <%= submit_tag('Accept all cookies', name: 'cookies[all]', role: 'button', class: 'govuk-button govuk-button--primary govuk-!-margin-right-5 cookies-modal-details', data: { module: 'govuk-button' }) %>
-          <%= submit_tag('Accept necessary cookies only', name: 'cookies[partial]', role: 'button', class: 'govuk-button govuk-button--primary', id: 'cookies-partial-button', data: { module: 'govuk-button' }) %>
+          <%= submit_tag('Accept necessary cookies only', name: 'cookies[necessary]', role: 'button', class: 'govuk-button govuk-button--primary', id: 'cookies-necessary-button', data: { module: 'govuk-button' }) %>
         <% end %>
         <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Necessary cookies</p>
         <p class="govuk-body">Necessary cookies do things such as remember your postcode so the service can recommend local courses and jobs. You can disable necessary cookies by changing your browser settings but this will mean the service can’t offer you as many features.</p>

--- a/app/views/shared/_cookies_banner.html.erb
+++ b/app/views/shared/_cookies_banner.html.erb
@@ -1,11 +1,33 @@
 <div id="cookies-banner" class="cookies-modal">
-  <div class="cookies-modal-content" id="cookies-modal">
+  <header class="govuk-header" role="banner" data-module="govuk-header" id="govuk-header">
+    <div class="govuk-header__container govuk-width-container govuk-!-padding-bottom-2">
+      <%= render 'shared/navigation/header_logo' %>
+      <%= render 'shared/navigation/main_header' %>
+    </div>
+  </header>
+  <div class="cookies-modal-content govuk-clearfix" id="cookies-modal">
     <div class="govuk-width-container">
-      <div class="govuk-main-wrapper govuk-!-padding-top-1 govuk-!-padding-bottom-1" role="region" aria-label="cookie banner">
-        <p class="govuk-body">This service uses cookies to personalise your experience and to collect information about how you use the site. You can find out more about cookies by clicking the cookies settings button.</p>
-        <%= link_to 'Accept cookies', '#', id: 'accept-cookies', class: 'govuk-button govuk-button--secondary govuk-!-margin-right-5', role: 'button', data: { module: 'govuk-button' } %>
-        <%= link_to 'Cookie settings', cookies_policy_path, class: 'govuk-button govuk-button--secondary', data: { module: 'govuk-button' } %>
+      <div class="govuk-grid-row">
+        <div class=" govuk-grid-column-full">
+          <div class="govuk-main-wrapper govuk-!-padding-top-1 govuk-!-padding-bottom-1" role="region" aria-label="cookie banner">
+        <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">This service uses cookie</p>
+        <p class="govuk-body cookies-modal-summary">This service uses necessary cookies to make our service work.</p>
+        <p class="govuk-body cookies-modal-details">This service uses necessary cookies to make our service work. We would also like to set optional cookies to help us improve it. We won’t set optional cookies unless you agree that we can enable them.</p>
+
+        <%= form_with local: true, url: update_cookie_preferences_path do %>
+          <%= submit_tag('Accept all cookies', name: 'cookies[all]', role: 'button', class: 'govuk-button govuk-button--primary govuk-!-margin-right-5 cookies-modal-details', data: { module: 'govuk-button' }) %>
+          <%= submit_tag('Accept necessary cookies only', name: 'cookies[partial]', role: 'button', class: 'govuk-button govuk-button--primary', id: 'cookies-partial-button', data: { module: 'govuk-button' }) %>
+        <% end %>
+        <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Necessary cookies</p>
+        <p class="govuk-body">Necessary cookies do things such as remember your postcode so the service can recommend local courses and jobs. You can disable necessary cookies by changing your browser settings but this will mean the service can’t offer you as many features.</p>
+        <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1 cookies-modal-details">Cookies that measure website use</p>
+        <p class="govuk-body govuk-!-margin-bottom-1 cookies-modal-details">We use Google Analytics to measure how you use Get help to retrain so we can improve it based on user needs. Google Analytics sets cookies that record how you got to the service, the pages you visit, how long you spend on each page and what you do there. These cookies collect information anonymously. If you disable optional cookies you can still use all the features in this service.</p>
+
+        <p class="govuk-body govuk-!-margin-bottom-6">You can find out more about cookies in our <%= link_to 'cookies policy', cookies_policy_path, class: 'govuk-link' %>.</p>
+          </div>
+        </div>
       </div>
     </div>
   </div>
 </div>
+

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,6 @@
+<header class="govuk-header" role="banner" data-module="govuk-header" id="govuk-header">
+  <div class="govuk-header__container govuk-width-container<%= container_class %>">
+    <%= render 'shared/navigation/header_logo' %>
+    <%= render 'shared/navigation/main_header' %>
+  </div>
+</header>

--- a/app/views/shared/tracking/_google_analytics.html.erb
+++ b/app/views/shared/tracking/_google_analytics.html.erb
@@ -1,4 +1,4 @@
-<% if Rails.configuration.google_analytics_tracking_id.present? %>
+<% if Rails.configuration.google_analytics_tracking_id.present? && user_session.cookies %>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=<%= Rails.configuration.google_analytics_tracking_id %>"></script>
   <script>

--- a/app/webpacker/packs/cookies-banner.js
+++ b/app/webpacker/packs/cookies-banner.js
@@ -3,64 +3,26 @@ function CookiesBanner () {
     var cookiesModal = document.querySelector('#cookies-banner');
 
     if (typeof(cookiesModal) !== 'undefined' && cookiesModal != null) {
-      if (getCookie('seen_cookie_message') !== 'true') {
-        displayCookiesModal(cookiesModal);
-        trapFocus(cookiesModal);
-      }
+      displayCookiesModalButton();
+      trapFocus(cookiesModal);
     }
   }
 
-  function getCookie(name) {
-    var v = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
-
-    return v ? v[2] : null;
-  }
-
-  function setCookie(name, value, days) {
-    var date = new Date;
-
-    date.setTime(date.getTime() + 24*60*60*1000*days);
-    document.cookie = name + "=" + value + ";path=/;expires=" + date.toGMTString();
-  }
-
-  function displayCookiesModal(modalElement) {
-    modalElement.insertBefore(document.querySelector('#govuk-header'), document.querySelector('#cookies-modal'));
-    document.querySelector('.govuk-header__container').classList.add('govuk-!-padding-bottom-2');
-
-    modalElement.style.display = 'block';
-
-    var cookiesAccept = document.querySelector('#accept-cookies');
-
-    if (typeof(cookiesAccept) !== 'undefined' && cookiesAccept != null) {
-      handleAcceptCookies(modalElement, cookiesAccept);
-    }
-  }
-
-  function handleAcceptCookies(modalElement, acceptElement) {
-    acceptElement.onclick = function(e) {
-      e.preventDefault();
-
-      document.querySelector('#govuk-header-container').appendChild(
-        document.querySelector('#govuk-header')
-      );
-      document.querySelector('.govuk-header__container').classList.remove('govuk-!-padding-bottom-2');
-
-      modalElement.style.display = 'none';
-      setCookie('seen_cookie_message', 'true', 30);
-    }
+  function displayCookiesModalButton(modalElement) {
+    document.querySelector('#cookies-partial-button').className = 'govuk-button govuk-button--secondary';
   }
 
   function trapFocus(element) {
     var focusableElements = element.querySelectorAll('a[href]:not([disabled])');
-    var firstElement = focusableElements[0];  
+    var firstElement = focusableElements[0];
     var lastElement = focusableElements[focusableElements.length - 1];
     var KEYCODE_TAB = 9;
 
     element.addEventListener('keydown', function(e) {
       var isTabPressed = (e.keyCode === KEYCODE_TAB);
 
-      if (!isTabPressed) { 
-        return; 
+      if (!isTabPressed) {
+        return;
       }
 
       if ( e.shiftKey ) /* shift + tab */ {

--- a/app/webpacker/packs/cookies-banner.js
+++ b/app/webpacker/packs/cookies-banner.js
@@ -9,7 +9,7 @@ function CookiesBanner () {
   }
 
   function displayCookiesModalButton(modalElement) {
-    document.querySelector('#cookies-partial-button').className = 'govuk-button govuk-button--secondary';
+    document.querySelector('#cookies-necessary-button').className = 'govuk-button govuk-button--secondary';
   }
 
   function trapFocus(element) {

--- a/app/webpacker/styles/_cookies.scss
+++ b/app/webpacker/styles/_cookies.scss
@@ -12,7 +12,6 @@
   display: none;
 }
 
-
 .cookies-modal {
   position: fixed;
   z-index: 1000;

--- a/app/webpacker/styles/_cookies.scss
+++ b/app/webpacker/styles/_cookies.scss
@@ -1,5 +1,19 @@
-.cookies-modal {
+.js-enabled {
+  .cookies-modal-details {
+    display: inline-block;
+  }
+
+  .cookies-modal-summary {
+    display: none;
+  }
+}
+
+.cookies-modal-details {
   display: none;
+}
+
+
+.cookies-modal {
   position: fixed;
   z-index: 1000;
   left: 0;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,8 @@ Rails.application.routes.draw do
     get 'link-expired', to: 'users#link_expired'
     get '/sign-in/:token', to: 'passwordless/sessions#show', authenticatable: 'user', as: :token_sign_in
 
+    post 'update-cookie-preferences', to: 'cookies#update'
+
     root to: 'home#index'
   end
 end

--- a/spec/features/cookies_banner_spec.rb
+++ b/spec/features/cookies_banner_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.feature 'Cookies Banner', type: :feature do
+  scenario 'User sees cookies modal with two options' do
+    visit(root_path)
+
+    ['Accept all cookies', 'Accept necessary cookies only'].each do |content|
+      expect(page).to have_button(content)
+    end
+  end
+
+  scenario 'User does not see cookies modal on cookies policy page' do
+    visit(root_path)
+    click_on('cookies policy')
+
+    ['Accept all cookies', 'Accept necessary cookies only'].each do |content|
+      expect(page).not_to have_button(content)
+    end
+  end
+
+  scenario 'User does not see cookies modal when they accept all cookies' do
+    visit(root_path)
+    click_on('Accept all cookies')
+
+    ['Accept all cookies', 'Accept necessary cookies only'].each do |content|
+      expect(page).not_to have_button(content)
+    end
+  end
+
+  scenario 'User does not see cookies modal when they accept necessary cookies only' do
+    visit(root_path)
+    click_on('Accept necessary cookies only')
+
+    ['Accept all cookies', 'Accept necessary cookies only'].each do |content|
+      expect(page).not_to have_button(content)
+    end
+  end
+
+  scenario 'User is redirected to same page they saw cookies modal on' do
+    visit(your_information_path)
+    click_on('Accept necessary cookies only')
+
+    expect(page).to have_current_path(your_information_path)
+  end
+end

--- a/spec/features/google_analytics_tracking_spec.rb
+++ b/spec/features/google_analytics_tracking_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Google Analytics tracking' do
     allow(Rails.configuration).to receive(:google_analytics_tracking_id).and_return('FOO')
 
     visit(root_path)
+    click_on('Accept all cookies')
 
     expect(page.source).to include("gtag('config', 'FOO')")
   end
@@ -13,6 +14,16 @@ RSpec.feature 'Google Analytics tracking' do
     allow(Rails.configuration).to receive(:google_analytics_tracking_id).and_return(nil)
 
     visit(root_path)
+    click_on('Accept all cookies')
+
+    expect(page.source).not_to include('gtag')
+  end
+
+  scenario 'snippet is not included when user only accepts necessary cookies' do
+    allow(Rails.configuration).to receive(:google_analytics_tracking_id).and_return(nil)
+
+    visit(root_path)
+    click_on('Accept necessary cookies only')
 
     expect(page.source).not_to include('gtag')
   end

--- a/spec/features/google_analytics_tracking_spec.rb
+++ b/spec/features/google_analytics_tracking_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Google Analytics tracking' do
   end
 
   scenario 'snippet is not included when user only accepts necessary cookies' do
-    allow(Rails.configuration).to receive(:google_analytics_tracking_id).and_return(nil)
+    allow(Rails.configuration).to receive(:google_analytics_tracking_id).and_return('FOO')
 
     visit(root_path)
     click_on('Accept necessary cookies only')

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'Navigation from home page' do
   scenario 'User can access the cookies policy page from the cookies modal', :js do
     visit(root_path)
 
-    click_on('Cookie settings')
+    click_on('cookies policy')
 
     expect(page).to have_text('Cookies are used')
   end

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Skills matcher', type: :feature do
 
   def visit_skills_for_current_job_profile(js_enabled = false)
     visit(job_profile_skills_path(job_profile_id: current_job_profile.slug))
-    click_on('Accept cookies') if js_enabled
+    click_on('Accept all cookies') if js_enabled
     click_on('Select these skills')
     click_on('Find out what you can do with these skills')
   end

--- a/spec/features/user_feedback_survey_spec.rb
+++ b/spec/features/user_feedback_survey_spec.rb
@@ -52,13 +52,13 @@ RSpec.feature 'User Feedback In Page Survey' do
 
   def answer_yes
     visit(task_list_path)
-    click_on('Accept cookies')
+    click_on('Accept all cookies')
     click_on('Yes')
   end
 
   def answer_no
     visit(task_list_path)
-    click_on('Accept cookies')
+    click_on('Accept all cookies')
     click_on('No')
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -130,4 +130,43 @@ RSpec.describe ApplicationHelper do
       expect(helper.back_link).to eq('<a class="govuk-back-link" href="/">Back</a>')
     end
   end
+
+  describe '.show_cookie_banner?' do
+    let(:user_session) { UserSession.new(session) }
+
+    before do
+      helper.singleton_class.class_eval do
+        def user_session
+          UserSession.new(session)
+        end
+      end
+    end
+
+    it 'returns false if current page is the cookie policy' do
+      allow(helper).to receive(:current_page?).and_return true
+
+      expect(helper).not_to be_show_cookie_banner
+    end
+
+    it 'returns true if current page is not the cookie policy, and cookie is empty' do
+      allow(helper).to receive(:current_page?).and_return false
+
+      expect(helper).to be_show_cookie_banner
+    end
+
+    it 'returns true if current page is not cookie policy, ghtr cookie is present and no user session cookie present' do
+      allow(helper).to receive(:current_page?).and_return false
+      allow(helper).to receive(:cookies).and_return('_get_help_to_retrain_session' => true)
+
+      expect(helper).to be_show_cookie_banner
+    end
+
+    it 'returns false if current page is not cookie policy, and both cookie and session are present' do
+      allow(helper).to receive(:current_page?).and_return false
+      allow(helper).to receive(:cookies).and_return('_get_help_to_retrain_session' => true)
+      user_session.cookies = true
+
+      expect(helper).not_to be_show_cookie_banner
+    end
+  end
 end

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe UserSession do
         'session_id' => 2,
         'training' => ['english_skills'],
         'job_hunting' => ['cv'],
-        'skills_matcher_sort' => 'growth',
-        'cookies' => false
+        'skills_matcher_sort' => 'growth'
       }
       new_session = { 'session_id' => 1 }
       described_class.merge_sessions(new_session: new_session, previous_session_data: old_session)
@@ -27,8 +26,7 @@ RSpec.describe UserSession do
         'session_id' => 1,
         'training' => ['english_skills'],
         'job_hunting' => ['cv'],
-        'skills_matcher_sort' => 'growth',
-        'cookies' => false
+        'skills_matcher_sort' => 'growth'
       )
     end
 

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe UserSession do
         'session_id' => 2,
         'training' => ['english_skills'],
         'job_hunting' => ['cv'],
-        'skills_matcher_sort' => 'growth'
+        'skills_matcher_sort' => 'growth',
+        'cookies' => false
       }
       new_session = { 'session_id' => 1 }
       described_class.merge_sessions(new_session: new_session, previous_session_data: old_session)
@@ -26,7 +27,8 @@ RSpec.describe UserSession do
         'session_id' => 1,
         'training' => ['english_skills'],
         'job_hunting' => ['cv'],
-        'skills_matcher_sort' => 'growth'
+        'skills_matcher_sort' => 'growth',
+        'cookies' => false
       )
     end
 
@@ -124,6 +126,18 @@ RSpec.describe UserSession do
 
     it 'returns an empty array if no job_hunting set' do
       expect(user_session.job_hunting).to be_nil
+    end
+  end
+
+  describe '#cookies' do
+    it 'returns cookies if set' do
+      user_session.cookies = true
+
+      expect(user_session.cookies).to eq(true)
+    end
+
+    it 'returns nil if no cookies set' do
+      expect(user_session.cookies).to be_nil
     end
   end
 

--- a/spec/services/tracking_service_spec.rb
+++ b/spec/services/tracking_service_spec.rb
@@ -74,6 +74,33 @@ RSpec.describe TrackingService do
       end
     end
 
+    context 'without a ga_cookie' do
+      subject(:service) {
+        described_class.new(
+          client_tracking_data: {},
+          ga_tracking_id: ga_tracking_id
+        )
+      }
+
+      before do
+        fake_batch_request_with(URI.encode_www_form(event_payload))
+      end
+
+      it 'does not make a call to GA' do
+        service.track_events(
+          props: [
+            {
+              key: :event_category,
+              label: 'Event Label',
+              value: 'Event action'
+            }
+          ]
+        )
+
+        expect(a_request(:post, /google/)).not_to have_been_made
+      end
+    end
+
     context 'with a valid ga_tracking ID' do
       before do
         fake_batch_request_with(URI.encode_www_form(event_payload))


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-974

* update policy page as we no longer use azure app insights and to
reflect new cookie policy guidelines
* User's selected values for cookies should be saved to a session. We
are using boolean now to show a user accepted all cookies or partial
cookies
*  show/hide cookie banner as a session available on for user and avoid creating session on home page
* Amend cookies modal to not rely on js and appear in different forms
with and without js. With js we see two options, without only one option.
* Hide/show content according to js being enabled or disabled
* When js is disabled we are ok for now not to trap focus
* When a user accepts all cookies user session set to true, when
partial set to false