### PR TITLE
GET-1054 Replace find a course link with button

### DIFF
--- a/app/views/pages/_find_other_courses.html.erb
+++ b/app/views/pages/_find_other_courses.html.erb
@@ -1,0 +1,9 @@
+  <p class="govuk-body govuk-!-margin-top-3">You can find other types of training by searching on Find a course, run by the National Careers Service. This button will take you to another government service.</p>
+  <div class="govuk-grid-row govuk-!-margin-bottom-0">
+    <div class="govuk-grid-column-one-half">
+      <h3 class="govuk-heading-s">Search for other courses</h3>
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <%= link_to 'Find other courses', 'https://nationalcareers.service.gov.uk/find-a-course', class: 'govuk-button govuk-button--secondary action-plan-action govuk-!-margin-bottom-2', data: { module: 'govuk-button' } %>
+    </div>
+  </div>

--- a/app/views/pages/_training.html.erb
+++ b/app/views/pages/_training.html.erb
@@ -43,17 +43,9 @@
       </div>
     <% end %>
   </div>
-  <p class="govuk-body govuk-!-margin-top-3">You can find other types of training by searching on Find a course, run by the National Careers Service. This button will take you to another government service.</p>
-  <div class="govuk-grid-row govuk-!-margin-bottom-0">
-    <div class="govuk-grid-column-one-half">
-      <h3 class="govuk-heading-s">Search for other courses</h3>
-    </div>
-    <div class="govuk-grid-column-one-half">
-      <%= link_to 'Find other courses', 'https://nationalcareers.service.gov.uk/find-a-course', class: 'govuk-button govuk-button--secondary action-plan-action govuk-!-margin-bottom-2', data: { module: 'govuk-button' } %>
-    </div>
-  </div>
+  <%= render 'find_other_courses' %>
   <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-3">Remember, you may be able to get funding to support your training, including help with things such as travel and childcare expenses.</p>
 <% else %>
   <p class="govuk-body">You chose not to get help with your maths, English, or computer skills. If you change your mind, you can edit your training choices. Remember, these courses are usually free and you may be able to get help with training costs such as travel and childcare expenses.</p>
-  <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-3">You can search for courses on <%= link_to('Find a course', 'https://nationalcareers.service.gov.uk/find-a-course', class: 'govuk-link') %>, run by the National Careers Service.</p>
+  <%= render 'find_other_courses' %>
 <% end %>


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-1054

Move button to partial as with/without training options
we have different text under the button. Remove old link text and button
when no training is selected.

