### PR TITLE
Get 1087 update breadcrumbs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::Base
   end
 
   def url_parser
-    @url_parser ||= UrlParser.new(request.referer, request.host)
+    @url_parser ||= UrlParser.new(request.referer, request.host, request.original_url)
   end
 
   helper_method :user_session, :current_user, :url_parser

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,7 +49,7 @@ class UsersController < ApplicationController
   end
 
   def set_redirect_path_for_registration
-    redirect_url = url_parser.get_redirect_path(paths_to_ignore: [save_your_results_path])
+    redirect_url = url_parser.get_redirect_path(paths_to_ignore: [save_your_results_path, email_sent_again_path])
     user_session.registration_triggered_path = redirect_url
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,8 +43,7 @@ module ApplicationHelper
   def back_url(paths_to_ignore)
     url = url_parser.get_redirect_path(paths_to_ignore: paths_to_ignore)
 
-    return root_path unless url.present?
-    return task_list_path if request.original_url.include?(url)
+    return root_path if url.nil? || request.original_url.include?(url)
 
     url
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,22 +29,14 @@ module ApplicationHelper
   end
 
   def back_link(custom_url: nil, paths_to_ignore: [])
-    link_to('Back', custom_url || back_url(paths_to_ignore), class: 'govuk-back-link')
+    back_url = custom_url || url_parser.get_redirect_path(paths_to_ignore: paths_to_ignore) || root_path
+
+    link_to('Back', back_url, class: 'govuk-back-link')
   end
 
   def show_cookie_banner?
     return if current_page?(cookies_policy_path)
 
     cookies['_get_help_to_retrain_session'].blank? || user_session.cookies.nil?
-  end
-
-  private
-
-  def back_url(paths_to_ignore)
-    url = url_parser.get_redirect_path(paths_to_ignore: paths_to_ignore)
-
-    return root_path unless url
-
-    url
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,7 +43,7 @@ module ApplicationHelper
   def back_url(paths_to_ignore)
     url = url_parser.get_redirect_path(paths_to_ignore: paths_to_ignore)
 
-    return root_path if url.nil? || request.original_url.include?(url)
+    return root_path unless url
 
     url
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,15 +28,24 @@ module ApplicationHelper
     @target_job ||= JobProfile.find_by(id: user_session.target_job_id)
   end
 
-  def back_link
-    back_url = url_parser.get_redirect_path || root_path
-
-    link_to('Back', back_url, class: 'govuk-back-link')
+  def back_link(custom_url: nil, paths_to_ignore: [])
+    link_to('Back', custom_url || back_url(paths_to_ignore), class: 'govuk-back-link')
   end
 
   def show_cookie_banner?
     return if current_page?(cookies_policy_path)
 
     cookies['_get_help_to_retrain_session'].blank? || user_session.cookies.nil?
+  end
+
+  private
+
+  def back_url(paths_to_ignore)
+    url = url_parser.get_redirect_path(paths_to_ignore: paths_to_ignore)
+
+    return root_path unless url.present?
+    return task_list_path if request.original_url.include?(url)
+
+    url
   end
 end

--- a/app/helpers/question_helper.rb
+++ b/app/helpers/question_helper.rb
@@ -26,6 +26,20 @@ module QuestionHelper
     )
   end
 
+  def job_hunting_question_breadcrumbs
+    return back_link(custom_url: it_training_questions_path) if questions_path
+
+    content_for(:breadcrumb) do
+      generate_breadcrumbs(
+        t('breadcrumb.edit_your_advice_choices'), [
+          [t('breadcrumb.home'), root_path],
+          [t('breadcrumb.task_list'), task_list_path],
+          [t('breadcrumb.action_plan'), action_plan_path]
+        ]
+      )
+    end
+  end
+
   def questions_path
     training_questions ||
       it_training_questions ||

--- a/app/lib/url_parser.rb
+++ b/app/lib/url_parser.rb
@@ -1,14 +1,15 @@
 class UrlParser
-  attr_reader :uri, :host
+  attr_reader :uri, :host, :original
 
-  def initialize(referer, host)
+  def initialize(referer, host, original = nil)
     @uri = URI(referer) if referer
     @host = host
+    @original = URI(original) if original
   end
 
   def get_redirect_path(paths_to_ignore: [])
     return unless recognized_host?
-    return if paths_to_ignore.include?(uri.path)
+    return if paths_to_ignore.include?(uri.path) || referred_from_same_page?
 
     uri.request_uri
   end
@@ -21,5 +22,11 @@ class UrlParser
     uri.host == host
   rescue ArgumentError, URI::Error
     false
+  end
+
+  def referred_from_same_page?
+    return unless original
+
+    original.path == uri.path
   end
 end

--- a/app/views/check_your_skills/index.html.erb
+++ b/app/views/check_your_skills/index.html.erb
@@ -3,7 +3,8 @@
     generate_breadcrumbs(
       t('breadcrumb.check_your_skills'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path]
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path]
       ]
     )
   end

--- a/app/views/check_your_skills/results.html.erb
+++ b/app/views/check_your_skills/results.html.erb
@@ -1,9 +1,10 @@
 <% page_title :check_your_skills_results %>
 <% content_for :breadcrumb do
     generate_breadcrumbs(
-      t('breadcrumb.search_results'),
+      t('breadcrumb.search_your_skills_results'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path],
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path],
         [t('breadcrumb.check_your_skills'), check_your_skills_path]
       ]
     )

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -4,7 +4,8 @@
     generate_breadcrumbs(
       t('breadcrumb.training_courses_near_you'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path],
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path],
         [t('breadcrumb.action_plan'), action_plan_path]
       ]
     )

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -4,7 +4,8 @@
     generate_breadcrumbs(
       t('breadcrumb.course_details'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path],
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path],
         [t('breadcrumb.action_plan'), action_plan_path],
         [t('breadcrumb.csv_courses_training_courses_near_you'), courses_path(topic_id: params[:topic_id])]
       ]

--- a/app/views/errors/save_results_error.html.erb
+++ b/app/views/errors/save_results_error.html.erb
@@ -4,7 +4,8 @@
     generate_breadcrumbs(
       t('breadcrumb.results_saved'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path]
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path]
       ]
     )
   end

--- a/app/views/job_profiles/index.html.erb
+++ b/app/views/job_profiles/index.html.erb
@@ -3,7 +3,8 @@
     generate_breadcrumbs(
       t('breadcrumb.job_profiles_search'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path]
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path]
       ]
     )
   end

--- a/app/views/job_profiles/results.html.erb
+++ b/app/views/job_profiles/results.html.erb
@@ -3,7 +3,8 @@
     generate_breadcrumbs(
       t('breadcrumb.job_profiles_search'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path]
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path]
       ]
     )
   end

--- a/app/views/job_profiles/show.html.erb
+++ b/app/views/job_profiles/show.html.erb
@@ -3,7 +3,8 @@
     generate_breadcrumbs(
       t('breadcrumb.job_profile'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path],
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path],
         [t('breadcrumb.job_matches'), skills_matcher_index_path],
       ]
     )

--- a/app/views/job_profiles/skills/index.html.erb
+++ b/app/views/job_profiles/skills/index.html.erb
@@ -3,7 +3,8 @@
     generate_breadcrumbs(
       t('breadcrumb.current_job_skills'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path],
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path],
         [t('breadcrumb.check_your_skills'), check_your_skills_path],
         [t('breadcrumb.search_results'), results_check_your_skills_path(search: params[:search])]
       ]

--- a/app/views/job_vacancies/index.html.erb
+++ b/app/views/job_vacancies/index.html.erb
@@ -4,7 +4,8 @@
     generate_breadcrumbs(
       t('breadcrumb.jobs_near_me'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path],
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path],
         [t('breadcrumb.action_plan'), action_plan_path]
       ]
     )

--- a/app/views/pages/action_plan.html.erb
+++ b/app/views/pages/action_plan.html.erb
@@ -3,7 +3,8 @@
     generate_breadcrumbs(
       t('breadcrumb.action_plan'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path]
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path]
       ]
     )
   end

--- a/app/views/pages/cover_letter_advice.html.erb
+++ b/app/views/pages/cover_letter_advice.html.erb
@@ -3,7 +3,8 @@
     generate_breadcrumbs(
       t('breadcrumb.cover_letter_advice'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path],
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path],
         [t('breadcrumb.action_plan'), action_plan_path]
       ]
     )

--- a/app/views/pages/cv_advice.html.erb
+++ b/app/views/pages/cv_advice.html.erb
@@ -3,7 +3,8 @@
     generate_breadcrumbs(
       t('breadcrumb.cv_advice'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path],
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path],
         [t('breadcrumb.action_plan'), action_plan_path]
       ]
     )

--- a/app/views/pages/interview_advice.html.erb
+++ b/app/views/pages/interview_advice.html.erb
@@ -3,7 +3,8 @@
     generate_breadcrumbs(
       t('breadcrumb.interview_advice'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path],
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path],
         [t('breadcrumb.action_plan'), action_plan_path]
       ]
     )

--- a/app/views/pages/offers_near_me.html.erb
+++ b/app/views/pages/offers_near_me.html.erb
@@ -3,7 +3,8 @@
     generate_breadcrumbs(
       t('breadcrumb.offers_near_me'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path],
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path],
         [t('breadcrumb.action_plan'), action_plan_path]
       ]
     )

--- a/app/views/questions/edit_training.html.erb
+++ b/app/views/questions/edit_training.html.erb
@@ -3,7 +3,8 @@
     generate_breadcrumbs(
       t('breadcrumb.edit_training_questions'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path],
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path],
         [t('breadcrumb.action_plan'), action_plan_path]
       ]
     )

--- a/app/views/questions/it_training.html.erb
+++ b/app/views/questions/it_training.html.erb
@@ -1,5 +1,5 @@
 <% page_title :it_training_questions %>
-<%= back_link %>
+<%= back_link(custom_url: training_questions_path) %>
 
 <div class="govuk-grid-row govuk-!-margin-top-7 govuk-body">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/questions/it_training.html.erb
+++ b/app/views/questions/it_training.html.erb
@@ -1,13 +1,5 @@
 <% page_title :it_training_questions %>
-<% content_for :breadcrumb do
-    generate_breadcrumbs(
-      t('breadcrumb.it_training_questions'),
-      [
-        [t('breadcrumb.task_list_home'), task_list_path]
-      ]
-    )
-  end
-%>
+<%= back_link %>
 
 <div class="govuk-grid-row govuk-!-margin-top-7 govuk-body">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/questions/job_hunting.html.erb
+++ b/app/views/questions/job_hunting.html.erb
@@ -1,5 +1,6 @@
 <% page_title :job_hunting_questions %>
-<%= back_link(custom_url: it_training_questions_path) %>
+
+<%= job_hunting_question_breadcrumbs %>
 
 <div class="govuk-grid-row govuk-!-margin-top-7 govuk-body">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/questions/job_hunting.html.erb
+++ b/app/views/questions/job_hunting.html.erb
@@ -1,5 +1,5 @@
 <% page_title :job_hunting_questions %>
-<%= back_link %>
+<%= back_link(custom_url: it_training_questions_path) %>
 
 <div class="govuk-grid-row govuk-!-margin-top-7 govuk-body">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/questions/job_hunting.html.erb
+++ b/app/views/questions/job_hunting.html.erb
@@ -1,13 +1,5 @@
 <% page_title :job_hunting_questions %>
-<% content_for :breadcrumb do
-    generate_breadcrumbs(
-      t('breadcrumb.job_hunting_questions'),
-      [
-        [t('breadcrumb.task_list_home'), task_list_path]
-      ]
-    )
-  end
-%>
+<%= back_link %>
 
 <div class="govuk-grid-row govuk-!-margin-top-7 govuk-body">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/questions/training.html.erb
+++ b/app/views/questions/training.html.erb
@@ -1,13 +1,5 @@
 <% page_title :training_questions %>
-<% content_for :breadcrumb do
-    generate_breadcrumbs(
-      t('breadcrumb.training_questions'),
-      [
-        [t('breadcrumb.task_list_home'), task_list_path]
-      ]
-    )
-  end
-%>
+<%= back_link %>
 
 <div class="govuk-grid-row govuk-!-margin-top-7 govuk-body">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/questions/training.html.erb
+++ b/app/views/questions/training.html.erb
@@ -1,5 +1,5 @@
 <% page_title :training_questions %>
-<%= back_link %>
+<%= back_link(custom_url: skills_matcher_index_path) %>
 
 <div class="govuk-grid-row govuk-!-margin-top-7 govuk-body">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/skills/index.html.erb
+++ b/app/views/skills/index.html.erb
@@ -3,7 +3,8 @@
     generate_breadcrumbs(
       t('breadcrumb.your_skills'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path]
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path],
       ]
     )
   end

--- a/app/views/skills_matcher/index.html.erb
+++ b/app/views/skills_matcher/index.html.erb
@@ -3,7 +3,8 @@
     generate_breadcrumbs(
       t('breadcrumb.job_matches'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path]
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path]
       ]
     )
   end

--- a/app/views/users/link_expired.html.erb
+++ b/app/views/users/link_expired.html.erb
@@ -3,7 +3,8 @@
     generate_breadcrumbs(
       t('breadcrumb.link_expired'),
       [
-        [t('breadcrumb.task_list_home'), task_list_path]
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path]
       ]
     )
   end

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,13 +1,6 @@
 <% page_title :save_your_results %>
-<% content_for :breadcrumb do
-    generate_breadcrumbs(
-      t('breadcrumb.save_your_results'),
-      [
-        [t('breadcrumb.task_list_home'), task_list_path]
-      ]
-    )
-  end
-%>
+<%= back_link(paths_to_ignore: [email_sent_again_path]) %>
+
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <%= error_summary(@user) %>

--- a/app/views/users/registration_email_sent_again.html.erb
+++ b/app/views/users/registration_email_sent_again.html.erb
@@ -1,13 +1,6 @@
 <% page_title :email_sent_again %>
-<% content_for :breadcrumb do
-    generate_breadcrumbs(
-      t('breadcrumb.email_sent_again'),
-      [
-        [t('breadcrumb.task_list_home'), task_list_path]
-      ]
-    )
-  end
-%>
+<%= back_link %>
+
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>

--- a/app/views/users/registration_results_saved.html.erb
+++ b/app/views/users/registration_results_saved.html.erb
@@ -1,13 +1,6 @@
 <% page_title :results_saved %>
-<% content_for :breadcrumb do
-    generate_breadcrumbs(
-      t('breadcrumb.results_saved'),
-      [
-        [t('breadcrumb.task_list_home'), task_list_path]
-      ]
-    )
-  end
-%>
+<%= back_link(custom_url: save_your_progress_path) %>
+
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>

--- a/app/views/users/return_to_saved_results.html.erb
+++ b/app/views/users/return_to_saved_results.html.erb
@@ -1,13 +1,5 @@
 <% page_title :return_to_saved_results %>
-<% content_for :breadcrumb do
-    generate_breadcrumbs(
-      t('breadcrumb.return_to_saved_results'),
-      [
-        [t('breadcrumb.task_list_home'), task_list_path]
-      ]
-    )
-  end
-%>
+<%= back_link(paths_to_ignore: [link_sent_again_path]) %>
 
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/users/sign_in_link_sent.html.erb
+++ b/app/views/users/sign_in_link_sent.html.erb
@@ -1,13 +1,5 @@
 <% page_title :link_sent %>
-<% content_for :breadcrumb do
-    generate_breadcrumbs(
-      t('breadcrumb.link_sent'),
-      [
-        [t('breadcrumb.home'), root_path]
-      ]
-    )
-  end
-%>
+<%= back_link(custom_url: return_to_saved_results_path) %>
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>

--- a/app/views/users/sign_in_link_sent_again.html.erb
+++ b/app/views/users/sign_in_link_sent_again.html.erb
@@ -1,13 +1,6 @@
 <% page_title :link_sent_again %>
-<% content_for :breadcrumb do
-    generate_breadcrumbs(
-      t('breadcrumb.link_sent_again'),
-      [
-        [t('breadcrumb.home'), root_path]
-      ]
-    )
-  end
-%>
+<%= back_link(custom_url: return_to_saved_results_path) %>
+
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>

--- a/config/features.rb
+++ b/config/features.rb
@@ -5,5 +5,5 @@ Flipflop.configure do
 
   feature :foo, description: 'Example feature flag', default: true
   feature :health_check, description: 'Dummy feature for split.io health check'
-  feature :csv_courses, description: 'Enable service to use the new CSV courses data'
+  feature :csv_courses, description: 'Enable service to use the new CSV courses data', default: true
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -5,5 +5,5 @@ Flipflop.configure do
 
   feature :foo, description: 'Example feature flag', default: true
   feature :health_check, description: 'Dummy feature for split.io health check'
-  feature :csv_courses, description: 'Enable service to use the new CSV courses data', default: true
+  feature :csv_courses, description: 'Enable service to use the new CSV courses data'
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,22 +2,23 @@ en-GB:
   breadcrumb:
     home: Home
     action_plan: Action plan
-    offers_near_me: Offers near me
+    offers_near_me: Offers near you
     training_questions: Training options
     edit_training_questions: Edit your training choices
     it_training_questions: Computer skills training
     job_hunting_questions: Job hunting advice
-    jobs_near_me: Jobs near me
-    task_list: Get help to retrain
+    jobs_near_me: Jobs near you
+    task_list: Steps
     task_list_home: 'Home: Get help to retrain'
-    check_your_skills: Check your existing skills
+    check_your_skills: Check your skills
     job_matches: Your job matches
     search_results: Search results
-    job_profiles_search: Your job matches
+    search_your_skills_results: Check your skills results
+    job_profiles_search: Your work matches
     job_profile: Job profile details
     your_skills: Your skills
-    training_courses_near_you: Find and apply to training courses near you
-    csv_courses_training_courses_near_you: Training courses near you
+    training_courses_near_you: Courses near you
+    csv_courses_training_courses_near_you: Courses near you
     course_details: Course details
     location_ineligible: No courses in your area
     current_job_skills: Job skills
@@ -40,7 +41,7 @@ en-GB:
     check_your_skills_index: Check your skills - Get help to retrain
     check_your_skills_results: Check your skills results - Get help to retrain
     skills_index: Your skills - Get help to retrain
-    skills_current_job_skills: Current job skills - Get help to retrain
+    skills_current_job_skills: Job skills - Get help to retrain
     skills_matcher_index: Your job matches - Get help to retrain
     job_profiles_index: Search for a type of work - Get help to retrain
     job_profiles_results: Search for a type of work results - Get help to retrain

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,7 +9,6 @@ en-GB:
     job_hunting_questions: Job hunting advice
     jobs_near_me: Jobs near you
     task_list: Steps
-    task_list_home: 'Home: Get help to retrain'
     check_your_skills: Check your skills
     job_matches: Your job matches
     search_results: Search results

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en-GB:
     offers_near_me: Offers near you
     training_questions: Training options
     edit_training_questions: Edit your training choices
+    edit_your_advice_choices: Edit your advice choices
     it_training_questions: Computer skills training
     job_hunting_questions: Job hunting advice
     jobs_near_me: Jobs near you
@@ -13,7 +14,7 @@ en-GB:
     job_matches: Your job matches
     search_results: Search results
     search_your_skills_results: Check your skills results
-    job_profiles_search: Your work matches
+    job_profiles_search: Your job matches
     job_profile: Job profile details
     your_skills: Your skills
     training_courses_near_you: Courses near you

--- a/spec/features/action_plan_spec.rb
+++ b/spec/features/action_plan_spec.rb
@@ -177,6 +177,15 @@ RSpec.feature 'Action plan spec' do
     expect(page).to have_link('Edit your advice choices', href: job_hunting_questions_path)
   end
 
+  scenario 'User can navigate back to action plan after trying to edit the advice options' do
+    user_targets_a_job
+
+    click_on('Edit your advice choices')
+    click_on('Action plan')
+
+    expect(page).to have_current_path(action_plan_path)
+  end
+
   scenario 'Page links to cv help if job hunting question answered for cv' do
     user_targets_a_job
     click_on('Edit your advice choices')

--- a/spec/features/find_courses_near_me_spec.rb
+++ b/spec/features/find_courses_near_me_spec.rb
@@ -158,7 +158,7 @@ RSpec.feature 'Find training courses', type: :feature do
     select('Up to 40 miles', from: 'distance')
     click_on('Apply filters')
     click_on('My Course')
-    click_on('Training courses near you')
+    click_on('Courses near you')
 
     expect(page).to have_select('distance', selected: 'Up to 40 miles')
   end

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -31,16 +31,6 @@ RSpec.feature 'Questions' do
     expect(page).to have_current_path(training_questions_path)
   end
 
-  scenario 'User goes back to training questions path when deeplinking to it training questions page on a non empty session and then hitting Back' do
-    user_targets_job
-
-    visit(it_training_questions_path)
-
-    click_on('Back')
-
-    expect(page).to have_current_path(training_questions_path)
-  end
-
   scenario 'User sees job hunting questions when targetting a job' do
     user_targets_job
     click_on('Continue')
@@ -53,16 +43,6 @@ RSpec.feature 'Questions' do
     user_targets_job
     click_on('Continue')
     click_on('Continue')
-
-    click_on('Back')
-
-    expect(page).to have_current_path(it_training_questions_path)
-  end
-
-  scenario 'User goes back to IT training questions path when deeplinking to job hunting questions page on a non empty session and then hitting Back' do
-    user_targets_job
-
-    visit(job_hunting_questions_path)
 
     click_on('Back')
 

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -9,22 +9,10 @@ RSpec.feature 'Questions' do
     expect(page).to have_current_path(training_questions_path)
   end
 
-  scenario 'User can go back to previous page from training questions page' do
+  scenario 'User defaults to job matches path from training questions page when hitting Back' do
     user_targets_job
 
-    click_on('Back')
-
-    expect(page).to have_current_path(job_profile_path(job_profile.slug))
-  end
-
-  scenario 'User defaults to going back to root path when deeplinking to training questions page on a non empty session and then hitting Back' do
-    user_targets_job
-
-    visit(training_questions_path)
-
-    click_on('Back')
-
-    expect(page).to have_current_path(root_path)
+    expect(page).to have_link('Back', href: skills_matcher_index_path)
   end
 
   scenario 'User sees IT training questions when targetting a job' do
@@ -43,14 +31,14 @@ RSpec.feature 'Questions' do
     expect(page).to have_current_path(training_questions_path)
   end
 
-  scenario 'User defaults to going back to root path when deeplinking to it training questions page on a non empty session and then hitting Back' do
+  scenario 'User goes back to training questions path when deeplinking to it training questions page on a non empty session and then hitting Back' do
     user_targets_job
 
     visit(it_training_questions_path)
 
     click_on('Back')
 
-    expect(page).to have_current_path(root_path)
+    expect(page).to have_current_path(training_questions_path)
   end
 
   scenario 'User sees job hunting questions when targetting a job' do
@@ -71,14 +59,14 @@ RSpec.feature 'Questions' do
     expect(page).to have_current_path(it_training_questions_path)
   end
 
-  scenario 'User defaults to going back to root path when deeplinking to job hunting questions page on a non empty session and then hitting Back' do
+  scenario 'User goes back to IT training questions path when deeplinking to job hunting questions page on a non empty session and then hitting Back' do
     user_targets_job
 
     visit(job_hunting_questions_path)
 
     click_on('Back')
 
-    expect(page).to have_current_path(root_path)
+    expect(page).to have_current_path(it_training_questions_path)
   end
 
   scenario 'User navigates to action plan after going through questions' do

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -9,11 +9,48 @@ RSpec.feature 'Questions' do
     expect(page).to have_current_path(training_questions_path)
   end
 
+  scenario 'User can go back to previous page from training questions page' do
+    user_targets_job
+
+    click_on('Back')
+
+    expect(page).to have_current_path(job_profile_path(job_profile.slug))
+  end
+
+  scenario 'User defaults to going back to root path when deeplinking to training questions page on a non empty session and then hitting Back' do
+    user_targets_job
+
+    visit(training_questions_path)
+
+    click_on('Back')
+
+    expect(page).to have_current_path(root_path)
+  end
+
   scenario 'User sees IT training questions when targetting a job' do
     user_targets_job
     click_on('Continue')
 
     expect(page).to have_current_path(it_training_questions_path)
+  end
+
+  scenario 'User can go back to previous page from IT training questions page' do
+    user_targets_job
+    click_on('Continue')
+
+    click_on('Back')
+
+    expect(page).to have_current_path(training_questions_path)
+  end
+
+  scenario 'User defaults to going back to root path when deeplinking to it training questions page on a non empty session and then hitting Back' do
+    user_targets_job
+
+    visit(it_training_questions_path)
+
+    click_on('Back')
+
+    expect(page).to have_current_path(root_path)
   end
 
   scenario 'User sees job hunting questions when targetting a job' do
@@ -22,6 +59,26 @@ RSpec.feature 'Questions' do
     click_on('Continue')
 
     expect(page).to have_current_path(job_hunting_questions_path)
+  end
+
+  scenario 'User can go back to previous page from job hunting questions page' do
+    user_targets_job
+    click_on('Continue')
+    click_on('Continue')
+
+    click_on('Back')
+
+    expect(page).to have_current_path(it_training_questions_path)
+  end
+
+  scenario 'User defaults to going back to root path when deeplinking to job hunting questions page on a non empty session and then hitting Back' do
+    user_targets_job
+
+    visit(job_hunting_questions_path)
+
+    click_on('Back')
+
+    expect(page).to have_current_path(root_path)
   end
 
   scenario 'User navigates to action plan after going through questions' do

--- a/spec/features/skills_builder_spec.rb
+++ b/spec/features/skills_builder_spec.rb
@@ -36,17 +36,17 @@ RSpec.feature 'Build your skills', type: :feature do
     click_on('Select these skills')
   end
 
-  scenario 'Breadcrumbs: user only sees 1 clickable item in the navigation' do
+  scenario 'Breadcrumbs: user only sees 2 clickable items in the navigation' do
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     click_on('Select these skills')
 
-    expect(page).to have_css('nav.govuk-breadcrumbs a', count: 1)
+    expect(page).to have_css('nav.govuk-breadcrumbs a', count: 2)
   end
 
-  scenario 'Breadcrumbs - user can click on \'Home: Get help to retrain\' nav item' do
+  scenario 'Breadcrumbs - user can click on \'Steps\' nav item' do
     visit(job_profile_skills_path(job_profile_id: job_profile.slug))
     click_on('Select these skills')
-    click_on('Home: Get help to retrain')
+    click_on('Steps')
 
     expect(page).to have_current_path(task_list_path)
   end

--- a/spec/features/task_list_spec.rb
+++ b/spec/features/task_list_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Task list', type: :feature do
     visit(task_list_path)
     click_on('Check your existing skills')
 
-    expect(page).to have_text('Check your existing skills')
+    expect(page).to have_text('Check your skills')
   end
 
   scenario 'User navigates to skills matcher results page' do

--- a/spec/features/user_registration_spec.rb
+++ b/spec/features/user_registration_spec.rb
@@ -62,6 +62,12 @@ RSpec.feature 'User registration' do
   end
 
   scenario 'user can go back to the task list page' do
+    Geocoder::Lookup::Test.add_stub(
+      'NW6 1JJ', [{ 'coordinates' => [0.1, 1] }]
+    )
+
+    create(:course, latitude: 0.1, longitude: 1, topic: 'maths')
+
     fill_in_user_personal_information
     click_on('Save your progress')
     click_on('Back')

--- a/spec/features/user_registration_spec.rb
+++ b/spec/features/user_registration_spec.rb
@@ -128,12 +128,12 @@ RSpec.feature 'User registration' do
     expect(page).to have_text(/Save your progress/)
   end
 
-  scenario 'User can go back to task list path after trying to send the email again' do
+  scenario 'User can go back to the root path after trying to send the email again' do
     register_user
     click_on('enter your email address again')
     click_on('Back')
 
-    expect(page).to have_current_path(task_list_path)
+    expect(page).to have_current_path(root_path)
   end
 
   scenario 'User does not get error message if they enter their same email but different case' do

--- a/spec/features/user_registration_spec.rb
+++ b/spec/features/user_registration_spec.rb
@@ -61,6 +61,14 @@ RSpec.feature 'User registration' do
     expect(page).to have_current_path(save_your_results_path)
   end
 
+  scenario 'user can go back to the task list page' do
+    fill_in_user_personal_information
+    click_on('Save your progress')
+    click_on('Back')
+
+    expect(page).to have_current_path(task_list_path)
+  end
+
   scenario 'User gets relevant messaging if no email is entered' do
     visit(save_your_results_path)
     click_on('Save your progress')
@@ -100,6 +108,13 @@ RSpec.feature 'User registration' do
     expect(page).to have_text(/Your progress has been saved/)
   end
 
+  scenario 'User will be taken to the save your progress path when clicking Back' do
+    register_user
+    click_on('Back')
+
+    expect(page).to have_current_path(save_your_progress_path)
+  end
+
   scenario 'User can see their email on link page' do
     register_user
 
@@ -111,6 +126,14 @@ RSpec.feature 'User registration' do
     click_on('enter your email address again')
 
     expect(page).to have_text(/Save your progress/)
+  end
+
+  scenario 'User can go back to task list path after trying to send the email again' do
+    register_user
+    click_on('enter your email address again')
+    click_on('Back')
+
+    expect(page).to have_current_path(task_list_path)
   end
 
   scenario 'User does not get error message if they enter their same email but different case' do
@@ -127,6 +150,23 @@ RSpec.feature 'User registration' do
     click_on('send it again')
 
     expect(page).to have_current_path(email_sent_again_path)
+  end
+
+  scenario 'User can go back to the previous page from link sent page' do
+    register_user
+    click_on('send it again')
+    click_on('Back')
+
+    expect(page).to have_current_path(save_your_progress_path)
+  end
+
+  scenario 'User does not get stuck in a weird state trying to click Back twice starting from link sent page' do
+    register_user
+    click_on('send it again')
+    click_on('Back')
+    click_on('Back')
+
+    expect(page).to have_current_path(root_path)
   end
 
   scenario 'User resends email and can see their email on email sent again page' do

--- a/spec/features/user_sign_in_spec.rb
+++ b/spec/features/user_sign_in_spec.rb
@@ -105,6 +105,13 @@ RSpec.feature 'User sign in' do
     expect(page).to have_text(/test@test.test/)
   end
 
+  scenario 'User will be taken to return to saved progress path when clicking Back' do
+    send_sign_in_email
+    click_on('Back')
+
+    expect(page).to have_current_path(return_to_saved_results_path)
+  end
+
   scenario 'User can resend email and is redirected to link sent again page' do
     register_user
     send_sign_in_email
@@ -113,12 +120,39 @@ RSpec.feature 'User sign in' do
     expect(page).to have_current_path(link_sent_again_path)
   end
 
+  scenario 'User can go back to the previous page from link sent again page' do
+    register_user
+    send_sign_in_email
+    click_on('send it again')
+    click_on('Back')
+
+    expect(page).to have_current_path(return_to_saved_results_path)
+  end
+
+  scenario 'User does not get stuck in a weird state when clicking Back twice' do
+    register_user
+    send_sign_in_email
+    click_on('send it again')
+    click_on('Back')
+    click_on('Back')
+
+    expect(page).to have_current_path(root_path)
+  end
+
   scenario 'User resends email and can see their email on email sent again page' do
     register_user
     send_sign_in_email
     click_on('send it again')
 
     expect(page).to have_text(/test@test.test/)
+  end
+
+  scenario 'User can go back to the previous page from return to saved results page' do
+    visit(your_information_path)
+    click_on('Return to saved progress')
+    click_on('Back')
+
+    expect(page).to have_current_path(your_information_path)
   end
 
   scenario 'User receives sign in email if email valid and user exists' do

--- a/spec/helpers/question_helper_spec.rb
+++ b/spec/helpers/question_helper_spec.rb
@@ -103,4 +103,22 @@ RSpec.describe QuestionHelper do
       expect(helper.progression_indicator(step: 1)).to be_nil
     end
   end
+
+  describe '#job_hunting_question_breadcrumbs' do
+    it 'shows the Back link to IT Training questions page when not all questions have been answered' do
+      user_session.training = ['english_skills']
+
+      expect(helper.job_hunting_question_breadcrumbs).to eq(
+        '<a class="govuk-back-link" href="/it-training-questions">Back</a>'
+      )
+    end
+
+    it 'hides the Back link if all questions have been answered' do
+      user_session.training = ['english_skills']
+      user_session.it_training = ['computer_skills']
+      user_session.job_hunting = ['cv']
+
+      expect(helper.job_hunting_question_breadcrumbs).to be_nil
+    end
+  end
 end

--- a/spec/lib/url_parser_spec.rb
+++ b/spec/lib/url_parser_spec.rb
@@ -35,5 +35,13 @@ RSpec.describe UrlParser do
 
       expect(parser.get_redirect_path(paths_to_ignore: ['/save-my-results'])).to be_nil
     end
+
+    it 'returns nothing if referred from the same page' do
+      referer = 'http://myhost.com/privacy-policy'
+      original = 'http://myhost.com/privacy-policy'
+      parser = described_class.new(referer, 'myhost.com', original)
+
+      expect(parser.get_redirect_path).to be_nil
+    end
   end
 end


### PR DESCRIPTION
### Context

For more consistency across user journey we would like
to update the breadcrumbs across the whole service as follows:

Home > Your information
Home > Steps
Home > Steps > Check your skills
Home > Steps > Check your skills > Check your skills results
Home > Steps > Check your skills > Search results > Current job skills
Home > Steps > Your skills
Home > Steps > Check your skills
Home > Steps > Your job matches
Home > Steps > Your job matches > Job profile details
Home > Steps > Action plan
Home > Steps > Action plan > Courses near you
Home > Steps > Action plan > Courses near you
Home > Steps > Action plan > CV advice
Home > Steps > Action plan > Cover letter advice
Home > Steps > Action plan > Interview advice
Home > Steps > Action plan > Offers near you
Home > Steps > Action plan > Jobs near you

Add Back functionality for the following sections:

- user registration
- training questions
- user sign in
- save progress error page
- link expired page

The logic needs updated as follows:

1. Save your progress journey
2. Return to your saved progress journey
3. Training questions

Because of a few edge cases, the back_link is now able
to accept a custom url for redirection and can also ignore
paths.

The current Back link implementation needs to ignore
paths like:

- email-sent-again which is only accessible via POST
- link-sent again which is only accessible via POST

Training questions, because they come in sequence, and
according to GDS pattern the user needs to be able to navigate
throuhg every question using the Back link, so adding
explicit redirect routes fixes this issue.

### Ticket
https://dfedigital.atlassian.net/browse/GET-1087

