### PR TITLE
Lock Ruby alpine image version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine as assets
+FROM ruby:2.6.5-alpine as assets
 
 ENV RAILS_ENV production
 ENV NODE_ENV production


### PR DESCRIPTION
We were not using a specific version in the Dockerfile,
to force ourselves to upgrade. Switch to specific version
now as we won't be maintaining the project anymore

