### PR TITLE
GET-1091 Show validation error on postcode API error

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,4 +1,4 @@
-class CoursesController < ApplicationController # rubocop:disable Metrics/ClassLength
+class CoursesController < ApplicationController
   DISTANCE = [
     ['Up to 10 miles', '10'], ['Up to 20 miles', '20'], ['Up to 30 miles', '30'], ['Up to 40 miles', '40']
   ].freeze
@@ -58,16 +58,10 @@ class CoursesController < ApplicationController # rubocop:disable Metrics/ClassL
     @distance ||= courses_params[:distance] || user_session.distance
   end
 
-  def courses_params # rubocop:disable Metrics/MethodLength
+  def courses_params
     params.permit(
-      :postcode,
-      :topic_id,
-      :hours,
-      :delivery_type,
-      :distance,
-      :page,
-      :course_id,
-      :course_run_id,
+      :postcode, :topic_id, :hours, :delivery_type,
+      :distance, :page, :course_id, :course_run_id,
       :authenticity_token
     )
   end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -58,7 +58,7 @@ class CoursesController < ApplicationController # rubocop:disable Metrics/ClassL
     @distance ||= courses_params[:distance] || user_session.distance
   end
 
-  def courses_params
+  def courses_params # rubocop:disable Metrics/MethodLength
     params.permit(
       :postcode,
       :topic_id,
@@ -67,7 +67,8 @@ class CoursesController < ApplicationController # rubocop:disable Metrics/ClassL
       :distance,
       :page,
       :course_id,
-      :course_run_id
+      :course_run_id,
+      :authenticity_token
     )
   end
 

--- a/spec/features/find_courses_near_me_spec.rb
+++ b/spec/features/find_courses_near_me_spec.rb
@@ -483,6 +483,20 @@ RSpec.feature 'Find training courses', type: :feature do
     expect(page).to have_text(/Sorry, there is a problem with this service/)
   end
 
+  scenario 'User gets postcode validation error if there is a PostcodeNotFound Error from the API' do
+    Geocoder::Lookup::Test.add_stub(
+      'NW6 8ET', [{ 'coordinates' => [0.1, 1] }]
+    )
+    find_a_course_service = instance_double(FindACourseService)
+    allow(FindACourseService).to receive(:new).and_return(find_a_course_service)
+    allow(find_a_course_service).to receive(:search).and_raise(FindACourseService::PostcodeNotFoundError)
+
+    capture_user_location('NW6 8ET')
+    visit(courses_path(topic_id: 'maths'))
+
+    expect(page).to have_text(/Enter a real postcode/)
+  end
+
   scenario 'User deep linking to a course details page gets relevant messaging if there is an API error' do
     find_a_course_service = instance_double(FindACourseService)
     allow(FindACourseService).to receive(:new).and_return(find_a_course_service)

--- a/spec/services/find_a_course_service_spec.rb
+++ b/spec/services/find_a_course_service_spec.rb
@@ -76,6 +76,23 @@ RSpec.describe FindACourseService do
       expect { service.search(options: options) }.to raise_exception(described_class::APIError)
     end
 
+    it 'raises postcode error if postcode not found' do
+      options = { keyword: 'maths' }
+      stub_request(:post, /findacourse/)
+        .to_return(
+          status: 400,
+          body: {
+            'type' => nil,
+            'title' => 'PostcodeNotFound',
+            'status' => 400,
+            'detail' => 'Specified postcode cannot be found.',
+            'instance' => nil
+          }.to_json
+        )
+
+      expect { service.search(options: options) }.to raise_exception(described_class::PostcodeNotFoundError)
+    end
+
     it 'raises error if the query is not authorised' do
       options = { keyword: 'maths' }
       service = described_class.new(


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-1091

* Add response body to error message
* Raise postcode not found error when error body from API contains
the relevant message
* Catch the error message at the course search level and add
the validation error postcode not found to the object. We have
to check for errors then validation as `valid?` will overwrite
the existing errors and remove them.
* Add authenticity token to params to avoid errors

