### PR TITLE
Update missing second step of image to 2.6.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN yarn install
 COPY . ./
 RUN bundle exec rails assets:precompile SECRET_KEY_BASE=stubbed
 
-FROM ruby:2.6-alpine
+FROM ruby:2.6.5-alpine
 
 ENV RAILS_ENV production
 ENV RACK_ENV production


### PR DESCRIPTION
I missed updating the second part of the Dockerfile image to 2.6.5, hopefully this should resolve things.
