### PR TITLE
Authentication process to ignore the resource name

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -9,11 +9,12 @@ class AdminUser < RestrictedActiveRecordBase
 
     admin_user = find_or_initialize_by(
       email: user_info[:email],
-      name: user_info[:name],
       resource_id: auth_hash[:uid]
     )
 
+    admin_user.name = user_info[:name]
     admin_user.roles = roles_from(auth_hash)
+
     admin_user
   end
 

--- a/spec/features/admin/authentication_spec.rb
+++ b/spec/features/admin/authentication_spec.rb
@@ -72,6 +72,18 @@ RSpec.feature 'Admin Users Authentication' do
     end
   end
 
+  scenario 'Authenticates returning user correctly when the name in Active Azure Directory is different from the one persisted in our database' do
+    create(:admin_user, name: 'james.bond', email: 'test@test.com', resource_id: '1111-111-11-1')
+
+    stub_omniauth
+
+    visit(auth_azure_ad_auth_callback_path)
+
+    ['Dashboard', 'some.name', 'Logout'].each do |content|
+      expect(page).to have_content(content)
+    end
+  end
+
   scenario 'Stores the user details on successful authentication' do
     stub_omniauth
 

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -68,12 +68,6 @@ RSpec.describe AdminUser do
       expect(active_admin.valid?).to be true
     end
 
-    it 'correctly presists the identified resource name' do
-      active_admin = described_class.from_omniauth(auth_hash)
-
-      expect(active_admin.name).to eq('some.name')
-    end
-
     it 'updates the identified resource\'s name if changed in Azure Active Directory' do
       create(:admin_user, name: 'james.bond', email: 'test@test.com', resource_id: '1111-111-11-1')
 

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -68,6 +68,20 @@ RSpec.describe AdminUser do
       expect(active_admin.valid?).to be true
     end
 
+    it 'correctly presists the identified resource name' do
+      active_admin = described_class.from_omniauth(auth_hash)
+
+      expect(active_admin.name).to eq('some.name')
+    end
+
+    it 'updates the identified resource\'s name if changed in Azure Active Directory' do
+      create(:admin_user, name: 'james.bond', email: 'test@test.com', resource_id: '1111-111-11-1')
+
+      active_admin = described_class.from_omniauth(auth_hash)
+
+      expect(active_admin.name).to eq('some.name')
+    end
+
     it 'returns an invalid active record instance if user_info key has incomplete data' do
       auth_hash = {
         'provider' => :azure_ad_auth,


### PR DESCRIPTION
### Context
We recently noticed that resources in Azure Active Directory
can have the name attribute changed breaking our current
implementation which relied on the combination of
resource_id + email + name as the unique identifier
of authorised users for the Admin feature.

Relying instead on just resource_id + email as the unique
identifier will fix this issue.

### Ticket
https://dfedigital.atlassian.net/browse/GET-1095

### Testing
Need to manually update the name of your user in the database and then try to login via AAD.
