### PR TITLE
Ensure order of headings is semantically correct

### DIFF
--- a/app/views/users/registration_results_saved.html.erb
+++ b/app/views/users/registration_results_saved.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
     <p class="govuk-body">We've sent an email to</p>
-    <h3 class="govuk-heading-m"><%= @user.email %></h3>
+    <h2 class="govuk-heading-m"><%= @user.email %></h2>
     <p class="govuk-body">Check your email inbox to make sure you've received the email. You may need to verify your email address by clicking a link in the email.</p>
     <%= form_with local: true, url: email_sent_again_path do |form| %>
       <%= hidden_field_tag('email', @user.email) %>

--- a/app/views/users/sign_in_link_sent.html.erb
+++ b/app/views/users/sign_in_link_sent.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
     <p class="govuk-body">We've sent an email to</p>
-    <h3 class="govuk-heading-m"><%= params[:email] %></h3>
+    <h2 class="govuk-heading-m"><%= params[:email] %></h2>
     <p class="govuk-body">This email contains a link that will take you back to any progress you’ve saved.</p>
     <p class="govuk-body">The link expires after one hour.</p>
     <%= form_with local: true, url: link_sent_again_path do |form| %>


### PR DESCRIPTION
### Context
Heading levels should only increase by one.
https://dequeuniversity.com/rules/axe/3.3/heading-order?application=axeAPI


### Ticket
https://dfedigital.atlassian.net/browse/GET-1071
