### PR TITLE
GET-787 Rescue all errors from notify service in healthcheck

### DIFF
--- a/app/services/health_check/notify_check.rb
+++ b/app/services/health_check/notify_check.rb
@@ -26,7 +26,7 @@ module HealthCheck
 
     def fetch_value
       NotifyService.new.health_check
-    rescue Notifications::Client::RequestError, RuntimeError, ArgumentError => e
+    rescue StandardError => e
       @output = "Notify API error: #{e.message}"
       nil
     end


### PR DESCRIPTION
jira-ticket: https://dfedigital.atlassian.net/browse/GET-787

When displaying the health check page, we should show a failure
of a particular service rather than the whole page crashing. Make
sure that we catch *all* notify service errors so it doesn't fail
on NET::Http errors such as SocketError

