### PR TITLE
Health endpoint responds with 200 for :warn, :pass

### DIFF
--- a/app/middleware/status_report.rb
+++ b/app/middleware/status_report.rb
@@ -1,7 +1,7 @@
 class StatusReport
   STATUS_CODES = {
     pass: 200,
-    warn: 207,
+    warn: 200,
     fail: 503
   }.freeze
 

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe 'Health check', type: :request do
     context 'when health check has warnings' do
       let(:status) { :warn }
 
-      it 'has 207 response' do
+      it 'has 200 response' do
         get status_path
-        expect(response.status).to eq 207
+        expect(response.status).to eq 200
       end
     end
 


### PR DESCRIPTION
### Context
Currently, our health check endpoint will return a 207 code
when at least one of our 3rd party services responds with :warn.
Azure will deem the overall system as unhealthy switching to
maintenance page.

We do want our users to still be able to access our
service. To mitigate this, our health endpoint needs to
return 200 instead of 207 even when at least one of our 3rd
party services might respond with a :warn code.

More on how health probes work in Azure:
https://docs.microsoft.com/en-us/azure/frontdoor/front-door-health-probes#health-probe-responses

### Screenshots

#### Before

![Screen Shot 2020-04-23 at 12 33 30](https://user-images.githubusercontent.com/1955084/80094765-bb0f8d00-855e-11ea-93bc-50389c2cca0a.png)

#### After

![Screen Shot 2020-04-23 at 12 28 59](https://user-images.githubusercontent.com/1955084/80094783-c367c800-855e-11ea-8c2e-9efd3a78751f.png)


### Ticket
https://dfedigital.atlassian.net/browse/GET-1144