### PR TITLE
Disable IP restriction for Admin temporarily

### DIFF
--- a/azure/config/prod.parameters.json
+++ b/azure/config/prod.parameters.json
@@ -64,6 +64,10 @@
         {
           "ipAddress": "185.125.226.42/32",
           "name": "Toolkit office Range"
+        },
+        {
+          "ipAddress": "0.0.0.0/0",
+          "name": "Allow All"
         }
       ]
     },

--- a/azure/config/uat.parameters.json
+++ b/azure/config/uat.parameters.json
@@ -64,6 +64,10 @@
         {
           "ipAddress": "185.125.226.42/32",
           "name": "Toolkit office Range"
+        },
+        {
+          "ipAddress": "0.0.0.0/0",
+          "name": "Allow All"
         }
       ]
     },


### PR DESCRIPTION
### Context

Because of the COV19 issue and with everyone working
outside the office, restriction of access by IP did not
seem like a sustainable solution anymore with
IPs being dynamic.

We've decided to temporarily allow access to any IP.
This is not compromising security at all,
as the Admin remains an authentication and permission
based access section of our service.

We've kept the old office IP ranges, as when things will
go to normal, we can always revert back to IP restriction
easily. Should this become a permanent solution, the IP
ranges can be removed completely.

### Ticket

