### PR TITLE
Remove the IP Restriction config

### DIFF
--- a/azure/config/prod.parameters.json
+++ b/azure/config/prod.parameters.json
@@ -55,22 +55,6 @@
         }
       ]
     },
-    "adminIpSecurityRestrictions": {
-      "value": [
-        {
-          "ipAddress": "217.38.175.64/28",
-          "name": "Office Range"
-        },
-        {
-          "ipAddress": "185.125.226.42/32",
-          "name": "Toolkit office Range"
-        },
-        {
-          "ipAddress": "0.0.0.0/0",
-          "name": "Allow All"
-        }
-      ]
-    },
     "secretKeyBase": {
       "reference": {
         "keyVault": {

--- a/azure/config/uat.parameters.json
+++ b/azure/config/uat.parameters.json
@@ -55,22 +55,6 @@
         }
       ]
     },
-    "adminIpSecurityRestrictions": {
-      "value": [
-        {
-          "ipAddress": "217.38.175.64/28",
-          "name": "Office Range"
-        },
-        {
-          "ipAddress": "185.125.226.42/32",
-          "name": "Toolkit office Range"
-        },
-        {
-          "ipAddress": "0.0.0.0/0",
-          "name": "Allow All"
-        }
-      ]
-    },
     "secretKeyBase": {
       "reference": {
         "keyVault": {


### PR DESCRIPTION
### Context

Initially we tried adding 0.0.0.0/0 as an additional
entry to the existing configuration. This means that
any IP is allowed access. However, there seems to still
be an access issue for people with the DfE KIT on.

Because we don't have the DfE KIT on it's hard to debug
what the issue is. To unblock things, we decided to remove
the IP Restriction config completely.

### Ticket
https://dfedigital.atlassian.net/browse/GET-1147

