### PR TITLE
Add distance filter to Jobs Near Me page

### DIFF
--- a/app/controllers/job_vacancies_controller.rb
+++ b/app/controllers/job_vacancies_controller.rb
@@ -1,14 +1,12 @@
 class JobVacanciesController < ApplicationController
+  DISTANCE = [
+    ['Up to 10 miles', '10'], ['Up to 20 miles', '20'], ['Up to 30 miles', '30'], ['Up to 40 miles', '40']
+  ].freeze
+
   def index
     return redirect_to task_list_path unless target_job.present?
 
-    @job_vacancy_search = JobVacancySearch.new(
-      postcode: postcode,
-      name: target_job.name,
-      page: job_vacancies_params[:page]
-    )
-
-    user_session.postcode = postcode if postcode && @job_vacancy_search.valid?
+    persist_valid_filters_on_session
 
     @job_vacancies = job_vacancies
   rescue FindAJobService::APIError
@@ -21,18 +19,38 @@ class JobVacanciesController < ApplicationController
     @postcode ||= job_vacancies_params[:postcode] || user_session.postcode
   end
 
+  def distance
+    @distance ||= job_vacancies_params[:distance] || user_session.distance
+  end
+
+  def persist_valid_filters_on_session
+    return unless job_vacancy_search.valid?
+
+    user_session.postcode = postcode if postcode
+    user_session.distance = distance if distance
+  end
+
   def job_vacancies
     Kaminari
-      .paginate_array(jobs, total_count: @job_vacancy_search.count)
+      .paginate_array(jobs, total_count: job_vacancy_search.count)
       .page(job_vacancies_params[:page])
       .per(50)
   end
 
   def job_vacancies_params
-    params.permit(:postcode, :page)
+    params.permit(:postcode, :page, :distance)
   end
 
   def jobs
     @job_vacancy_search.jobs.map { |j| JobVacancyDecorator.new(j) }
+  end
+
+  def job_vacancy_search
+    @job_vacancy_search ||= JobVacancySearch.new(
+      postcode: postcode,
+      name: target_job.name,
+      page: job_vacancies_params[:page],
+      distance: job_vacancies_params[:distance]
+    )
   end
 end

--- a/app/views/job_vacancies/_search_filter.html.erb
+++ b/app/views/job_vacancies/_search_filter.html.erb
@@ -1,0 +1,32 @@
+<div class="govuk-accordion govuk-accordion-jobs-near-me" data-module="govuk-accordion" id="accordion-jobs-near-me">
+  <div class="govuk-accordion__section">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="accordion-jobs-near-me-heading-1">
+          Filters
+        </span>
+      </h2>
+    </div>
+    <div id="accordion-jobs-near-me-content-1" class="govuk-accordion__section-content govuk-!-padding-top-0" aria-labelledby="accordion-jobs-near-me-heading-1">
+      <%= form_with model: @job_vacancy_search, local: true, url: jobs_near_me_path do |form| %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-half">
+            <%= form_group_tag @job_vacancy_search, :postcode do %>
+              <%= errors_tag @job_vacancy_search, :postcode %>
+              <%= form.label :postcode, class: 'govuk-label', for: 'postcode' %>
+              <%= text_field_tag(:postcode, @postcode, class: css_classes_for_input(@job_vacancy_search, :postcode, "jobs-near-me-search-input govuk-input govuk-input govuk-!-width-full"), autocomplete: 'postal-code') %>
+            <% end %>
+          </div>
+          <div class="govuk-grid-column-one-half">
+            <div class="govuk-form-group">
+              <%= errors_tag_minimal @job_vacancy_search, :postcode %>
+              <%= label_tag :distance, 'Distance', for: 'distance', class: 'govuk-label' %>
+              <%= select_tag :distance, options_for_select(JobVacanciesController::DISTANCE, @distance || '20'), class: 'govuk-select govuk-!-width-full', id: 'distance' %>
+            </div>
+          </div>
+        </div>
+        <%= button_tag('Apply filters', class: 'govuk-button', data: { module: 'govuk-button' }) %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/job_vacancies/index.html.erb
+++ b/app/views/job_vacancies/index.html.erb
@@ -16,25 +16,19 @@
   <div class="govuk-grid-column-two-thirds">
     <%= error_summary(@job_vacancy_search) %>
     <h1 class="govuk-heading-xl"><%= target_job.name %> jobs near you</h1>
-    <p class="govuk-body">These jobs within 20 miles of your postcode are currently being advertised in the <%= link_to('Find a job', 'https://findajob.dwp.gov.uk/', class: 'govuk-link') %> service from the Department for Work and Pensions.</p>
-    <p class="govuk-body">Selecting one of these jobs will take you to another government service.</p>
     <div class="govuk-grid-column-full govuk-!-padding-0">
-      <%= form_with model: @job_vacancy_search, local: true, url: jobs_near_me_path do |form| %>
-        <%= form_group_tag @job_vacancy_search, :postcode do %>
-          <%= form.label :postcode, class: 'govuk-label', for: 'postcode' %>
-          <%= errors_tag @job_vacancy_search, :postcode %>
-          <%= text_field_tag(:postcode, @postcode, class: css_classes_for_input(@job_vacancy_search, :postcode, "course-search-input govuk-input govuk-!-width-one-half"), autocomplete: 'postal-code') %>
-          <%= button_tag('', class: 'search-button-results', name: nil, aria: { label: 'Search button' }, data: { module: 'govuk-button' }) %>
-        <% end %>
-      <% end %>
+      <%= render 'search_filter' %>
     </div>
-    <div class="govuk-grid-column-full govuk-!-padding-0">
+    <p class="govuk-body">These jobs are currently being advertised in the <%= link_to('Find a job', 'https://findajob.dwp.gov.uk/', class: 'govuk-link') %> service from the Department for Work and Pensions.</p>
+    <p class="govuk-body">Selecting one of these jobs will take you to another government service.</p>
+    <div class="govuk-grid-column-full govuk-!-padding-0 govuk-!-margin-top-3">
       <% if @job_vacancies.empty? %>
         <p class="govuk-body-m">0 job vacancies found on the Find a job service</p>
         <h2 class="govuk-heading-s">This service only looks for jobs advertised on the Find a job service from the Department for Work and Pensions. To find <%= target_job.name %> jobs you may need to search elsewhere.</h2>
         <p class="govuk-body">You could try:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>using a different postcode</li>
+          <li>using the filters to search a wider local area</li>
           <li>using other job sites</li>
           <li>entering a different name for this job on the <%= link_to 'Find a job', 'https://findajob.dwp.gov.uk/', class: 'govuk-link' %> service</li>
         </ul>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -4,10 +4,12 @@ import OutboundLinkTracking from './outbound-link-tracking';
 import UserFeedback from './user-feedback';
 import Sorting from './sorting';
 import CoursesAccordion from './courses-accordion';
+import JobsNearMeAccordion from './jobs-near-me-accordion';
 import Rails from 'rails-ujs';
 import { initAll } from 'govuk-frontend';
 
 CoursesAccordion.start();
+JobsNearMeAccordion.start();
 CookiesBanner.start();
 UserFeedback.start();
 OutboundLinkTracking.start();

--- a/app/webpacker/packs/jobs-near-me-accordion.js
+++ b/app/webpacker/packs/jobs-near-me-accordion.js
@@ -1,0 +1,11 @@
+function JobsNearMeAccordion () {
+  this.start = function () {
+    var largerThanTablet = window.matchMedia('(min-width: 700px)');
+    var postcodeError = document.querySelector('#job_vacancy_search_postcode-error');
+    if ((largerThanTablet.matches === true) || (typeof(postcodeError) !== 'undefined' && postcodeError != null)) {
+      window.sessionStorage.setItem('accordion-jobs-near-me-content-1', true);
+    }
+  }
+}
+
+export default new JobsNearMeAccordion();

--- a/app/webpacker/styles/_jobs-near-me.scss
+++ b/app/webpacker/styles/_jobs-near-me.scss
@@ -1,0 +1,3 @@
+.govuk-accordion-jobs-near-me > .govuk-accordion__controls {
+  display: none;
+}

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -12,3 +12,4 @@
 @import "alerts";
 @import "footer";
 @import "course";
+@import "jobs-near-me";


### PR DESCRIPTION
### Context
Add distance filter to Jobs Near Me page:

Add accordion to allow the user to filter by distance

By default, 20 miles distance

- Persist distance filter if navigate away from page
- Collapse in mobile by default
- Expand on desktop or tablet
- Error messages to stay the same - filter should expand and red and summary shown at top (like with courses)

If there are no results, add a new bullet point (second)
Content: “using the filters to search a wider local area”


### Guidance to review
https://dfedigital.atlassian.net/browse/GET-1110