### PR TITLE
Refactor date of birth validation on PID form

### DIFF
--- a/app/models/user_personal_data.rb
+++ b/app/models/user_personal_data.rb
@@ -7,8 +7,8 @@ class UserPersonalData < RestrictedActiveRecordBase
   validates :last_name, presence: true
   validates :postcode, presence: true
   validates :postcode, postcode: true, allow_blank: true
-  validate  :dob_format, unless: -> { dob? }
-  validate  :dob_in_the_past, if: -> { dob? }
+  validate  :dob_format
+  validate  :dob_in_the_past, if: -> { dob.present? }
   validates :gender, presence: true
 
   has_paper_trail on: %i[update]
@@ -16,16 +16,50 @@ class UserPersonalData < RestrictedActiveRecordBase
   private
 
   def dob_format
-    self.dob = Date.new(birth_year.to_i, birth_month.to_i, birth_day.to_i)
+    handle_format_errors_for(birth_day, birth_month, birth_year)
   rescue ArgumentError
-    add_invalid_dob_error
+    add_error_message(key: 'dob.invalid')
+  end
+
+  def add_error_message(key:)
+    errors.add(:dob, I18n.t(key, scope: 'activerecord.errors.models.user_personal_data.attributes'))
   end
 
   def dob_in_the_past
-    add_invalid_dob_error if dob > DateTime.now
+    add_error_message(key: 'dob.past') if dob > DateTime.now
+    add_error_message(key: 'dob.invalid') if dob < Date.new(1900, 1, 1)
   end
 
-  def add_invalid_dob_error
-    errors.add(:dob, I18n.t('dob.invalid', scope: 'activerecord.errors.models.user_personal_data.attributes'))
+  # Because there 8 possible combinations given by birth_day, birth_month and birth_year,
+  # we are using the following truth table:
+  #
+  # birth_day birth_month birth_year | encoded_date
+  # 0         0           0          | 0
+  # 0         0           1          | 1
+  # 0         1           0          | 2
+  # .................................| ..
+  # where: 0 = missing or negative value, 1 - value present and positive
+  # This way we can use the encoded date of birth and capture every possible combination so we can
+  # display the correct date format error message.
+
+  def handle_format_errors_for(birth_day, birth_month, birth_year) # rubocop:disable Metrics/CyclomaticComplexity
+    case encode_date(birth_day, birth_month, birth_year)
+    when 0 then add_error_message(key: 'dob.blank')
+    when 1 then add_error_message(key: 'dob.missing_day_month')
+    when 2 then add_error_message(key: 'dob.missing_day_year')
+    when 3 then add_error_message(key: 'dob.missing_day')
+    when 4 then add_error_message(key: 'dob.missing_month_year')
+    when 5 then add_error_message(key: 'dob.missing_month')
+    when 6 then add_error_message(key: 'dob.missing_year')
+    else self.dob = Date.new(birth_year.to_i, birth_month.to_i, birth_day.to_i)
+    end
+  end
+
+  def encode_date(birth_day, birth_month, birth_year)
+    [birth_day, birth_month, birth_year].map { |e| to_binary(e) }.join('').to_i(2)
+  end
+
+  def to_binary(value)
+    value.to_i.positive? ? 1 : 0
   end
 end

--- a/app/models/user_personal_data.rb
+++ b/app/models/user_personal_data.rb
@@ -7,7 +7,7 @@ class UserPersonalData < RestrictedActiveRecordBase
   validates :last_name, presence: true
   validates :postcode, presence: true
   validates :postcode, postcode: true, allow_blank: true
-  validate  :dob_format
+  validate  :dob_format, unless: -> { dob.present? }
   validate  :dob_in_the_past, if: -> { dob.present? }
   validates :gender, presence: true
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -249,7 +249,15 @@ en-GB:
             postcode:
               blank: Enter a postcode
             dob:
-              invalid: Enter a valid date of birth
+              invalid: Enter a real date of birth
+              blank: Enter your date of birth
+              past: Your date of birth must be in the past
+              missing_year: Your date of birth must include a year
+              missing_day: Your date of birth must include a day
+              missing_month: Your date of birth must include a month
+              missing_day_month: Your date of birth must include a day and month
+              missing_day_year: Your date of birth must include a day and year
+              missing_month_year: Your date of birth must include a month and year
 
   active_admin:
     sign_in:

--- a/spec/factories/user_personal_data.rb
+++ b/spec/factories/user_personal_data.rb
@@ -5,5 +5,8 @@ FactoryBot.define do
     postcode { ['NW11 8QE', 'NW11 7PT', 'NW11 7HB', 'NW10 7SF', 'NW10 7NZ', 'NW10 6HJ'].sample }
     gender { %w[male female not_mentioned].sample }
     dob { Faker::Date.between(from: 99.years.ago, to: 18.years.ago) }
+    birth_day { 13 }
+    birth_month { 1 }
+    birth_year { DateTime.now.year - 18 }
   end
 end

--- a/spec/factories/user_personal_data.rb
+++ b/spec/factories/user_personal_data.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     postcode { ['NW11 8QE', 'NW11 7PT', 'NW11 7HB', 'NW10 7SF', 'NW10 7NZ', 'NW10 6HJ'].sample }
     gender { %w[male female not_mentioned].sample }
-    dob { Faker::Date.between(from: 99.years.ago, to: 18.years.ago) }
     birth_day { 13 }
     birth_month { 1 }
     birth_year { DateTime.now.year - 18 }

--- a/spec/features/your_information_spec.rb
+++ b/spec/features/your_information_spec.rb
@@ -9,6 +9,38 @@ RSpec.feature 'Your information' do
     I18n.t('dob.invalid', scope: i18n_scope)
   }
 
+  let(:dob_blank_error) {
+    I18n.t('dob.blank', scope: i18n_scope)
+  }
+
+  let(:dob_past_error) {
+    I18n.t('dob.past', scope: i18n_scope)
+  }
+
+  let(:dob_missing_year_error) {
+    I18n.t('dob.missing_year', scope: i18n_scope)
+  }
+
+  let(:dob_missing_day_error) {
+    I18n.t('dob.missing_day', scope: i18n_scope)
+  }
+
+  let(:dob_missing_month_error) {
+    I18n.t('dob.missing_month', scope: i18n_scope)
+  }
+
+  let(:dob_missing_month_year_error) {
+    I18n.t('dob.missing_month_year', scope: i18n_scope)
+  }
+
+  let(:dob_missing_day_month_error) {
+    I18n.t('dob.missing_day_month', scope: i18n_scope)
+  }
+
+  let(:dob_missing_day_year_error) {
+    I18n.t('dob.missing_day_year', scope: i18n_scope)
+  }
+
   let(:first_name_blank_error) {
     I18n.t('first_name.blank', scope: i18n_scope)
   }
@@ -86,7 +118,7 @@ RSpec.feature 'Your information' do
       [
         first_name_blank_error,
         last_name_blank_error,
-        dob_invalid_error,
+        dob_blank_error,
         gender_blank_error
       ]
     )
@@ -135,20 +167,71 @@ RSpec.feature 'Your information' do
     expect(page).to have_css('input#user_personal_data_postcode', class: 'govuk-input--error')
   end
 
-  scenario 'When the date of birth is empty user gets: Enter a valid date of birth' do
+  scenario 'When the date of birth is empty user gets: Enter your date of birth' do
     click_on('Continue')
 
-    expect(page).to have_content(dob_invalid_error)
+    expect(page).to have_content(dob_blank_error)
   end
 
-  scenario 'When the date is valid but in future user gets: Enter a valid date of birth' do
+  scenario 'When the day of birth is missing user gets: Enter your date of birth' do
+    fill_in('user_personal_data[birth_month]', with: '1')
+    fill_in('user_personal_data[birth_year]', with: DateTime.now.year - 18)
+
+    click_on('Continue')
+
+    expect(page).to have_content(dob_missing_day_error)
+  end
+
+  scenario 'When the month of birth is missing user gets: Your date of birth must include a month' do
+    fill_in('user_personal_data[birth_day]', with: '1')
+    fill_in('user_personal_data[birth_year]', with: DateTime.now.year - 18)
+
+    click_on('Continue')
+
+    expect(page).to have_content(dob_missing_month_error)
+  end
+
+  scenario 'When the year of birth is missing user gets: Your date of birth must include a year' do
+    fill_in('user_personal_data[birth_day]', with: '1')
+    fill_in('user_personal_data[birth_month]', with: '1')
+
+    click_on('Continue')
+
+    expect(page).to have_content(dob_missing_year_error)
+  end
+
+  scenario 'When the day and month of birth are missing user gets: Your date of birth must include a day and month' do
+    fill_in('user_personal_data[birth_year]', with: DateTime.now.year - 18)
+
+    click_on('Continue')
+
+    expect(page).to have_content(dob_missing_day_month_error)
+  end
+
+  scenario 'When the month and year of birth are missing user gets: Your date of birth must include a month and year' do
+    fill_in('user_personal_data[birth_day]', with: '1')
+
+    click_on('Continue')
+
+    expect(page).to have_content(dob_missing_month_year_error)
+  end
+
+  scenario 'When the day and year of birth are missing user gets: Your date of birth must include a day and year' do
+    fill_in('user_personal_data[birth_month]', with: '1')
+
+    click_on('Continue')
+
+    expect(page).to have_content(dob_missing_day_year_error)
+  end
+
+  scenario 'When the date is valid but in future user gets: Your date of birth must be in the past' do
     fill_in('user_personal_data[birth_day]', with: '1')
     fill_in('user_personal_data[birth_month]', with: '1')
     fill_in('user_personal_data[birth_year]', with: DateTime.now.year + 3)
 
     click_on('Continue')
 
-    expect(page).to have_content(dob_invalid_error)
+    expect(page).to have_content(dob_past_error)
   end
 
   scenario 'When the date is present but has invalid day, user gets: Enter a valid date of birth' do
@@ -171,14 +254,14 @@ RSpec.feature 'Your information' do
     expect(page).to have_content(dob_invalid_error)
   end
 
-  scenario 'When the date is present but has invalid year, user gets: Enter a valid date of birth' do
+  scenario 'When the date is present but has invalid year, user gets: Your date of birth must include a year' do
     fill_in('user_personal_data[birth_day]', with: '1')
     fill_in('user_personal_data[birth_month]', with: '1')
-    fill_in('user_personal_data[birth_year]', with: '99999')
+    fill_in('user_personal_data[birth_year]', with: '-34')
 
     click_on('Continue')
 
-    expect(page).to have_content(dob_invalid_error)
+    expect(page).to have_content(dob_missing_year_error)
   end
 
   scenario 'Birth day field is highlighted when there is a validation error' do


### PR DESCRIPTION
### Context
Adding more granular date of birth validation for
the PID form for the following cases:

- If no date is entered
- If an incomplete date is entered - missing day
- If an incomplete date is entered - missing month
- If an incomplete date is entered - missing year
- If an incomplete date is entered - missing day and month
- If an incomplete date is entered - missing day and year
- If an incomplete date is entered - missing month and year
- If the date entered is not a real one/not number characters
- If the date is in the future when it needs to be in the past
- If the date of birth is earlier than 1900

### Ticket
https://dfedigital.atlassian.net/browse/GET-716
