### PR TITLE
Track the outcode on courses page

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -35,6 +35,10 @@ class CoursesController < ApplicationController
     @postcode ||= courses_params[:postcode] || user_session.postcode
   end
 
+  def outcode
+    UKPostcode.parse(postcode).outcode
+  end
+
   def distance
     @distance ||= courses_params[:distance] || user_session.distance
   end
@@ -83,7 +87,7 @@ class CoursesController < ApplicationController
   end
 
   def track_course_filters # rubocop:disable Metrics/MethodLength
-    track_event(:courses_index_search, postcode) if postcode.present?
+    track_event(:courses_index_search, outcode) if postcode.present?
     track_course_filter_for(
       parameter: courses_params[:delivery_type],
       value_mapping: DELIVERY_TYPES,

--- a/spec/features/find_courses_near_me_spec.rb
+++ b/spec/features/find_courses_near_me_spec.rb
@@ -345,7 +345,7 @@ RSpec.feature 'Find training courses', type: :feature do
     )
   end
 
-  scenario 'tracks search postcode' do
+  scenario 'tracks the outcode of the searched postcode' do
     tracking_service = instance_spy(TrackingService)
     allow(TrackingService).to receive(:new).and_return(tracking_service)
 
@@ -359,7 +359,7 @@ RSpec.feature 'Find training courses', type: :feature do
         {
           key: :courses_index_search,
           label: 'Courses near me - Postcode search',
-          value: 'NW6 8ET'
+          value: 'NW6'
         }
       ]
     )


### PR DESCRIPTION
### Context
Because of GDPR concerns about reporting the
full postcode people search on the courses page
we decided to report just the outcode to
Google Analytics.

### Ticket
https://dfedigital.atlassian.net/browse/GET-1151
