### PR TITLE
Improve querying for job vacancies

### DIFF
--- a/app/services/find_a_job_service.rb
+++ b/app/services/find_a_job_service.rb
@@ -51,11 +51,17 @@ class FindAJobService
     {
       api_id: api_id,
       api_key: api_key,
-      q: options[:name],
       w: outcode(options[:postcode]),
       d: options[:distance],
       p: options[:page]
-    }.reject { |_k, v| v.blank? }
+    }.tap { |hash| hash[query_key_for(options[:name])] = options[:name] }
+      .reject { |_k, v| v.blank? }
+  end
+
+  def query_key_for(search_string)
+    return :qph if search_string.present? && search_string.split(/\s/).count > 1
+
+    :qtl
   end
 
   def outcode(postcode)

--- a/spec/services/find_a_job_service_spec.rb
+++ b/spec/services/find_a_job_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe FindAJobService do
       options = { name: 'developer', distance: 20, postcode: 'NW11' }
       stub_request(:get, /findajob/)
         .with(
-          query: { 'api_id' => 'test', 'api_key' => 'test', 'q' => 'developer', 'd' => '20', 'w' => 'NW11' }
+          query: { 'api_id' => 'test', 'api_key' => 'test', 'qtl' => 'developer', 'd' => '20', 'w' => 'NW11' }
         )
         .to_return(body: find_a_job_developer_response.to_json)
 
@@ -55,7 +55,7 @@ RSpec.describe FindAJobService do
       options = { name: 'developer', distance: 20, postcode: 'NW11' }
       stub_request(:get, /findajob/)
         .with(
-          query: { 'api_id' => 'test', 'api_key' => 'test', 'q' => 'developer', 'd' => '20', 'w' => 'NW11' }
+          query: { 'api_id' => 'test', 'api_key' => 'test', 'qtl' => 'developer', 'd' => '20', 'w' => 'NW11' }
         )
         .to_return(body: find_a_job_zero_results_response.to_json)
 
@@ -78,7 +78,19 @@ RSpec.describe FindAJobService do
       options = { name: 'developer', distance: 20 }
       stub_request(:get, /findajob/)
         .with(
-          query: { 'api_id' => 'test', 'api_key' => 'test', 'q' => 'developer', 'd' => '20' }
+          query: { 'api_id' => 'test', 'api_key' => 'test', 'qtl' => 'developer', 'd' => '20' }
+        )
+        .to_return(body: find_a_job_developer_response.to_json)
+
+      expect(service.job_vacancies(options)).to eq(find_a_job_developer_response)
+    end
+
+    it 'uses qph as query string param when the job title contains multiple words' do
+      options = { name: 'software developer', distance: 20 }
+
+      stub_request(:get, /findajob/)
+        .with(
+          query: { 'api_id' => 'test', 'api_key' => 'test', 'qph' => 'software developer', 'd' => '20' }
         )
         .to_return(body: find_a_job_developer_response.to_json)
 


### PR DESCRIPTION
### Context
After some data analysis we discovered that we
can get more relevant results if we use:

- qtl as query string param for job titles that have
only one word
- qph as query string param for job titles that have
multiple words

### Guidance to review

