### PR TITLE
Add standalone edit page for Job Hunting options

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -49,6 +49,17 @@ class QuestionsController < ApplicationController
     redirect_to action_plan_path
   end
 
+  def edit_job_hunting_answers
+    user_session.job_hunting = questions_params[:job_hunting] || []
+
+    track_selections(
+      selected: selected_options_for('job_hunting'),
+      unselected: unselected_options_for('job_hunting')
+    )
+
+    redirect_to action_plan_path
+  end
+
   private
 
   def track_training_options

--- a/app/views/pages/_job_hunting.html.erb
+++ b/app/views/pages/_job_hunting.html.erb
@@ -3,7 +3,7 @@
     <h3 class="govuk-heading-m govuk-!-margin-bottom-2">Get job hunting advice</h3>
   </div>
   <div class="govuk-grid-column-one-half govuk-!-margin-bottom-1">
-    <%= link_to 'Edit your advice choices', job_hunting_questions_path, class: 'govuk-link action-plan-action' %>
+    <%= link_to 'Edit your advice choices', edit_job_hunting_questions_path, class: 'govuk-link action-plan-action' %>
   </div>
 </div>
 <% if user_session.job_hunting.present? %>

--- a/app/views/questions/edit_job_hunting.html.erb
+++ b/app/views/questions/edit_job_hunting.html.erb
@@ -1,0 +1,51 @@
+<% page_title :edit_job_hunting_questions %>
+<% content_for :breadcrumb do
+    generate_breadcrumbs(
+      t('breadcrumb.edit_your_advice_choices'),
+      [
+        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.task_list'), task_list_path],
+        [t('breadcrumb.action_plan'), action_plan_path]
+      ]
+    )
+  end
+%>
+
+<div class="govuk-grid-row govuk-!-margin-top-7 govuk-body">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: edit_job_hunting_questions_path, local: true do |f| %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="job-hunting-options-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3">
+              <%= t('.title') %>
+            </h1>
+            <p class="govuk-body-l">Add or remove the advice you want to get.</p>
+          </legend>
+          <span id="job-hunting-options-hint" class="govuk-hint">
+            Tick or untick the boxes to add or remove these from your action plan.
+          </span>
+          <div class="govuk-checkboxes govuk-!-margin-top-6">
+            <div class="govuk-checkboxes__item govuk-!-margin-top-6">
+              <%= check_box_tag 'job_hunting[]', :cv, user_session.job_hunting&.include?('cv'), id: :job_hunting_cv, class: 'govuk-checkboxes__input' %>
+              <%= label_tag :job_hunting_cv, 'I want advice on creating or updating a CV', class: 'govuk-label govuk-checkboxes__label' %>
+            </div>
+            <div class="govuk-checkboxes__item govuk-!-margin-top-6 govuk-!-margin-bottom-2">
+              <%= check_box_tag 'job_hunting[]', :cover_letter, user_session.job_hunting&.include?('cover_letter'), id: :job_hunting_cover_letter, class: 'govuk-checkboxes__input' %>
+              <%= label_tag :job_hunting_cover_letter, 'I want advice on writing a cover letter', class: 'govuk-label govuk-checkboxes__label' %>
+            </div>
+            <div class="govuk-checkboxes__item govuk-!-margin-top-6 govuk-!-margin-bottom-2">
+              <%= check_box_tag 'job_hunting[]', :interviews, user_session.job_hunting&.include?('interviews'), id: :job_hunting_interviews, class: 'govuk-checkboxes__input' %>
+            <%= label_tag :job_hunting_interviews, 'I want advice on preparing for interviews', class: 'govuk-label govuk-checkboxes__label' %>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <%= f.button('Continue', class: 'govuk-button govuk-!-margin-top-0 govuk-button govuk-!-margin-bottom-2', data: { module: 'govuk-button' }) %>
+    <% end %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render "shared/contact_us" %>
+    <%= render 'shared/save_or_return_to_your_results' %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,8 @@ en-GB:
       title: Maths and English skills
     edit_training:
       title: Edit your training choices
+    edit_job_hunting:
+      title: Edit your job hunting choices
     it_training:
       title: Digital and computer skills
   pages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,7 @@ en-GB:
     it_training_questions: Digital and computer skills - Get help to retrain
     edit_training_questions: Edit your training choices - Get help to retrain
     job_hunting_questions: Job hunting advice - Get help to retrain
+    edit_job_hunting_questions: Edit your job hunting advice - Get help to retrain
     user_personal_data: Your information - Get help to retrain
     jobs_near_me: Jobs near you - Get help to retrain
     errors_not_found: Not found - Get help to retrain

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,8 @@ Rails.application.routes.draw do
     post 'training-questions', to: 'questions#training_answers'
     get 'edit-training-questions', to: 'questions#edit_training'
     post 'edit-training-questions', to: 'questions#edit_training_answers'
+    get 'edit-job-hunting-questions', to: 'questions#edit_job_hunting'
+    post 'edit-job-hunting-questions', to: 'questions#edit_job_hunting_answers'
     get 'it-training-questions', to: 'questions#it_training'
     post 'it-training-questions', to: 'questions#it_training_answers'
     get 'job-hunting-questions', to: 'questions#job_hunting'


### PR DESCRIPTION
### Context
Add standalone edit page for Job Hunting options

Track selected options in GA.

### Ticket
https://dfedigital.atlassian.net/browse/GET-1033