### PR TITLE
Add pagination separator for 1+ pages

### DIFF
--- a/app/views/skills_matcher/index.html.erb
+++ b/app/views/skills_matcher/index.html.erb
@@ -30,7 +30,7 @@
           <ul class="govuk-list">
             <%= render @job_profiles %>
           </ul>
-          <div class="<%= @results.size  > 1 ? 'govuk-!-padding-top-6 govuk-!-margin-top-6 pagination__section govuk-!-margin-bottom-4' : '' %>">
+          <div class="<%= @results.size  > 9 ? 'govuk-!-padding-top-6 govuk-!-margin-top-6 pagination__section govuk-!-margin-bottom-4' : '' %>">
             <%= paginate @results %>
           </div>
         <% else %>


### PR DESCRIPTION
### Context
Job matches page will only display the pagination
separator if users get more than one page of results.

### Ticket
https://dfedigital.atlassian.net/browse/GET-1121
