### PR TITLE
Bugfix: Deeplinking to action plan

### DIFF
--- a/app/views/pages/training/_with_options.html.erb
+++ b/app/views/pages/training/_with_options.html.erb
@@ -24,7 +24,7 @@
     </div>
   <% end %>
 
-  <% if user_session.it_training.include?('computer_skills') %>
+  <% if user_session.it_training&.include?('computer_skills') %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h3 class="govuk-heading-s">Computer skills training</h3>

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -22,6 +22,15 @@ RSpec.feature 'Questions' do
     expect(page).to have_current_path(it_training_questions_path)
   end
 
+  scenario 'User can deeplink to action plan after answering just the training question' do
+    user_targets_job
+    check('I need to improve my English skills', allow_label_click: true)
+    click_on('Continue')
+    visit(action_plan_path)
+
+    expect(page).to have_text('Your personal action plan')
+  end
+
   scenario 'User can go back to previous page from IT training questions page' do
     user_targets_job
     click_on('Continue')


### PR DESCRIPTION
### Context

Users should be able to deeplink to action plan
even if they've only answered just the first
training question.

The service should not break when this happens.

### Ticket
https://dfedigital.atlassian.net/browse/GET-1109
