### PR TITLE
Hotfix: Overcome webdriver connection issue

### DIFF
--- a/spec/support/personal_data.rb
+++ b/spec/support/personal_data.rb
@@ -1,11 +1,13 @@
 module PersonalData
-  def js_enabled?
-    RSpec.current_example.metadata[:js]
+  def fill_pid_form
+    visit(root_path)
+    click_on('Accept all cookies')
+    click_on('Start now')
+    fill_in_fields
+    click_on('Continue')
   end
 
-  def fill_pid_form
-    visit(your_information_path)
-    find('input[value="Accept all cookies"]').click if js_enabled?
+  def fill_in_fields
     fill_in('user_personal_data[first_name]', with: 'John')
     fill_in('user_personal_data[last_name]', with: 'Mayer')
     fill_in('user_personal_data[postcode]', with: 'NW6 8ET')
@@ -13,7 +15,6 @@ module PersonalData
     fill_in('user_personal_data[birth_month]', with: '1')
     fill_in('user_personal_data[birth_year]', with: DateTime.now.year - 20)
     find('#user_personal_data_gender_male', visible: :all).click
-    click_on('Continue')
   end
 end
 


### PR DESCRIPTION
### Context
Running the specs in offline mode, seem to throw
in some cases the following error:

Webdrivers::ConnectionError:
  Can not reach https://chromedriver.storage.googleapis.com/

This is coming from spec/support/personal_data when trying
to deep-link straight into the PID form and it looks
like an interaction issue with Webdriver.

Getting to PID from the landing page seems to solve the issue,
as the cookies modal is accepted at that level now.

Also, removes the need to identify the specs that have the :js
tag.

