### PR TITLE
Get 779 breadcrumbs fix

### DIFF
--- a/app/views/job_profiles/_job_profile.html.erb
+++ b/app/views/job_profiles/_job_profile.html.erb
@@ -1,6 +1,6 @@
 <li class="govuk-!-padding-bottom-1">
   <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-margin-top-2">
-     <%= link_to job_profile.name, job_profile_path(job_profile.slug), class: 'govuk-link' %>
+     <%= link_to job_profile.name, job_profile_path(job_profile.slug, search: params[:search]), class: 'govuk-link' %>
   </h2>
   <% if job_profile.alternative_titles.present? %>
     <span class="govuk-visually-hidden">Alternative titles for this job include:</span>

--- a/app/views/job_profiles/show.html.erb
+++ b/app/views/job_profiles/show.html.erb
@@ -5,7 +5,7 @@
       [
         [t('breadcrumb.home'), root_path],
         [t('breadcrumb.task_list'), task_list_path],
-        [t('breadcrumb.job_matches'), skills_matcher_index_path],
+        [t('breadcrumb.job_matches'), skills_matcher_index_path(search: params[:search])],
       ]
     )
   end

--- a/spec/features/job_profile_spec.rb
+++ b/spec/features/job_profile_spec.rb
@@ -210,6 +210,23 @@ RSpec.feature 'Job profile spec' do
     expect(page).not_to have_content('Skills you may need to develop')
   end
 
+  scenario 'User can go back to job matches from the breadcrumbs with the search term persisted on the url' do
+    job_profile = create(
+      :job_profile,
+      :with_html_content,
+      skills: [
+        create(:skill, name: 'Chameleon-like blend in tactics')
+      ]
+    )
+    visit(job_profile_skills_path(job_profile_id: job_profile.slug))
+    click_on('Select these skills')
+    visit(job_profile_path(job_profile.slug, search: 'therapy'))
+
+    click_on('Your job matches')
+
+    expect(page).to have_current_path(skills_matcher_index_path(search: 'therapy'))
+  end
+
   scenario 'Users without PID submitted get redirected to the landing page' do
     Capybara.reset_session!
 

--- a/spec/features/skills_matcher_spec.rb
+++ b/spec/features/skills_matcher_spec.rb
@@ -330,7 +330,7 @@ RSpec.feature 'Skills matcher', type: :feature do
     find('.search-button').click
     click_on('Fluffer')
 
-    expect(page).to have_current_path(job_profile_path('fluffer'))
+    expect(page).to have_current_path(job_profile_path('fluffer', search: 'fluffer'))
   end
 
   scenario 'search query string param is passed to job profiles search page if present' do


### PR DESCRIPTION
### Context
Persist search term when returning to job matches

If users look for other job profiles on the job
matches page, then select one result and decide
to navigate back to job matches through the
breadcrumbs, the search term will now be persisted.

### Ticket
https://dfedigital.atlassian.net/browse/GET-779

