### PR TITLE
Display a 404 page when a resource doesn't exist

### DIFF
--- a/app/controllers/job_profiles_skills_controller.rb
+++ b/app/controllers/job_profiles_skills_controller.rb
@@ -18,7 +18,7 @@ class JobProfilesSkillsController < ApplicationController
   private
 
   def job_profile
-    @job_profile ||= JobProfile.find_by(slug: skills_params[:job_profile_id])
+    @job_profile ||= JobProfile.find_by!(slug: skills_params[:job_profile_id])
   end
 
   def skills_builder

--- a/spec/features/skills_builder_spec.rb
+++ b/spec/features/skills_builder_spec.rb
@@ -482,4 +482,10 @@ RSpec.feature 'Build your skills', type: :feature do
 
     expect(page).to have_current_path(root_path)
   end
+
+  scenario 'Users see a 404 page if trying to access a profile that does not exist' do
+    expect {
+      visit(job_profile_skills_path(job_profile_id: 'not-existing-profile'))
+    }.to raise_error(ActiveRecord::RecordNotFound)
+  end
 end


### PR DESCRIPTION
### Context

Currently, if users are trying to access a job profile
that doesn't exist, they get a 500 page because of the
type of exception that is raised.

Raising a RecordNotFound instead will fix this issue.

### Ticket
https://dfedigital.atlassian.net/browse/GET-919
