### PR TITLE
Do not allow methods outside accepted HTTP methods

### DIFF
--- a/app/middleware/status_report.rb
+++ b/app/middleware/status_report.rb
@@ -9,8 +9,10 @@ class StatusReport
     @app = app
   end
 
-  def call(env)
-    if env['PATH_INFO'] == '/status'
+  def call(env) # rubocop:disable Metrics/MethodLength
+    if ActionDispatch::Request::HTTP_METHODS.exclude?(env['REQUEST_METHOD'].upcase)
+      [405, { 'Content-Type' => 'text/plain' }, ['Method Not Allowed']]
+    elsif env['PATH_INFO'] == '/status'
       health = HealthCheck::ReportService.new
       [
         STATUS_CODES[health.status],


### PR DESCRIPTION
### Context

Frontdoor has a security check routine that is ran
every couple of hours. Among other checks, it tries
to call a DEBUG method against our server.

As a good security practice the server should respond
with method not allowed in this case. This will also
turn off the noise in Sentry.

### Ticket

