### PR TITLE
Display a 404 page on a missed route

### DIFF
--- a/app/controllers/job_profiles_controller.rb
+++ b/app/controllers/job_profiles_controller.rb
@@ -48,7 +48,7 @@ class JobProfilesController < ApplicationController
   private
 
   def resource
-    @resource ||= JobProfile.find_by(slug: job_profile_params[:id])
+    @resource ||= JobProfile.find_by!(slug: job_profile_params[:id])
   end
 
   def job_profile_params

--- a/spec/features/job_profile_spec.rb
+++ b/spec/features/job_profile_spec.rb
@@ -242,4 +242,10 @@ RSpec.feature 'Job profile spec' do
 
     expect(page).to have_current_path(root_path)
   end
+
+  scenario 'Users see a 404 page if trying to access a profile that does not exist' do
+    expect {
+      visit(job_profile_path('non-existing-id'))
+    }.to raise_error(ActiveRecord::RecordNotFound)
+  end
 end


### PR DESCRIPTION
### Context
When trying to access a job profile that one wants
to target, and the profile id does not exist, users
should see a 404 page.


