### PR TITLE
Accessibility fix: 1.3.1 Info and Relationships

### DIFF
--- a/app/decorators/job_vacancy_decorator.rb
+++ b/app/decorators/job_vacancy_decorator.rb
@@ -21,7 +21,7 @@ class JobVacancyDecorator < SimpleDelegator
   def formatted_company
     return unless company
 
-    content_tag(:b, company)
+    content_tag(:strong, company)
   end
 
   def formatted_date(date_value)

--- a/app/views/job_vacancies/_job_vacancy.html.erb
+++ b/app/views/job_vacancies/_job_vacancy.html.erb
@@ -1,13 +1,13 @@
 <li>
   <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><%= link_to job_vacancy.title, job_vacancy.url, class: 'govuk-link' %></h2>
   <% if job_vacancy.date_posted.present? %>
-    <p class="govuk-body govuk-!-margin-bottom-0">Date posted: <b><%= job_vacancy.formatted_date_posted %></b></p>
+    <p class="govuk-body govuk-!-margin-bottom-0">Date posted: <strong><%= job_vacancy.formatted_date_posted %></strong></p>
   <% end %>
   <% if job_vacancy.closing_date.present? %>
-    <p class="govuk-body govuk-!-margin-bottom-0">Closing date: <b><%= job_vacancy.formatted_closing_date %></b></p>
+    <p class="govuk-body govuk-!-margin-bottom-0">Closing date: <strong><%= job_vacancy.formatted_closing_date %></strong></p>
   <% end %>
   <p class="govuk-body govuk-!-margin-bottom-0"><span class="govuk-visually-hidden">Company and location:</span><%= job_vacancy.company_and_location %></p>
-  <p class="govuk-body govuk-!-margin-bottom-1"><span class="govuk-visually-hidden">Salary:</span><b><%= job_vacancy.salary %></b></p>
+  <p class="govuk-body govuk-!-margin-bottom-1"><span class="govuk-visually-hidden">Salary:</span><strong><%= job_vacancy.salary %></strong></p>
   <p class="govuk-body"><%= job_vacancy.description %></p>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-top-0">
 </li>

--- a/spec/decorators/job_vacancy_decorator_spec.rb
+++ b/spec/decorators/job_vacancy_decorator_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe JobVacancyDecorator do
       )
       decorated_vacancy = described_class.new(job_vacancy)
 
-      expect(decorated_vacancy.company_and_location).to eq('<b>Amazon</b> - London, UK')
+      expect(decorated_vacancy.company_and_location).to eq('<strong>Amazon</strong> - London, UK')
     end
 
     it 'returns the formatted company if there is no location' do
       job_vacancy = JobVacancy.new('company' => 'Amazon')
       decorated_vacancy = described_class.new(job_vacancy)
 
-      expect(decorated_vacancy.company_and_location).to eq('<b>Amazon</b>')
+      expect(decorated_vacancy.company_and_location).to eq('<strong>Amazon</strong>')
     end
 
     it 'returns the location if there is no company' do


### PR DESCRIPTION
### Context
The 'bold' tag is used to highlight text.

Solution: Use the 'strong' tag instead.

### Ticket
https://dfedigital.atlassian.net/browse/GET-966

