### PR TITLE
Search labels should not contain the word button

### DIFF
--- a/app/views/job_profiles/index.html.erb
+++ b/app/views/job_profiles/index.html.erb
@@ -29,7 +29,7 @@
           <%= form_group_tag @job_profile_search, :term do %>
             <%= errors_tag @job_profile_search, :term %>
             <%= text_field(nil, :search, class: 'govuk-input search-input govuk-!-width-one-half', placeholder: t('.placeholder'), aria: { label: 'Search' }, data: { cy: 'search-field'}) %>
-            <%= button_tag('Search', class: 'govuk-button search-button', name: nil, aria: { label: 'Search button' }, data: { cy: 'search-field-submit-btn', module: 'govuk-button' }) %>
+            <%= button_tag('Search', class: 'govuk-button search-button', name: nil, aria: { label: 'Search' }, data: { cy: 'search-field-submit-btn', module: 'govuk-button' }) %>
           <% end %>
         <% end %>
       </section>

--- a/app/views/shared/search/_form.html.erb
+++ b/app/views/shared/search/_form.html.erb
@@ -4,6 +4,6 @@
   <%= form_group_tag @job_profile_search, :term do %>
     <%= errors_tag @job_profile_search, :term %>
     <%= text_field(nil, :search, class: 'govuk-input search-input govuk-!-width-one-half', placeholder: t('placeholder', scope: scope), aria: { label: 'Search' }, data: { cy: 'search-field'}) %>
-    <%= button_tag('Search', class: 'govuk-button search-button', name: nil, aria: { label: 'Search button' }, data: { cy: 'search-field-submit-btn', module: 'govuk-button' }) %>
+    <%= button_tag('Search', class: 'govuk-button search-button', name: nil, aria: { label: 'Search' }, data: { cy: 'search-field-submit-btn', module: 'govuk-button' }) %>
   <% end %>
 <% end %>

--- a/app/views/shared/search/_results_form.html.erb
+++ b/app/views/shared/search/_results_form.html.erb
@@ -3,7 +3,7 @@
     <%= form_group_tag @job_profile_search, :term do %>
       <%= errors_tag @job_profile_search, :term %>
       <%= text_field(nil, :search, value: params[:search], class: 'search-input govuk-input govuk-!-width-one-half', placeholder: t('placeholder', scope: scope), aria: { label: 'Search' }) %>
-      <%= button_tag('Search', class: 'govuk-button search-button', name: nil, aria: { label: 'Search button' }, data: { module: 'govuk-button' }) %>
+      <%= button_tag('Search', class: 'govuk-button search-button', name: nil, aria: { label: 'Search' }, data: { module: 'govuk-button' }) %>
       <%= render 'shared/search/spell_check' %>
     <% end %>
   <% end %>


### PR DESCRIPTION
### Context
DAC Report:
Non-descriptive labelling
Labels were encountered that were not descriptive.

Solution:
Remove the word button from the label as this element
is a button, it will read as such to a screen reader user.

###  Ticket
https://dfedigital.atlassian.net/browse/GET-950
