### PR TITLE
Restructure the markup in accordance with DAC

### DIFF
--- a/app/views/job_profiles/skills/index.html.erb
+++ b/app/views/job_profiles/skills/index.html.erb
@@ -20,22 +20,22 @@
         <%= form_group_tag @skills_builder, :skills do %>
           <fieldset class="govuk-fieldset" aria-describedby="current-job-skills-hint">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-              <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3">
+              <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-0">
                 <%= @job_profile.name %> skills
               </h1>
-              <p class="govuk-body">Most <%= @job_profile.name.pluralize %> will have these skills.</p>
-              <p class="govuk-body">We’ll use these skills to suggest other types of work you can do.</p>
-              <span id="current-job-skills-hint" class="govuk-hint">
-                If you want to remove any of these skills, click the tick to remove it from the list.
-              </span>
             </legend>
+            <p class="govuk-body">Most <%= @job_profile.name.pluralize %> will have these skills.</p>
+            <p class="govuk-body">We’ll use these skills to suggest other types of work you can do.</p>
+            <span id="current-job-skills-hint" class="govuk-hint govuk-!-margin-bottom-6">
+              If you want to remove any of these skills, click the tick to remove it from the list.
+            </span>
             <%= errors_tag @skills_builder, :skills %>
             <div class="govuk-checkboxes">
               <%= hidden_field_tag('skill_ids[]', nil, id: 'skill_ids') %>
               <%= hidden_field_tag('search', params[:search], id: 'search') %>
               <% @skills_builder.job_profile.skills.each do |skill| %>
                 <div class="govuk-checkboxes__item">
-                  <%= check_box_tag('skill_ids[]', skill.id, @skills_builder.skill_ids.include?(skill.id), id: dom_id(skill), class: 'govuk-checkboxes__input') %>
+                  <%= check_box_tag('skill_ids[]', skill.id, @skills_builder.skill_ids.include?(skill.id), id: dom_id(skill), class: 'govuk-checkboxes__input', aria: { describedby: "current-job-skills-hint" }) %>
                   <%= label_tag(dom_id(skill), skill.name.capitalize, class: 'govuk-label govuk-checkboxes__label') %>
                 </div>
               <% end %>


### PR DESCRIPTION
### Context
Solution:
Remove the `<p>` and `<span>` containing the hint text from the legend.
Associate each checkbox with the hint text by using aria-described by.

### Ticket
https://dfedigital.atlassian.net/browse/GET-951
