### PR TITLE
Remove aria-label from the img tags

### DIFF
--- a/app/views/job_profiles/_highlights.html.erb
+++ b/app/views/job_profiles/_highlights.html.erb
@@ -2,11 +2,11 @@
   <div class="govuk-grid-column-one-half">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-quarter govuk-!-margin-top-5 govuk-!-margin-bottom-6">
-        <div class="profile-highlights salary-icon" role="img" aria-label="Pound sterling icon"></div>
+        <div class="profile-highlights salary-icon"></div>
       </div>
       <div class="govuk-grid-column-three-quarters">
         <h2 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-1">Typical Salary</h2>
-        <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-2 responsive-section-break">
+        <hr aria-hidden="true" class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-2 responsive-section-break">
         <%= @job_profile.salary_range %>
       </div>
     </div>
@@ -16,11 +16,11 @@
     <div class="govuk-grid-column-one-half">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-quarter govuk-!-margin-top-5 govuk-!-margin-bottom-6">
-          <div class="profile-highlights <%= @job_profile.growth_icon %>" role="img" aria-label="Arrow pointing upwards"></div>
+          <div class="profile-highlights <%= @job_profile.growth_icon %>"></div>
         </div>
         <div class="govuk-grid-column-three-quarters">
           <h2 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-1">Recent job growth</h2>
-          <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-2 responsive-section-break">
+          <hr aria-hidden="true" class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-2 responsive-section-break">
           <p id="lifestyle" class="govuk-body"><%= @job_profile.growth_type %></p>
         </div>
       </div>


### PR DESCRIPTION
### Context
1. According to DAC, the information provided via the aria-label
for images on the job profiles page does not provide
any more useful information. This may be confusing for some
screen reader users in a non-testing environment.

2. Also, the visual separators should not be announced
to screen reader users.

Solution:

1. Remove the role of image and the aria-label from all four <div>
elements as screen reader users do not need to
be aware of this information.
2. Use aria-hidden="true" on separators.

### Ticket
https://dfedigital.atlassian.net/browse/GET-952

