### PR TITLE
Concept: Override target job when an alternative job title is passed

### DIFF
--- a/app/controllers/job_vacancies_controller.rb
+++ b/app/controllers/job_vacancies_controller.rb
@@ -28,6 +28,10 @@ class JobVacanciesController < ApplicationController
     UKPostcode.parse(postcode).outcode
   end
 
+  def job_alternative_title
+    @job_alternative_title ||= job_vacancies_params[:job_alternative_title]
+  end
+
   def persist_valid_filters_on_session
     return unless job_vacancy_search.valid?
 
@@ -43,7 +47,7 @@ class JobVacanciesController < ApplicationController
   end
 
   def job_vacancies_params
-    params.permit(:postcode, :page, :distance)
+    params.permit(:postcode, :page, :distance, :job_alternative_title)
   end
 
   def jobs
@@ -51,12 +55,14 @@ class JobVacanciesController < ApplicationController
   end
 
   def job_vacancy_search
-    @job_vacancy_search ||= JobVacancySearch.new(
+    options = {
       postcode: postcode,
-      name: target_job.name,
+      name: job_alternative_title.present? ? job_alternative_title : target_job.name,
       page: job_vacancies_params[:page],
       distance: job_vacancies_params[:distance]
-    )
+    }.compact
+
+    @job_vacancy_search ||= JobVacancySearch.new(options)
   end
 
   def track_search_filters

--- a/app/controllers/job_vacancies_controller.rb
+++ b/app/controllers/job_vacancies_controller.rb
@@ -6,6 +6,8 @@ class JobVacanciesController < ApplicationController
   def index
     return redirect_to task_list_path unless target_job.present?
 
+    @alternative_job_titles = alternative_job_titles
+
     track_search_filters
     persist_valid_filters_on_session
 
@@ -28,8 +30,14 @@ class JobVacanciesController < ApplicationController
     UKPostcode.parse(postcode).outcode
   end
 
-  def job_alternative_title
-    @job_alternative_title ||= job_vacancies_params[:job_alternative_title]
+  def alternative_job_title
+    @alternative_job_title ||= job_vacancies_params[:alternative_job_title]
+  end
+
+  def alternative_job_titles
+    return unless target_job.alternative_titles.present?
+
+    target_job.alternative_titles.split(',').map(&:strip) - [alternative_job_title]
   end
 
   def persist_valid_filters_on_session
@@ -47,7 +55,7 @@ class JobVacanciesController < ApplicationController
   end
 
   def job_vacancies_params
-    params.permit(:postcode, :page, :distance, :job_alternative_title)
+    params.permit(:postcode, :page, :distance, :alternative_job_title)
   end
 
   def jobs
@@ -57,7 +65,7 @@ class JobVacanciesController < ApplicationController
   def job_vacancy_search
     options = {
       postcode: postcode,
-      name: job_alternative_title.present? ? job_alternative_title : target_job.name,
+      name: alternative_job_title.present? ? alternative_job_title : target_job.name,
       page: job_vacancies_params[:page],
       distance: job_vacancies_params[:distance]
     }.compact

--- a/app/controllers/job_vacancies_controller.rb
+++ b/app/controllers/job_vacancies_controller.rb
@@ -1,4 +1,6 @@
 class JobVacanciesController < ApplicationController
+  include JobVacanciesHelper
+
   DISTANCE = [
     ['Up to 10 miles', '10'], ['Up to 20 miles', '20'], ['Up to 30 miles', '30'], ['Up to 40 miles', '40']
   ].freeze

--- a/app/helpers/job_vacancies_helper.rb
+++ b/app/helpers/job_vacancies_helper.rb
@@ -1,0 +1,5 @@
+module JobVacanciesHelper
+  def titleize_without_downcasing(string)
+    string.sub(/^./, &:upcase)
+  end
+end

--- a/app/views/job_vacancies/_alternative_job_titles.html.erb
+++ b/app/views/job_vacancies/_alternative_job_titles.html.erb
@@ -1,1 +1,1 @@
-<span class="govuk-!-margin-right-2"><%= link_to(alterantive_job_title.strip, jobs_near_me_path(alternative_job_title: alterantive_job_title.strip), class: 'govuk-link govuk-body') %></span>
+<span class="govuk-!-margin-right-1"><%= link_to(titleize_without_downcasing(alterantive_job_title), jobs_near_me_path(alternative_job_title: alterantive_job_title), class: 'govuk-link govuk-body') %></span>

--- a/app/views/job_vacancies/_alternative_job_titles.html.erb
+++ b/app/views/job_vacancies/_alternative_job_titles.html.erb
@@ -1,0 +1,1 @@
+<span class="govuk-!-margin-right-2"><%= link_to(alterantive_job_title.strip, jobs_near_me_path(alternative_job_title: alterantive_job_title.strip), class: 'govuk-link govuk-body') %></span>

--- a/app/views/job_vacancies/index.html.erb
+++ b/app/views/job_vacancies/index.html.erb
@@ -15,7 +15,7 @@
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <%= error_summary(@job_vacancy_search) %>
-    <h1 class="govuk-heading-xl"><%= @job_alternative_title.present? ? @job_alternative_title.titleize : target_job.name %> jobs near you</h1>
+    <h1 class="govuk-heading-xl"><%= @alternative_job_title.present? ? @alternative_job_title : target_job.name %> jobs near you</h1>
     <div class="govuk-grid-column-full govuk-!-padding-0">
       <%= render 'search_filter' %>
     </div>
@@ -27,7 +27,9 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>using a different postcode</li>
           <li>using the filters to search a wider local area</li>
-          <li>using other job sites</li>
+          <% if @alternative_job_titles.present? %>
+            <li>checking the following options: <%= render partial: 'alternative_job_titles', collection: @alternative_job_titles, as: :alterantive_job_title %></li>
+          <% end %>
           <li>entering a different name for this job on the <%= link_to 'Find a job', 'https://findajob.dwp.gov.uk/', class: 'govuk-link' %> service</li>
         </ul>
       <% else %>

--- a/app/views/job_vacancies/index.html.erb
+++ b/app/views/job_vacancies/index.html.erb
@@ -15,7 +15,7 @@
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <%= error_summary(@job_vacancy_search) %>
-    <h1 class="govuk-heading-xl"><%= target_job.name %> jobs near you</h1>
+    <h1 class="govuk-heading-xl"><%= @job_alternative_title.present? ? @job_alternative_title.titleize : target_job.name %> jobs near you</h1>
     <div class="govuk-grid-column-full govuk-!-padding-0">
       <%= render 'search_filter' %>
     </div>

--- a/app/views/job_vacancies/index.html.erb
+++ b/app/views/job_vacancies/index.html.erb
@@ -15,7 +15,7 @@
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <%= error_summary(@job_vacancy_search) %>
-    <h1 class="govuk-heading-xl"><%= @alternative_job_title.present? ? @alternative_job_title : target_job.name %> jobs near you</h1>
+    <h1 class="govuk-heading-xl"><%= @alternative_job_title.present? ? titleize_without_downcasing(@alternative_job_title) : target_job.name %> jobs near you</h1>
     <div class="govuk-grid-column-full govuk-!-padding-0">
       <%= render 'search_filter' %>
     </div>
@@ -28,7 +28,7 @@
           <li>using a different postcode</li>
           <li>using the filters to search a wider local area</li>
           <% if @alternative_job_titles.present? %>
-            <li>checking the following options: <%= render partial: 'alternative_job_titles', collection: @alternative_job_titles, as: :alterantive_job_title %></li>
+            <li>checking the following alterantive job positions: <%= render partial: 'alternative_job_titles', collection: @alternative_job_titles, as: :alterantive_job_title %></li>
           <% end %>
           <li>entering a different name for this job on the <%= link_to 'Find a job', 'https://findajob.dwp.gov.uk/', class: 'govuk-link' %> service</li>
         </ul>

--- a/spec/features/jobs_near_me_spec.rb
+++ b/spec/features/jobs_near_me_spec.rb
@@ -144,7 +144,7 @@ RSpec.feature 'Jobs near me', type: :feature do
     allow(FindAJobService).to receive(:new).and_return(find_a_job_service)
     allow(find_a_job_service).to receive(:job_vacancies).with(
       postcode: 'NW6 8ET',
-      name: 'Developer',
+      name: 'developer',
       page: 1,
       distance: 20
     ).and_return(
@@ -160,7 +160,7 @@ RSpec.feature 'Jobs near me', type: :feature do
       click_on('Continue')
     end
 
-    visit(jobs_near_me_path(alternative_job_title: 'Developer'))
+    visit(jobs_near_me_path(alternative_job_title: 'developer'))
 
     expect(page).to have_text('Developer jobs near you')
   end
@@ -177,7 +177,7 @@ RSpec.feature 'Jobs near me', type: :feature do
     allow(FindAJobService).to receive(:new).and_return(find_a_job_service)
     user_targets_a_job
 
-    ['checking the following options:', 'Super admin', 'IT Admin'].each do |copy|
+    ['checking the following alterantive job positions:', 'Super admin', 'IT Admin'].each do |copy|
       expect(page).to have_text(copy)
     end
   end

--- a/spec/helpers/job_vacancies_helper_spec.rb
+++ b/spec/helpers/job_vacancies_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe JobVacanciesHelper do
+  describe '#titleize_without_downcasing' do
+    it 'does not change a string that is already titleized' do
+      expect(
+        helper.titleize_without_downcasing('PCSO offer')
+      ).to eq('PCSO offer')
+    end
+
+    it 'does titleize a string that is not already' do
+      expect(
+        helper.titleize_without_downcasing('community officer')
+      ).to eq('Community officer')
+    end
+  end
+end


### PR DESCRIPTION
### Context
We want to allow users to surface additional job vacancies,
by being able to override the targetted job on the session.

Also fix the following bug:
- until now, if a page/distance param was not being passed
at the controller level, it was still explicitly passed as nil in
the JobVacancySearch causing the initial page
number to be nil.to_i = 0 instead of 1.
- similar situation for distance.

### Screenshot
![Screen Shot 2020-06-18 at 16 32 04](https://user-images.githubusercontent.com/1955084/85041561-040c4800-b182-11ea-828e-f1e21dd8054e.png)

### Ticket
https://dfedigital.atlassian.net/browse/GET-1163
