### PR TITLE
UAT & PRD env require different SHAs for gtag inline JS

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,7 +11,9 @@ Rails.application.config.content_security_policy do |policy|
   policy.script_src  :self,
                      'https://www.google-analytics.com',
                      'https://www.googletagmanager.com',
-                     "'sha256-Dxc0MAwW+c3gw7Gc7P3nkQRqGGCluJ1IWIwINlTBthQ='", # gtag inline JS
+                     "'sha256-Dxc0MAwW+c3gw7Gc7P3nkQRqGGCluJ1IWIwINlTBthQ='", # gtag inline JS SHA (DEV, QA)
+                     "'sha256-mj+puRQe0IXRcvvMkkPqZb+Vrr49Swt4nVDcYiOc0qA='", # gtag inline JS SHA (UAT)
+                     "'sha256-iWZlDtXlrEVKWt8xS+oXaedWXwdpr618P2kN/EXVkfA='", # gtag inline JS SHA (PRD)
                      "'sha256-IWjjekDxqqURWMjVH447fuaAvoZKwpDwLS0ZdcJ+Ey4='" # template body inline JS
   # If you are using webpack-dev-server then specify webpack-dev-server host
   policy.connect_src :self, :https, 'http://localhost:3035', 'ws://localhost:3035' if Rails.env.development?


### PR DESCRIPTION
### Context
Introducing the Content Security Policy (CSP) seems to
reject the gtag inline JS script on UAT env as it has a
different SHA.

