### PR TITLE
Allow analytics.js to be executed

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,6 +10,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.object_src  :none
   policy.script_src  :self,
                      'https://www.google-analytics.com',
+                     'https://www.google-analytics.com/analytics.js',
                      'https://www.googletagmanager.com',
                      'https://connect.facebook.net',
                      "'sha256-Dxc0MAwW+c3gw7Gc7P3nkQRqGGCluJ1IWIwINlTBthQ='", # gtag inline JS SHA (DEV, QA)


### PR DESCRIPTION
### Context
We've recently seen in Sentry that our CSP rejected
https://www.google-analytics.com/analytics.js script.

White-listing it.
